### PR TITLE
support universal binary

### DIFF
--- a/macbuild_arm.sh
+++ b/macbuild_arm.sh
@@ -1,4 +1,0 @@
-#!/bin/zsh
-
-# for ARM64
-./macbuild.sh arch:arm64

--- a/macbuild_intel.sh
+++ b/macbuild_intel.sh
@@ -1,4 +1,0 @@
-#!/bin/zsh
-
-# for x86
-./macbuild.sh arch:x86_64


### PR DESCRIPTION
- **support universal binary build.**
- **remove macbuild_arm.sh and macbuild_intel.sh because macbuild.sh supports detecting target arch from host arch and also supports universal binary.**
