### PR TITLE
Changed animation property name "play" to "playing"

### DIFF
--- a/gd_spritestudio/gd_node_ssplayer.cpp
+++ b/gd_spritestudio/gd_node_ssplayer.cpp
@@ -554,7 +554,7 @@ bool GdNodeSsPlayer::_set( const StringName& p_name, const Variant& p_property )
 
 		return	true;
 	}else
-	if ( p_name == GdUiText( "play" ) ) {
+	if ( p_name == GdUiText( "playing" ) ) {
 		setPlay( p_property );
 
 		return	true;
@@ -585,7 +585,7 @@ bool GdNodeSsPlayer::_get( const StringName& p_name, Variant& r_property ) const
 
 		return	true;
 	}else
-	if ( p_name == GdUiText( "play" ) ) {
+	if ( p_name == GdUiText( "playing" ) ) {
 		r_property = getPlay();
 
 		return	true;
@@ -673,7 +673,7 @@ void GdNodeSsPlayer::_get_property_list( List<PropertyInfo>* p_list ) const
 
 			p_list->push_back( animationsPropertyInfo );
 
-			animationsPropertyInfo.name = GdUiText( "play" );
+			animationsPropertyInfo.name = GdUiText( "playing" );
 			animationsPropertyInfo.type = Variant::BOOL;
 			animationsPropertyInfo.usage = PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_STORAGE;
 			animationsPropertyInfo.hint = PROPERTY_HINT_NONE;


### PR DESCRIPTION
Godot 4 で Play フラグがトグルせず再生開始できない問題の修正に該当します。