### PR TITLE
Fix incorrect EMPTY check when appending trailing slash to base paths

### DIFF
--- a/gd_spritestudio/gd_resource_ssproject.cpp
+++ b/gd_spritestudio/gd_resource_ssproject.cpp
@@ -148,22 +148,22 @@ Error GdResourceSsProject::loadFromFile( const String& strPath, const String& st
 	}
 
 	m_strAnimePack = m_strRoot + String::utf8( m_pProject->settings.animeBaseDirectory.c_str() );
-	if ( EMPTY(m_strAnimePack) && !m_strAnimePack.ends_with( "/" ) )
+	if ( !EMPTY(m_strAnimePack) && !m_strAnimePack.ends_with( "/" ) )
 	{
 		m_strAnimePack += "/";
 	}
 	m_strCellMap = m_strRoot + String::utf8( m_pProject->settings.cellMapBaseDirectory.c_str() );
-	if ( EMPTY(m_strCellMap) && !m_strCellMap.ends_with( "/" ) )
+	if ( !EMPTY(m_strCellMap) && !m_strCellMap.ends_with( "/" ) )
 	{
 		m_strCellMap += "/";
 	}
 	m_strImage = m_strRoot + String::utf8( m_pProject->settings.imageBaseDirectory.c_str() );
-	if ( EMPTY(m_strImage) && !m_strImage.ends_with( "/" ) )
+	if ( !EMPTY(m_strImage) && !m_strImage.ends_with( "/" ) )
 	{
 		m_strImage += "/";
 	}
 	m_strEffect = m_strRoot + String::utf8( m_pProject->settings.effectBaseDirectory.c_str() );
-	if ( EMPTY(m_strEffect) && !m_strEffect.ends_with( "/" ) )
+	if ( !EMPTY(m_strEffect) && !m_strEffect.ends_with( "/" ) )
 	{
 		m_strEffect += "/";
 	}


### PR DESCRIPTION
This PR fixes an inverted EMPTY() condition when appending trailing slashes
to SpriteStudio base directory paths.

The incorrect condition caused missing '/' characters in resolved SSAE,
cellmap, image, and effect file paths when loading sspj projects.

This change ensures base directories correctly end with a trailing slash
only when the path is non-empty.