### PR TITLE
fix: update ssruntime vertex computation to support 5 vertices only

### DIFF
--- a/gd_spritestudio/gd_ssplayer_node2d.cpp
+++ b/gd_spritestudio/gd_ssplayer_node2d.cpp
@@ -451,7 +451,6 @@ namespace {
         Vector2 pivot;
         bool flip_h = false;
         bool flip_v = false;
-        bool use_5_vertices = true;
         bool has_deform = false;
         Vector2 deform_lt, deform_rt, deform_lb, deform_rb;
     };
@@ -472,7 +471,6 @@ namespace {
             params.pivot.x, params.pivot.y,
             0, 0, // pivot_offset
             params.flip_h, params.flip_v,
-            params.use_5_vertices,
             p_dx, p_dy,
             out_x, out_y
         );
@@ -495,7 +493,6 @@ namespace {
         bool img_flip_h = false;
         bool img_flip_v = false;
         bool rotated = false;
-        bool use_5_vertices = true;
     };
 
     int compute_uvs(const SsUvComputeParams& params, float* out_u, float* out_v) {
@@ -510,7 +507,6 @@ namespace {
             params.part_flip_h, params.part_flip_v,
             params.img_flip_h, params.img_flip_v,
             params.rotated,
-            params.use_5_vertices,
             out_u, out_v
         );
     }
@@ -678,7 +674,6 @@ void GdSsPlayerNode2D::_draw_part(RenderingServer *rs, RID ci, const ss::runtime
         params.pivot = Vector2(pivot->v1(), pivot->v2());
         params.flip_h = part->flip_h();
         params.flip_v = part->flip_v();
-        params.use_5_vertices = true;
 
         if (flags & ss::runtime::UpdateAttributeFlags_AttributeVertex) {
             auto vd = frameData->vertices()->Get(part->vertex());
@@ -718,7 +713,6 @@ void GdSsPlayerNode2D::_draw_part(RenderingServer *rs, RID ci, const ss::runtime
         uv_params.img_flip_h = part->img_flip_h();
         uv_params.img_flip_v = part->img_flip_v();
         uv_params.rotated = cell->rotated();
-        uv_params.use_5_vertices = true;
 
         compute_uvs(uv_params, out_u, out_v);
 

--- a/gd_spritestudio/runtime/ssruntime.h
+++ b/gd_spritestudio/runtime/ssruntime.h
@@ -230,7 +230,7 @@ int32_t ss_runtime_get_passed_event_index(void *context, int32_t index);
 /// - `input_data`: Must point to an array of at least 6 floats if `has_deform` (flag 4) is false,
 ///   or 14 floats if `has_deform` is true.
 ///   Layout: [size_x, size_y, pivot_x, pivot_y, pivot_offset_x, pivot_offset_y, (optional) dx0..3, dy0..3]
-/// - `out_x`, `out_y`: Must point to buffers with at least 4 floats, or 5 floats if `use_5_vertices` (flag 8) is true.
+/// - `out_x`, `out_y`: Must point to buffers with at least 5 floats.
 /// Computes the local vertices for a part using primitive parameters.
 /// deform_x_ptr, deform_y_ptr: optional pointers to float arrays of size 4.
 /// out_x, out_y: pointers to float arrays of size 5 to store results.
@@ -244,7 +244,6 @@ int32_t ss_vertex_compute_local(float size_w,
                                 float pivot_offset_y,
                                 bool h_flip,
                                 bool v_flip,
-                                bool use_5_vertices,
                                 const float *deform_x_ptr,
                                 const float *deform_y_ptr,
                                 float *out_x,
@@ -255,7 +254,7 @@ int32_t ss_vertex_compute_local(float size_w,
 /// # Safety
 /// - `input_data`: Must point to an array of at least 9 floats.
 ///   Layout: [left, top, right, bottom, trans_u, trans_v, rot_deg, scale_u, scale_v]
-/// - `out_u`, `out_v`: Must point to buffers with at least 4 floats, or 5 floats if `use_5_vertices` (flag 32) is true.
+/// - `out_u`, `out_v`: Must point to buffers with at least 5 floats.
 /// Computes the local UV coordinates for a part using primitive parameters.
 /// out_u, out_v: pointers to float arrays of size 5 to store results.
 /// # Safety
@@ -274,7 +273,6 @@ int32_t ss_uv_compute_local(float u_left,
                             bool img_flip_h,
                             bool img_flip_v,
                             bool rotated,
-                            bool use_5_vertices,
                             float *out_u,
                             float *out_v);
 


### PR DESCRIPTION
Updated the vertex and UV computation logic to align with the latest ssruntime changes, where the vertex count is now fixed to 5. Removed the 'use_5_vertices' parameter from the relevant functions and structures.

ref
https://github.com/SpriteStudio/SpriteStudio7-SDK/pull/153