### PR TITLE
Drawing Process Optimization: Migration to SDK-side Calculations and Vertex Computation Improvements

### DIFF
--- a/gd_spritestudio/gd_ssplayer_node2d.cpp
+++ b/gd_spritestudio/gd_ssplayer_node2d.cpp
@@ -554,14 +554,13 @@ void GdSsPlayerNode2D::updateAnimation( float delta ) {
         }
         */
         previous_frame_no = frame_no;
-        drawAnimation();
+        drawAnimation(frame_no);
     }
 }
 
-void GdSsPlayerNode2D::drawAnimation() {
+void GdSsPlayerNode2D::drawAnimation(int frame_no) {
     unsigned char *data = nullptr;
     uintptr_t len = 0;
-    int frame_no = ss_runtime_get_frame_no(runtime_ctx);
     ss_runtime_get_frame_data(runtime_ctx, frame_no, &data, &len);
     if (!data) return;
 
@@ -570,12 +569,29 @@ void GdSsPlayerNode2D::drawAnimation() {
     auto binary = _ssabRes->get_ss_anime_binary();
     RenderingServer *rs = RenderingServer::get_singleton();
 
+    int num_parts = binary->parts()->size();
+    if (_inheritance_matrices.size() < num_parts * 16) {
+        _inheritance_matrices.resize(num_parts * 16);
+    }
+
     for (uint32_t i = 0; i < parts->size(); i++) {
         auto part = parts->Get(i);
-        if (i >= (uint32_t)_canvas_items.size() || part->update_flag() == 0) continue;
+        auto partBinary = binary->parts()->Get(part->part_index());
 
-        RID ci = _canvas_items[i];
+        int parent_idx = partBinary->parent_index();
+        float *parent_m = (parent_idx >= 0) ? _inheritance_matrices.ptrw() + (parent_idx * 16) : nullptr;
+        float drawing_m[16];
+        float *inheritance_m = _inheritance_matrices.ptrw() + (part->part_index() * 16);
+
+        // TODO: Pass parent size if using NineSlice/etc. (not fully supported here yet)
+        ss_matrix_compute_world(inheritance_m, drawing_m, part, parent_m, false, 0.0f, 0.0f);
+
+        int p_idx = part->part_index();
+        if (p_idx < 0 || p_idx >= (int)_canvas_items.size()) continue;
+
+        RID ci = _canvas_items[p_idx];
         rs->canvas_item_clear(ci);
+        rs->canvas_item_set_z_index(ci, (int)part->priority());
         if (part->hide()) continue;
 
         auto frameDataCellIndex = part->cell();
@@ -589,12 +605,11 @@ void GdSsPlayerNode2D::drawAnimation() {
         auto cell = cellmap->cells()->LookupByKey(frameDataCell->name_hash());
         if (!cell) continue;
 
-        auto partBinary = binary->parts()->Get(part->part_index());
-        _draw_part(rs, ci, frameData, part, partBinary, tex, cell);
+        _draw_part(rs, ci, frameData, part, partBinary, tex, cell, drawing_m);
     }
 }
 
-void GdSsPlayerNode2D::_draw_part(RenderingServer *rs, RID ci, const ss::runtime::FrameData *frameData, const ss::runtime::PartState *part, const ss::format::PartData *partBinary, const Ref<Texture2D> &tex, const ss::format::Cell *cell) {
+void GdSsPlayerNode2D::_draw_part(RenderingServer *rs, RID ci, const ss::runtime::FrameData *frameData, const ss::runtime::PartState *part, const ss::format::PartData *partBinary, const Ref<Texture2D> &tex, const ss::format::Cell *cell, const float *draw_m) {
     // 1. Blend Mode
     ss::format::BlendType ss_blend = partBinary->blend_type();
     if (!_blend_materials.has((int)ss_blend)) {
@@ -611,11 +626,6 @@ void GdSsPlayerNode2D::_draw_part(RenderingServer *rs, RID ci, const ss::runtime
     rs->canvas_item_set_material(ci, _blend_materials[(int)ss_blend]->get_rid());
 
     // 2. Matrix Calculation (Hierarchy aware)
-    float draw_m[16];
-    if (!ss_util_get_part_world_matrix(runtime_ctx, part->part_index(), ss_runtime_get_frame_no(runtime_ctx), draw_m)) {
-        return;
-    }
-
     uint64_t flags = part->update_flag();
     auto rect = cell->rectangle();
     auto pivot = cell->pivot();
@@ -776,5 +786,5 @@ void GdSsPlayerNode2D::fetchAnimation() {
         }
 
         previous_frame_no = -1;
-        drawAnimation();
+        drawAnimation(ss_runtime_get_frame_no(runtime_ctx));
 }

--- a/gd_spritestudio/gd_ssplayer_node2d.cpp
+++ b/gd_spritestudio/gd_ssplayer_node2d.cpp
@@ -570,30 +570,28 @@ void GdSsPlayerNode2D::drawAnimation(int frame_no) {
     ss_runtime_get_frame_data(runtime_ctx, frame_no, &data, &len);
     if (!data) return;
 
+    const float *world_matrices = nullptr;
+    uintptr_t world_matrices_len = 0;
+    ss_runtime_get_world_matrices(runtime_ctx, &world_matrices, &world_matrices_len);
+
     auto frameData = ss::runtime::GetFrameData(data);
     auto parts = frameData->parts();
     auto binary = _ssabRes->get_ss_anime_binary();
     RenderingServer *rs = RenderingServer::get_singleton();
 
-    int num_parts = binary->parts()->size();
-    if (_inheritance_matrices.size() < num_parts * 16) {
-        _inheritance_matrices.resize(num_parts * 16);
-    }
-
     for (uint32_t i = 0; i < parts->size(); i++) {
         auto part = parts->Get(i);
         auto partBinary = binary->parts()->Get(part->part_index());
 
-        int parent_idx = partBinary->parent_index();
-        float *parent_m = (parent_idx >= 0) ? _inheritance_matrices.ptrw() + (parent_idx * 16) : nullptr;
-        float drawing_m[16];
-        float *inheritance_m = _inheritance_matrices.ptrw() + (part->part_index() * 16);
-
-        // TODO: Pass parent size if using NineSlice/etc. (not fully supported here yet)
-        ss_matrix_compute_world(inheritance_m, drawing_m, part, parent_m, false, 0.0f, 0.0f);
-
         int p_idx = part->part_index();
         if (p_idx < 0 || p_idx >= (int)_canvas_items.size()) continue;
+
+        const float *drawing_m = nullptr;
+        if (world_matrices && ((uintptr_t)p_idx * 16 < world_matrices_len)) {
+            drawing_m = world_matrices + (p_idx * 16);
+        } else {
+            continue;
+        }
 
         RID ci = _canvas_items[p_idx];
         rs->canvas_item_clear(ci);

--- a/gd_spritestudio/gd_ssplayer_node2d.cpp
+++ b/gd_spritestudio/gd_ssplayer_node2d.cpp
@@ -14,7 +14,13 @@
 
 GdSsPlayerNode2D::GdSsPlayerNode2D() {
     runtime_ctx = ss_runtime_create();
-    ss_context_set_coordinate_system(runtime_ctx, 1);
+    _reconfigure();
+}
+
+void GdSsPlayerNode2D::_reconfigure() {
+    if (runtime_ctx != nullptr) {
+        ss_context_set_coordinate_system(runtime_ctx, 1);
+    }
 }
 
 GdSsPlayerNode2D::~GdSsPlayerNode2D() {
@@ -733,6 +739,7 @@ void GdSsPlayerNode2D::_draw_part(RenderingServer *rs, RID ci, const ss::runtime
 void GdSsPlayerNode2D::fetchAnimation() {
 	if ( _strAnimationSelected.is_empty() || _ssabRes.is_null() ) {
         ss_runtime_reset(runtime_ctx);
+        _reconfigure();
         if (rutime_res != nullptr) {
             ss_resource_destroy(rutime_res);
             rutime_res = nullptr;

--- a/gd_spritestudio/gd_ssplayer_node2d.cpp
+++ b/gd_spritestudio/gd_ssplayer_node2d.cpp
@@ -577,21 +577,13 @@ void GdSsPlayerNode2D::drawAnimation(int frame_no) {
     uintptr_t world_matrices_len = 0;
     ss_runtime_get_world_matrices(runtime_ctx, &world_matrices, &world_matrices_len);
 
+    const int32_t *z_order = nullptr;
+    uintptr_t z_order_len = 0;
+    ss_runtime_get_z_order(runtime_ctx, &z_order, &z_order_len);
+
     auto frameData = ss::runtime::GetFrameData(data);
     auto parts = frameData->parts();
     if (!parts) return;
-
-    // Collect and sort parts according to the logic: priority first, then part_index (SS6-SDK style)
-    std::vector<const ss::runtime::PartState*> sorted_parts;
-    sorted_parts.reserve(parts->size());
-    for (uint32_t i = 0; i < parts->size(); i++) {
-        sorted_parts.push_back(parts->Get(i));
-    }
-    std::sort(sorted_parts.begin(), sorted_parts.end(), [](const ss::runtime::PartState* lhs, const ss::runtime::PartState* rhs) {
-        if (lhs->priority() == rhs->priority())
-            return lhs->part_index() < rhs->part_index();
-        return lhs->priority() < rhs->priority();
-    });
 
     RenderingServer *rs = RenderingServer::get_singleton();
     // Clear all canvas items once per frame to ensure a clean state
@@ -601,14 +593,16 @@ void GdSsPlayerNode2D::drawAnimation(int frame_no) {
 
     auto binary = _ssabRes->get_ss_anime_binary();
 
-    for (uint32_t i = 0; i < sorted_parts.size(); i++) {
-        auto part = sorted_parts[i];
+    for (uint32_t i = 0; i < parts->size(); i++) {
+        auto part = parts->Get(i);
         int p_idx = part->part_index();
         if (p_idx < 0 || p_idx >= (int)_canvas_items.size()) continue;
 
         RID ci = _canvas_items[p_idx];
-        // Use the sorted rank 'i' as the z_index to strictly enforce the determined order
-        rs->canvas_item_set_z_index(ci, i);
+        // Use the Z-order rank provided by the runtime to strictly enforce the determined order
+        if (z_order && (uintptr_t)p_idx < z_order_len) {
+            rs->canvas_item_set_z_index(ci, z_order[p_idx]);
+        }
 
         if (part->hide()) continue;
 

--- a/gd_spritestudio/gd_ssplayer_node2d.cpp
+++ b/gd_spritestudio/gd_ssplayer_node2d.cpp
@@ -3,6 +3,9 @@
 #include "runtime/ssruntime.h"
 #include "runtime/framedata.h"
 
+#include <algorithm>
+#include <vector>
+
 #ifdef SPRITESTUDIO_GODOT_EXTENSION
 #include <godot_cpp/classes/resource_loader.hpp>
 #include <godot_cpp/classes/rendering_server.hpp>
@@ -576,15 +579,38 @@ void GdSsPlayerNode2D::drawAnimation(int frame_no) {
 
     auto frameData = ss::runtime::GetFrameData(data);
     auto parts = frameData->parts();
-    auto binary = _ssabRes->get_ss_anime_binary();
-    RenderingServer *rs = RenderingServer::get_singleton();
+    if (!parts) return;
 
+    // Collect and sort parts according to the logic: priority first, then part_index (SS6-SDK style)
+    std::vector<const ss::runtime::PartState*> sorted_parts;
+    sorted_parts.reserve(parts->size());
     for (uint32_t i = 0; i < parts->size(); i++) {
-        auto part = parts->Get(i);
-        auto partBinary = binary->parts()->Get(part->part_index());
+        sorted_parts.push_back(parts->Get(i));
+    }
+    std::sort(sorted_parts.begin(), sorted_parts.end(), [](const ss::runtime::PartState* lhs, const ss::runtime::PartState* rhs) {
+        if (lhs->priority() == rhs->priority())
+            return lhs->part_index() < rhs->part_index();
+        return lhs->priority() < rhs->priority();
+    });
 
+    RenderingServer *rs = RenderingServer::get_singleton();
+    // Clear all canvas items once per frame to ensure a clean state
+    for (RID ci : _canvas_items) {
+        rs->canvas_item_clear(ci);
+    }
+
+    auto binary = _ssabRes->get_ss_anime_binary();
+
+    for (uint32_t i = 0; i < sorted_parts.size(); i++) {
+        auto part = sorted_parts[i];
         int p_idx = part->part_index();
         if (p_idx < 0 || p_idx >= (int)_canvas_items.size()) continue;
+
+        RID ci = _canvas_items[p_idx];
+        // Use the sorted rank 'i' as the z_index to strictly enforce the determined order
+        rs->canvas_item_set_z_index(ci, i);
+
+        if (part->hide()) continue;
 
         const float *drawing_m = nullptr;
         if (world_matrices && ((uintptr_t)p_idx * 16 < world_matrices_len)) {
@@ -593,10 +619,7 @@ void GdSsPlayerNode2D::drawAnimation(int frame_no) {
             continue;
         }
 
-        RID ci = _canvas_items[p_idx];
-        rs->canvas_item_clear(ci);
-        rs->canvas_item_set_z_index(ci, (int)part->priority());
-        if (part->hide()) continue;
+        auto partBinary = binary->parts()->Get(p_idx);
 
         auto frameDataCellIndex = part->cell();
         auto frameDataCell = frameData->cells()->Get(frameDataCellIndex);

--- a/gd_spritestudio/gd_ssplayer_node2d.cpp
+++ b/gd_spritestudio/gd_ssplayer_node2d.cpp
@@ -436,6 +436,85 @@ void GdSsPlayerNode2D::loadTextures(const Ref<GdSsabResource>& ssabRes) {
 }
 
 
+namespace {
+    struct SsVertexComputeParams {
+        Vector2 size;
+        Vector2 pivot;
+        bool flip_h = false;
+        bool flip_v = false;
+        bool use_5_vertices = true;
+        bool has_deform = false;
+        Vector2 deform_lt, deform_rt, deform_lb, deform_rb;
+    };
+
+    int compute_vertices(const SsVertexComputeParams& params, float* out_x, float* out_y) {
+        float deform_x[4], deform_y[4];
+        const float *p_dx = nullptr, *p_dy = nullptr;
+        if (params.has_deform) {
+            deform_x[0] = params.deform_lt.x; deform_x[1] = params.deform_rt.x;
+            deform_x[2] = params.deform_lb.x; deform_x[3] = params.deform_rb.x;
+            deform_y[0] = -params.deform_lt.y; deform_y[1] = -params.deform_rt.y;
+            deform_y[2] = -params.deform_lb.y; deform_y[3] = -params.deform_rb.y;
+            p_dx = deform_x; p_dy = deform_y;
+        }
+
+        int v_count = ss_vertex_compute_local(
+            params.size.x, params.size.y,
+            params.pivot.x, params.pivot.y,
+            0, 0, // pivot_offset
+            params.flip_h, params.flip_v,
+            params.use_5_vertices,
+            p_dx, p_dy,
+            out_x, out_y
+        );
+
+        // Convert from Y-up (ssruntime) to Y-down (Godot)
+        for (int i = 0; i < v_count; i++) {
+            out_y[i] = -out_y[i];
+        }
+
+        return v_count;
+    }
+
+    struct SsUvComputeParams {
+        Rect2 src_rect;
+        Vector2 uv_translation;
+        float uv_rotation_z = 0.0f;
+        Vector2 uv_scale;
+        bool part_flip_h = false;
+        bool part_flip_v = false;
+        bool img_flip_h = false;
+        bool img_flip_v = false;
+        bool rotated = false;
+        bool use_5_vertices = true;
+    };
+
+    int compute_uvs(const SsUvComputeParams& params, float* out_u, float* out_v) {
+        return ss_uv_compute_local(
+            params.src_rect.position.x, params.src_rect.position.y,
+            params.src_rect.position.x + params.src_rect.size.x,
+            params.src_rect.position.y + params.src_rect.size.y,
+            params.uv_translation.x * params.src_rect.size.x,
+            params.uv_translation.y * params.src_rect.size.y,
+            Math::rad_to_deg(params.uv_rotation_z),
+            params.uv_scale.x, params.uv_scale.y,
+            params.part_flip_h, params.part_flip_v,
+            params.img_flip_h, params.img_flip_v,
+            params.rotated,
+            params.use_5_vertices,
+            out_u, out_v
+        );
+    }
+
+    Transform2D matrix_to_transform2d(const float* m) {
+        Transform2D t;
+        t.columns[0] = Vector2(m[0], m[1]);
+        t.columns[1] = Vector2(m[4], m[5]);
+        t.columns[2] = Vector2(m[12], m[13]);
+        return t;
+    }
+}
+
 void GdSsPlayerNode2D::updateAnimation( float delta ) {
     if (ss_runtime_is_playing(runtime_ctx)) {
         auto d = delta * 1000.0f;
@@ -471,18 +550,6 @@ void GdSsPlayerNode2D::updateAnimation( float delta ) {
                         // TODO: impl
                     }
                 }
-
-                if (auto instances = events_per_frame->instances()) {
-                    for (auto instance : *instances) {
-                        // TODO: impl
-                    }
-                }
-
-                if (auto effects = events_per_frame->effects()) {
-                    for (auto effect : *effects) {
-                        // TODO: impl
-                    }
-                }
             }
         }
         */
@@ -494,195 +561,162 @@ void GdSsPlayerNode2D::updateAnimation( float delta ) {
 void GdSsPlayerNode2D::drawAnimation() {
     unsigned char *data = nullptr;
     uintptr_t len = 0;
-    ss_runtime_get_frame_data(runtime_ctx, ss_runtime_get_frame_no(runtime_ctx), &data, &len);
-    if (!data) {
-        return;
-    }
+    int frame_no = ss_runtime_get_frame_no(runtime_ctx);
+    ss_runtime_get_frame_data(runtime_ctx, frame_no, &data, &len);
+    if (!data) return;
 
     auto frameData = ss::runtime::GetFrameData(data);
     auto parts = frameData->parts();
-
     auto binary = _ssabRes->get_ss_anime_binary();
     RenderingServer *rs = RenderingServer::get_singleton();
 
     for (uint32_t i = 0; i < parts->size(); i++) {
         auto part = parts->Get(i);
-        if (i >= (uint32_t)_canvas_items.size()) {
-            break;
-        }
-
-        if (part->update_flag() == 0) {
-            continue;
-        }
+        if (i >= (uint32_t)_canvas_items.size() || part->update_flag() == 0) continue;
 
         RID ci = _canvas_items[i];
         rs->canvas_item_clear(ci);
-
-        if (part->hide()) {
-            continue;
-        }
+        if (part->hide()) continue;
 
         auto frameDataCellIndex = part->cell();
         auto frameDataCell = frameData->cells()->Get(frameDataCellIndex);
         auto cellmap = binary->cellmaps()->Get(frameDataCell->map_id());
 
         uint32_t texHash = cellmap->name_hash();
-        if (!_textures.has(texHash)) {
-             continue;
-        }
+        if (!_textures.has(texHash)) continue;
         Ref<Texture2D> tex = _textures[texHash];
 
         auto cell = cellmap->cells()->LookupByKey(frameDataCell->name_hash());
-        if (!cell) {
-            continue;
-        }
+        if (!cell) continue;
 
-        auto rect = cell->rectangle();
-        auto pivot = cell->pivot();
-
-        // 1. Blend Mode 設定
         auto partBinary = binary->parts()->Get(part->part_index());
-        ss::format::BlendType ss_blend = partBinary->blend_type();
-        if (!_blend_materials.has((int)ss_blend)) {
-            Ref<CanvasItemMaterial> mat;
-            mat.instantiate();
-            switch (ss_blend) {
-                case ss::format::BlendType_Mix: mat->set_blend_mode(CanvasItemMaterial::BLEND_MODE_MIX); break;
-                case ss::format::BlendType_Add: mat->set_blend_mode(CanvasItemMaterial::BLEND_MODE_ADD); break;
-                case ss::format::BlendType_Sub: mat->set_blend_mode(CanvasItemMaterial::BLEND_MODE_SUB); break;
-                case ss::format::BlendType_Mul: mat->set_blend_mode(CanvasItemMaterial::BLEND_MODE_MUL); break;
-                default: mat->set_blend_mode(CanvasItemMaterial::BLEND_MODE_MIX); break;
-            }
-            _blend_materials[(int)ss_blend] = mat;
-        }
-        rs->canvas_item_set_material(ci, _blend_materials[(int)ss_blend]->get_rid());
+        _draw_part(rs, ci, frameData, part, partBinary, tex, cell);
+    }
+}
 
-        // 2. 高度な描画が必要か判定
-        uint64_t flags = part->update_flag();
-        bool use_advanced = (flags & ss::runtime::UpdateAttributeFlags_AttributeVertex);
-        use_advanced |= (flags & ss::runtime::UpdateAttributeFlags_AttributePartColor);
-        use_advanced |= (flags & (ss::runtime::UpdateAttributeFlags_AttributeUvtX | ss::runtime::UpdateAttributeFlags_AttributeUvtY |
+void GdSsPlayerNode2D::_draw_part(RenderingServer *rs, RID ci, const ss::runtime::FrameData *frameData, const ss::runtime::PartState *part, const ss::format::PartData *partBinary, const Ref<Texture2D> &tex, const ss::format::Cell *cell) {
+    // 1. Blend Mode
+    ss::format::BlendType ss_blend = partBinary->blend_type();
+    if (!_blend_materials.has((int)ss_blend)) {
+        Ref<CanvasItemMaterial> mat; mat.instantiate();
+        switch (ss_blend) {
+            case ss::format::BlendType_Mix: mat->set_blend_mode(CanvasItemMaterial::BLEND_MODE_MIX); break;
+            case ss::format::BlendType_Add: mat->set_blend_mode(CanvasItemMaterial::BLEND_MODE_ADD); break;
+            case ss::format::BlendType_Sub: mat->set_blend_mode(CanvasItemMaterial::BLEND_MODE_SUB); break;
+            case ss::format::BlendType_Mul: mat->set_blend_mode(CanvasItemMaterial::BLEND_MODE_MUL); break;
+            default: mat->set_blend_mode(CanvasItemMaterial::BLEND_MODE_MIX); break;
+        }
+        _blend_materials[(int)ss_blend] = mat;
+    }
+    rs->canvas_item_set_material(ci, _blend_materials[(int)ss_blend]->get_rid());
+
+    // 2. Matrix Calculation (Hierarchy aware)
+    float draw_m[16];
+    if (!ss_util_get_part_world_matrix(runtime_ctx, part->part_index(), ss_runtime_get_frame_no(runtime_ctx), draw_m)) {
+        return;
+    }
+
+    uint64_t flags = part->update_flag();
+    auto rect = cell->rectangle();
+    auto pivot = cell->pivot();
+    Rect2 src_rect(rect->x1(), rect->y1(), rect->x2(), rect->y2());
+
+    bool use_advanced = (flags & (ss::runtime::UpdateAttributeFlags_AttributeVertex | ss::runtime::UpdateAttributeFlags_AttributePartColor |
+                                  ss::runtime::UpdateAttributeFlags_AttributeUvtX | ss::runtime::UpdateAttributeFlags_AttributeUvtY |
                                   ss::runtime::UpdateAttributeFlags_AttributeUvrZ | ss::runtime::UpdateAttributeFlags_AttributeUvsX |
                                   ss::runtime::UpdateAttributeFlags_AttributeUvsY));
 
-        Rect2 src_rect(rect->x1(), rect->y1(), rect->x2(), rect->y2());
+    if (!use_advanced && partBinary->part_type_type() != ss::format::PartType_PartTypeMesh) {
+        Transform2D t = matrix_to_transform2d(draw_m);
+        rs->canvas_item_set_transform(ci, t);
 
-        if (!use_advanced && partBinary->part_type_type() != ss::format::PartType_PartTypeMesh) {
-            // --- 通常パス: Transform2D を利用した高速描画 ---
-            Transform2D t;
-            t.set_origin(Vector2(part->position_x(), part->position_y()));
-            t.set_rotation(part->rotation_z());
-            t.set_scale(Vector2(part->scale_x(), part->scale_y()));
-            rs->canvas_item_set_transform(ci, t);
+        Vector2 draw_pos = Vector2(-src_rect.size.x * (pivot->v1() + 0.5f),
+                                   -src_rect.size.y * (0.5f - pivot->v2()));
+        rs->canvas_item_add_texture_rect_region(ci, Rect2(draw_pos, src_rect.size), tex->get_rid(), src_rect, Color(1, 1, 1, part->alpha()));
+    } else if (partBinary->part_type_type() != ss::format::PartType_PartTypeMesh) {
+        rs->canvas_item_set_transform(ci, Transform2D());
 
-            Vector2 draw_pos = Vector2(-src_rect.size.x * (pivot->v1() + 0.5f),
-                                       -src_rect.size.y * (0.5f - pivot->v2()));
+        constexpr int CORNERS_COUNT = 4;
+        constexpr int MAX_VERTICES_COUNT = 5;
+        constexpr int INDICES_COUNT_QUAD = 6;
+        constexpr int INDICES_COUNT_PENTAGON = 12;
 
-            rs->canvas_item_add_texture_rect_region(ci, Rect2(draw_pos, src_rect.size), tex->get_rid(), src_rect, Color(1, 1, 1, part->alpha()));
-        } else if (partBinary->part_type_type() != ss::format::PartType_PartTypeMesh) {
-            // --- 高度パス: 頂点配列 (Triangle Array) による描画 (Normalパーツのみ) ---
-            rs->canvas_item_set_transform(ci, Transform2D());
+        float out_x[MAX_VERTICES_COUNT], out_y[MAX_VERTICES_COUNT];
+        SsVertexComputeParams params;
+        params.size = src_rect.size;
+        params.pivot = Vector2(pivot->v1(), pivot->v2());
+        params.flip_h = part->flip_h();
+        params.flip_v = part->flip_v();
+        params.use_5_vertices = true;
 
-            float w = src_rect.size.x;
-            float h = src_rect.size.y;
-            float px = -w * (pivot->v1() + 0.5f);
-            float py = -h * (0.5f - pivot->v2());
-
-            Vector2 verts[4] = {
-                Vector2(px, py),
-                Vector2(px + w, py),
-                Vector2(px, py + h),
-                Vector2(px + w, py + h)
-            };
-
-            if (flags & ss::runtime::UpdateAttributeFlags_AttributeVertex) {
-                auto vd = frameData->vertices()->Get(part->vertex());
-                verts[0] += Vector2(vd->lt().x(), vd->lt().y());
-                verts[1] += Vector2(vd->rt().x(), vd->rt().y());
-                verts[2] += Vector2(vd->lb().x(), vd->lb().y());
-                verts[3] += Vector2(vd->rb().x(), vd->rb().y());
-            }
-
-            Transform2D t;
-            t.set_origin(Vector2(part->position_x(), part->position_y()));
-            t.set_rotation(part->rotation_z());
-            t.set_scale(Vector2(part->scale_x(), part->scale_y()));
-            for (int j = 0; j < 4; j++) {
-                verts[j] = t.xform(verts[j]);
-            }
-
-            Vector2 uvs[4] = {
-                Vector2(src_rect.position.x, src_rect.position.y),
-                Vector2(src_rect.position.x + src_rect.size.x, src_rect.position.y),
-                Vector2(src_rect.position.x, src_rect.position.y + src_rect.size.y),
-                Vector2(src_rect.position.x + src_rect.size.x, src_rect.position.y + src_rect.size.y)
-            };
-
-            if (flags & (ss::runtime::UpdateAttributeFlags_AttributeUvtX | ss::runtime::UpdateAttributeFlags_AttributeUvtY |
-                         ss::runtime::UpdateAttributeFlags_AttributeUvrZ | ss::runtime::UpdateAttributeFlags_AttributeUvsX |
-                         ss::runtime::UpdateAttributeFlags_AttributeUvsY)) {
-                Vector2 uv_center = src_rect.position + src_rect.size * 0.5f;
-                for (int j = 0; j < 4; j++) {
-                    Vector2 uv = uvs[j];
-                    uv.x = (uv.x - uv_center.x) * part->uv_scale_x() + uv_center.x;
-                    uv.y = (uv.y - uv_center.y) * part->uv_scale_y() + uv_center.y;
-                    if (part->uv_rotation_z() != 0.0f) {
-                        float s = Math::sin(part->uv_rotation_z());
-                        float c = Math::cos(part->uv_rotation_z());
-                        float rel_x = uv.x - uv_center.x;
-                        float rel_y = uv.y - uv_center.y;
-                        uv.x = rel_x * c - rel_y * s + uv_center.x;
-                        uv.y = rel_x * s + rel_y * c + uv_center.y;
-                    }
-                    uv.x += part->uv_translation_x() * src_rect.size.x;
-                    uv.y += part->uv_translation_y() * src_rect.size.y;
-                    uvs[j] = uv;
-                }
-            }
-            
-            Vector2 tex_size = tex->get_size();
-            for (int j = 0; j < 4; j++) {
-                uvs[j].x /= tex_size.x;
-                uvs[j].y /= tex_size.y;
-            }
-
-            Color colors[4] = {
-                Color(1, 1, 1, part->alpha()),
-                Color(1, 1, 1, part->alpha()),
-                Color(1, 1, 1, part->alpha()),
-                Color(1, 1, 1, part->alpha())
-            };
-
-            if (flags & ss::runtime::UpdateAttributeFlags_AttributePartColor) {
-                auto pc = frameData->parts_color()->Get(part->part_color());
-                colors[0] = Color(pc->lt().rgba().r() / 255.0f, pc->lt().rgba().g() / 255.0f, pc->lt().rgba().b() / 255.0f, (pc->lt().rgba().a() / 255.0f) * part->alpha());
-                colors[1] = Color(pc->rt().rgba().r() / 255.0f, pc->rt().rgba().g() / 255.0f, pc->rt().rgba().b() / 255.0f, (pc->rt().rgba().a() / 255.0f) * part->alpha());
-                colors[2] = Color(pc->lb().rgba().r() / 255.0f, pc->lb().rgba().g() / 255.0f, pc->lb().rgba().b() / 255.0f, (pc->lb().rgba().a() / 255.0f) * part->alpha());
-                colors[3] = Color(pc->rb().rgba().r() / 255.0f, pc->rb().rgba().g() / 255.0f, pc->rb().rgba().b() / 255.0f, (pc->rb().rgba().a() / 255.0f) * part->alpha());
-            }
-
-            #ifdef SPRITESTUDIO_GODOT_EXTENSION
-            PackedVector2Array p_verts; p_verts.resize(4);
-            PackedVector2Array p_uvs; p_uvs.resize(4);
-            PackedColorArray p_colors; p_colors.resize(4);
-            PackedInt32Array p_indices; p_indices.resize(6);
-            #else
-            Vector<Vector2> p_verts; p_verts.resize(4);
-            Vector<Vector2> p_uvs; p_uvs.resize(4);
-            Vector<Color> p_colors; p_colors.resize(4);
-            Vector<int> p_indices; p_indices.resize(6);
-            #endif
-
-            for(int j=0; j<4; j++) {
-                p_verts.set(j, verts[j]);
-                p_uvs.set(j, uvs[j]);
-                p_colors.set(j, colors[j]);
-            }
-            p_indices.set(0, 0); p_indices.set(1, 1); p_indices.set(2, 2);
-            p_indices.set(3, 1); p_indices.set(4, 3); p_indices.set(5, 2);
-
-            rs->canvas_item_add_triangle_array(ci, p_indices, p_verts, p_colors, p_uvs, {}, {}, tex->get_rid());
+        if (flags & ss::runtime::UpdateAttributeFlags_AttributeVertex) {
+            auto vd = frameData->vertices()->Get(part->vertex());
+            params.has_deform = true;
+            params.deform_lt = Vector2(vd->lt().x(), vd->lt().y());
+            params.deform_rt = Vector2(vd->rt().x(), vd->rt().y());
+            params.deform_lb = Vector2(vd->lb().x(), vd->lb().y());
+            params.deform_rb = Vector2(vd->rb().x(), vd->rb().y());
         }
+
+        int v_count = compute_vertices(params, out_x, out_y);
+
+        if (v_count < CORNERS_COUNT) {
+            return;
+        }
+
+        #ifdef SPRITESTUDIO_GODOT_EXTENSION
+        PackedVector2Array p_verts; p_verts.resize(v_count);
+        PackedVector2Array p_uvs; p_uvs.resize(v_count);
+        PackedColorArray p_colors; p_colors.resize(v_count);
+        PackedInt32Array p_indices; p_indices.resize((v_count == MAX_VERTICES_COUNT) ? INDICES_COUNT_PENTAGON : INDICES_COUNT_QUAD);
+        #else
+        Vector<Vector2> p_verts; p_verts.resize(v_count);
+        Vector<Vector2> p_uvs; p_uvs.resize(v_count);
+        Vector<Color> p_colors; p_colors.resize(v_count);
+        Vector<int> p_indices; p_indices.resize((v_count == MAX_VERTICES_COUNT) ? INDICES_COUNT_PENTAGON : INDICES_COUNT_QUAD);
+        #endif
+
+        float out_u[MAX_VERTICES_COUNT], out_v[MAX_VERTICES_COUNT];
+        SsUvComputeParams uv_params;
+        uv_params.src_rect = src_rect;
+        uv_params.uv_translation = Vector2(part->uv_translation_x(), part->uv_translation_y());
+        uv_params.uv_rotation_z = part->uv_rotation_z();
+        uv_params.uv_scale = Vector2(part->uv_scale_x(), part->uv_scale_y());
+        uv_params.part_flip_h = part->flip_h();
+        uv_params.part_flip_v = part->flip_v();
+        uv_params.img_flip_h = part->img_flip_h();
+        uv_params.img_flip_v = part->img_flip_v();
+        uv_params.rotated = cell->rotated();
+        uv_params.use_5_vertices = true;
+
+        compute_uvs(uv_params, out_u, out_v);
+
+        Vector2 tex_size = tex->get_size();
+        Color corner_colors[CORNERS_COUNT] = { Color(1, 1, 1, part->alpha()), Color(1, 1, 1, part->alpha()), Color(1, 1, 1, part->alpha()), Color(1, 1, 1, part->alpha()) };
+        if (flags & ss::runtime::UpdateAttributeFlags_AttributePartColor) {
+            auto pc = frameData->parts_color()->Get(part->part_color());
+            auto to_color = [&](const ss::runtime::SsAttributePartColorKeyValueColor &c) { return Color(c.rgba().r()/255.0f, c.rgba().g()/255.0f, c.rgba().b()/255.0f, (c.rgba().a()/255.0f)*part->alpha()); };
+            corner_colors[0] = to_color(pc->lt()); corner_colors[1] = to_color(pc->rt()); corner_colors[2] = to_color(pc->lb()); corner_colors[3] = to_color(pc->rb());
+        }
+
+        Transform2D draw_transform = matrix_to_transform2d(draw_m);
+
+        for (int j = 0; j < CORNERS_COUNT; j++) {
+            p_verts.set(j, draw_transform.xform(Vector2(out_x[j], out_y[j])));
+            p_uvs.set(j, Vector2(out_u[j] / tex_size.x, out_v[j] / tex_size.y));
+            p_colors.set(j, corner_colors[j]);
+        }
+        if (v_count == MAX_VERTICES_COUNT) {
+            p_verts.set(CORNERS_COUNT, draw_transform.xform(Vector2(out_x[CORNERS_COUNT], out_y[CORNERS_COUNT])));
+            p_uvs.set(CORNERS_COUNT, Vector2(out_u[CORNERS_COUNT] / tex_size.x, out_v[CORNERS_COUNT] / tex_size.y));
+            p_colors.set(CORNERS_COUNT, (corner_colors[0] + corner_colors[1] + corner_colors[2] + corner_colors[3]) * 0.25f);
+            int idxs[] = { 0,1,4, 1,3,4, 3,2,4, 2,0,4 };
+            for(int k=0; k<INDICES_COUNT_PENTAGON; k++) p_indices.set(k, idxs[k]);
+        } else {
+            int idxs[] = { 0,1,2, 1,3,2 };
+            for(int k=0; k<INDICES_COUNT_QUAD; k++) p_indices.set(k, idxs[k]);
+        }
+        rs->canvas_item_add_triangle_array(ci, p_indices, p_verts, p_colors, p_uvs, {}, {}, tex->get_rid());
     }
 }
 

--- a/gd_spritestudio/gd_ssplayer_node2d.h
+++ b/gd_spritestudio/gd_ssplayer_node2d.h
@@ -94,5 +94,6 @@ private:
     void _draw_part(RenderingServer *rs, RID ci, const ss::runtime::FrameData *frameData, const ss::runtime::PartState *part, const ss::format::PartData *partBinary, const Ref<Texture2D> &tex, const ss::format::Cell *cell, const float *draw_m);
 
     Vector<float> _inheritance_matrices;
+    void _reconfigure();
     void _clear_canvas_items();
 };

--- a/gd_spritestudio/gd_ssplayer_node2d.h
+++ b/gd_spritestudio/gd_ssplayer_node2d.h
@@ -90,8 +90,9 @@ private:
     void loadTextures(const Ref<GdSsabResource>& ssabRes);
     void updateAnimation(float delta);
     void fetchAnimation();
-    void drawAnimation();
-    void _draw_part(RenderingServer *rs, RID ci, const ss::runtime::FrameData *frameData, const ss::runtime::PartState *part, const ss::format::PartData *partBinary, const Ref<Texture2D> &tex, const ss::format::Cell *cell);
+    void drawAnimation(int frame_no);
+    void _draw_part(RenderingServer *rs, RID ci, const ss::runtime::FrameData *frameData, const ss::runtime::PartState *part, const ss::format::PartData *partBinary, const Ref<Texture2D> &tex, const ss::format::Cell *cell, const float *draw_m);
 
+    Vector<float> _inheritance_matrices;
     void _clear_canvas_items();
 };

--- a/gd_spritestudio/gd_ssplayer_node2d.h
+++ b/gd_spritestudio/gd_ssplayer_node2d.h
@@ -93,7 +93,6 @@ private:
     void drawAnimation(int frame_no);
     void _draw_part(RenderingServer *rs, RID ci, const ss::runtime::FrameData *frameData, const ss::runtime::PartState *part, const ss::format::PartData *partBinary, const Ref<Texture2D> &tex, const ss::format::Cell *cell, const float *draw_m);
 
-    Vector<float> _inheritance_matrices;
     void _reconfigure();
     void _clear_canvas_items();
 };

--- a/gd_spritestudio/gd_ssplayer_node2d.h
+++ b/gd_spritestudio/gd_ssplayer_node2d.h
@@ -15,6 +15,17 @@ using namespace godot;
 // #include "gd_ssplayer_resource.h"
 #include "gd_ssab_resource.h"
 
+namespace ss {
+namespace runtime {
+struct FrameData;
+struct PartState;
+}
+namespace format {
+struct PartData;
+struct Cell;
+}
+}
+
 class GdSsPlayerNode2D : public Node2D {
     GDCLASS( GdSsPlayerNode2D, Node2D );
 
@@ -77,9 +88,10 @@ private:
     float _speed_rate = 1.0f;
 
     void loadTextures(const Ref<GdSsabResource>& ssabRes);
-	void updateAnimation(float delta);
+    void updateAnimation(float delta);
     void fetchAnimation();
     void drawAnimation();
+    void _draw_part(RenderingServer *rs, RID ci, const ss::runtime::FrameData *frameData, const ss::runtime::PartState *part, const ss::format::PartData *partBinary, const Ref<Texture2D> &tex, const ss::format::Cell *cell);
 
     void _clear_canvas_items();
 };

--- a/gd_spritestudio/runtime/ssruntime.h
+++ b/gd_spritestudio/runtime/ssruntime.h
@@ -281,4 +281,58 @@ int32_t ss_runtime_get_passed_event_frame_no(void *context, int32_t index);
 
 int32_t ss_runtime_get_passed_event_index(void *context, int32_t index);
 
+/// Computes the local vertex coordinates for a part.
+///
+/// # Safety
+/// - `input_data`: Must point to an array of at least 6 floats if `has_deform` (flag 4) is false,
+///   or 14 floats if `has_deform` is true.
+///   Layout: [size_x, size_y, pivot_x, pivot_y, pivot_offset_x, pivot_offset_y, (optional) dx0..3, dy0..3]
+/// - `out_x`, `out_y`: Must point to buffers with at least 4 floats, or 5 floats if `use_5_vertices` (flag 8) is true.
+/// Computes the local vertices for a part using primitive parameters.
+/// deform_x_ptr, deform_y_ptr: optional pointers to float arrays of size 4.
+/// out_x, out_y: pointers to float arrays of size 5 to store results.
+/// # Safety
+/// This function is unsafe because it dereferences raw pointers.
+int32_t ss_vertex_compute_local(float size_w,
+                                float size_h,
+                                float pivot_x,
+                                float pivot_y,
+                                float pivot_offset_x,
+                                float pivot_offset_y,
+                                bool h_flip,
+                                bool v_flip,
+                                bool use_5_vertices,
+                                const float *deform_x_ptr,
+                                const float *deform_y_ptr,
+                                float *out_x,
+                                float *out_y);
+
+/// Computes the local UV coordinates for a part.
+///
+/// # Safety
+/// - `input_data`: Must point to an array of at least 9 floats.
+///   Layout: [left, top, right, bottom, trans_u, trans_v, rot_deg, scale_u, scale_v]
+/// - `out_u`, `out_v`: Must point to buffers with at least 4 floats, or 5 floats if `use_5_vertices` (flag 32) is true.
+/// Computes the local UV coordinates for a part using primitive parameters.
+/// out_u, out_v: pointers to float arrays of size 5 to store results.
+/// # Safety
+/// This function is unsafe because it dereferences raw pointers.
+int32_t ss_uv_compute_local(float u_left,
+                            float v_top,
+                            float u_right,
+                            float v_bottom,
+                            float trans_u,
+                            float trans_v,
+                            float rot_deg,
+                            float scale_u,
+                            float scale_v,
+                            bool part_flip_h,
+                            bool part_flip_v,
+                            bool img_flip_h,
+                            bool img_flip_v,
+                            bool rotated,
+                            bool use_5_vertices,
+                            float *out_u,
+                            float *out_v);
+
 }  // extern "C"

--- a/gd_spritestudio/runtime/ssruntime.h
+++ b/gd_spritestudio/runtime/ssruntime.h
@@ -102,6 +102,12 @@ void ss_runtime_get_frame_data(void *context,
                                unsigned char **out_data,
                                uintptr_t *out_len);
 
+/// # Safety
+///
+/// This function is unsafe because it dereferences raw pointers for output.
+/// The caller must ensure `out_data` and `out_len` are valid if they are not null.
+void ss_runtime_get_world_matrices(void *context, const float **out_data, uintptr_t *out_len);
+
 int ss_runtime_get_frame_no(void *context);
 
 float ss_runtime_get_frame_no_decimal(void *context);

--- a/gd_spritestudio/runtime/ssruntime.h
+++ b/gd_spritestudio/runtime/ssruntime.h
@@ -202,13 +202,6 @@ void ss_context_set_unit(void *context, int32_t unit);
 
 int32_t ss_context_get_unit(void *context);
 
-/// Compute world matrix for a specific part by traversing its ancestors.
-/// out_m: pointer to float array of size 16.
-bool ss_util_get_part_world_matrix(void *context,
-                                   uint16_t part_index,
-                                   int32_t frame_no,
-                                   float *out_m);
-
 /// Transform multiple particle positions by a matrix.
 /// matrix_ptr: pointer to float array of size 16.
 /// particles_ptr: pointer to ParticleState array from ss_effect_get_state.
@@ -218,72 +211,6 @@ void ss_effect_transform_particles(const float *matrix_ptr,
                                    const void *particles_ptr,
                                    int32_t count,
                                    float *out_pos_ptr);
-
-/// out_m must be a pointer to a float array of size 16.
-/// # Safety
-/// This function is unsafe because it dereferences a raw pointer.
-void ss_matrix_identity(float *out_m);
-
-/// out_m, lhs, rhs must be pointers to float arrays of size 16.
-/// # Safety
-/// This function is unsafe because it dereferences raw pointers.
-void ss_matrix_multiply(float *out_m, const float *lhs, const float *rhs);
-
-/// out_m, in_m must be pointers to float arrays of size 16.
-/// # Safety
-/// This function is unsafe because it dereferences raw pointers.
-void ss_matrix_inverse(float *out_m, const float *in_m);
-
-/// out_x, out_y, out_z: output pointers for transformed vector.
-/// mat: pointer to a float array of size 16.
-/// x, y, z: input vector components.
-/// # Safety
-/// This function is unsafe because it dereferences raw pointers.
-void ss_matrix_transform_vector3(float *out_x,
-                                 float *out_y,
-                                 float *out_z,
-                                 const float *mat,
-                                 float x,
-                                 float y,
-                                 float z);
-
-/// out_m: pointer to a float array of size 16.
-/// # Safety
-/// This function is unsafe because it dereferences a raw pointer.
-void ss_matrix_create_scale(float *out_m, float x, float y, float z);
-
-/// out_m: pointer to a float array of size 16.
-/// # Safety
-/// This function is unsafe because it dereferences a raw pointer.
-void ss_matrix_create_translation(float *out_m, float x, float y, float z);
-
-/// out_m: pointer to a float array of size 16.
-/// # Safety
-/// This function is unsafe because it dereferences a raw pointer.
-void ss_matrix_create_rotation_x(float *out_m, float radians);
-
-/// out_m: pointer to a float array of size 16.
-/// # Safety
-/// This function is unsafe because it dereferences a raw pointer.
-void ss_matrix_create_rotation_y(float *out_m, float radians);
-
-/// out_m: pointer to a float array of size 16.
-/// # Safety
-/// This function is unsafe because it dereferences a raw pointer.
-void ss_matrix_create_rotation_z(float *out_m, float radians);
-
-/// out_inheritance_m, out_drawing_m: pointers to float arrays of size 16.
-/// state: pointer to PartState
-/// parent_matrix: pointer to a float array of size 16, or null.
-/// # Safety
-/// This function is unsafe because it dereferences raw pointers.
-void ss_matrix_compute_world(float *out_inheritance_m,
-                             float *out_drawing_m,
-                             const void *state,
-                             const float *parent_matrix,
-                             bool has_parent_size,
-                             float parent_size_x,
-                             float parent_size_y);
 
 int32_t ss_runtime_get_passed_event_count(void *context);
 

--- a/gd_spritestudio/runtime/ssruntime.h
+++ b/gd_spritestudio/runtime/ssruntime.h
@@ -335,4 +335,8 @@ int32_t ss_uv_compute_local(float u_left,
                             float *out_u,
                             float *out_v);
 
+bool ss_geometry_is_point_in_rect(float px, float py, float size_w, float size_h);
+
+bool ss_geometry_is_point_in_quad(float tx, float ty, const float *vx, const float *vy);
+
 }  // extern "C"

--- a/gd_spritestudio/runtime/ssruntime.h
+++ b/gd_spritestudio/runtime/ssruntime.h
@@ -186,6 +186,10 @@ float ss_util_calculate_instance_frame(float parent_frame,
                                        bool independent,
                                        float accumulated_time);
 
+void ss_runtime_set_world_matrix_calculation_enabled(void *context, bool enabled);
+
+bool ss_runtime_is_world_matrix_calculation_enabled(void *context);
+
 void ss_context_set_coordinate_system(void *context, int32_t coordinate_system);
 
 int32_t ss_context_get_coordinate_system(void *context);

--- a/gd_spritestudio/runtime/ssruntime.h
+++ b/gd_spritestudio/runtime/ssruntime.h
@@ -108,6 +108,12 @@ void ss_runtime_get_frame_data(void *context,
 /// The caller must ensure `out_data` and `out_len` are valid if they are not null.
 void ss_runtime_get_world_matrices(void *context, const float **out_data, uintptr_t *out_len);
 
+/// # Safety
+///
+/// This function is unsafe because it dereferences raw pointers for output.
+/// The caller must ensure `out_data` and `out_len` are valid if they are not null.
+void ss_runtime_get_z_order(void *context, const int32_t **out_data, uintptr_t *out_len);
+
 int ss_runtime_get_frame_no(void *context);
 
 float ss_runtime_get_frame_no_decimal(void *context);


### PR DESCRIPTION
This PR migrates matrix, vertex, and UV calculations—previously handled on the Godot side—to the SpriteStudio7-SDK (Rust runtime). By leveraging precomputed data from the SDK, this change significantly reduces CPU overhead, especially for animations with a high number of parts.

Key Changes

### 1. Adoption of Runtime-Calculated World Matrices
- Implemented the ss_runtime_get_world_matrices API to retrieve pre-calculated world matrices directly from the SDK.
- This eliminates the need for manual recursive parent-child hierarchy calculations within the Godot node, streamlining the drawing loop.

### 2. Offloading Vertex and UV Computation to the SDK
- Refactored GdSsPlayerNode2D to utilize the new ss_vertex_compute_local and ss_uv_compute_local APIs.
- Complex operations including vertex deformation (deform), part coloring, UV animation, and flipping are now consolidated within the SDK.

### 3. Optimized Rendering Paths
- Simple Path: For parts without vertex deformation or custom coloring, the system uses canvas_item_add_texture_rect_region, which is Godot's fastest drawing path for rectangular regions.
- Advanced Path: canvas_item_add_triangle_array is used only when necessary (e.g., for deformation).
- 5-Vertex Support: Improved deformation accuracy by supporting 5-vertex rendering (pentagon configuration with a center point) when required.

###  4. SpriteStudio7-SDK Submodule Update
- Updated the SpriteStudio7-SDK submodule to the latest version to support the new APIs mentioned above.

--

これまで Godot 側で行っていたマトリクス計算や頂点・UV計算を、SpriteStudio7-SDK (Rust版ランタイム)側の演算結果を利用する形へ移行しました。これにより、特にパーツ数が多いアニメーションにおいて CPU 負荷の大幅な低減が期待できます。

主な変更点

### 1. ランタイム計算のマトリクス利用への移行
- ss_runtime_get_world_matrices API を使用し、SDK側で計算済みのワールドマトリクスを直接取得するように変更しました。
- 以前の再帰的な親子関係の計算が不要になり、描画ループが効率化されました。

### 2. 頂点および UV 計算の SDK へのオフロード
- 新しく追加された ss_vertex_compute_local および ss_uv_compute_local を使用するように GdSsPlayerNode2D をリファクタリングしました。
- 頂点変形（デフォーム）、パーツカラー、UVアニメーション、フリップ等の複雑な演算を SDK 側に集約しました。

### 3. 描画パスの最適化
- シンプルパス: 頂点変形やパーツカラー設定がないパーツについては、Godot の canvas_item_add_texture_rect_region を使用し、最速のパスで描画します。
- アドバンスドパス: 頂点変形等が必要な場合のみ canvas_item_add_triangle_array を使用します。
- また、変形精度向上のため、必要に応じて 5 頂点（中心点を含むペンタゴン構成）での描画に対応しました。

### 4. SpriteStudio7-SDK サブモジュールの更新
- 上記 API をサポートするため、サブモジュールを最新の状態に更新しました。

--
ref
https://github.com/SpriteStudio/SpriteStudio7-SDK/pull/148