### PR TITLE
feature/internal vertex

### DIFF
--- a/ss_player/format/framedata.h
+++ b/ss_player/format/framedata.h
@@ -389,19 +389,22 @@ FLATBUFFERS_MANUALLY_ALIGNED_STRUCT(4) PartAttributeVertex FLATBUFFERS_FINAL_CLA
   ss::runtime::Vec2 rt_;
   ss::runtime::Vec2 lb_;
   ss::runtime::Vec2 rb_;
+  ss::runtime::Vec2 center_;
 
  public:
   PartAttributeVertex()
       : lt_(),
         rt_(),
         lb_(),
-        rb_() {
+        rb_(),
+        center_() {
   }
-  PartAttributeVertex(const ss::runtime::Vec2 &_lt, const ss::runtime::Vec2 &_rt, const ss::runtime::Vec2 &_lb, const ss::runtime::Vec2 &_rb)
+  PartAttributeVertex(const ss::runtime::Vec2 &_lt, const ss::runtime::Vec2 &_rt, const ss::runtime::Vec2 &_lb, const ss::runtime::Vec2 &_rb, const ss::runtime::Vec2 &_center)
       : lt_(_lt),
         rt_(_rt),
         lb_(_lb),
-        rb_(_rb) {
+        rb_(_rb),
+        center_(_center) {
   }
   const ss::runtime::Vec2 &lt() const {
     return lt_;
@@ -415,8 +418,11 @@ FLATBUFFERS_MANUALLY_ALIGNED_STRUCT(4) PartAttributeVertex FLATBUFFERS_FINAL_CLA
   const ss::runtime::Vec2 &rb() const {
     return rb_;
   }
+  const ss::runtime::Vec2 &center() const {
+    return center_;
+  }
 };
-FLATBUFFERS_STRUCT_END(PartAttributeVertex, 32);
+FLATBUFFERS_STRUCT_END(PartAttributeVertex, 40);
 
 FLATBUFFERS_MANUALLY_ALIGNED_STRUCT(4) PartAttributeShader FLATBUFFERS_FINAL_CLASS {
  private:

--- a/ss_player/format/ssab.h
+++ b/ss_player/format/ssab.h
@@ -4030,7 +4030,8 @@ struct PartAttributeInstance FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Ta
     VT_START_OFFSET = 12,
     VT_END_LABEL_HASH = 14,
     VT_END_OFFSET = 16,
-    VT_SPEED = 18
+    VT_SPEED = 18,
+    VT_REVERSE = 20
   };
   bool pingpong() const {
     return GetField<uint8_t>(VT_PINGPONG, 0) != 0;
@@ -4056,6 +4057,9 @@ struct PartAttributeInstance FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Ta
   float speed() const {
     return GetField<float>(VT_SPEED, 0.0f);
   }
+  bool reverse() const {
+    return GetField<uint8_t>(VT_REVERSE, 0) != 0;
+  }
   template <bool B = false>
   bool Verify(::flatbuffers::VerifierTemplate<B> &verifier) const {
     return VerifyTableStart(verifier) &&
@@ -4067,6 +4071,7 @@ struct PartAttributeInstance FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Ta
            VerifyField<uint32_t>(verifier, VT_END_LABEL_HASH, 4) &&
            VerifyField<int32_t>(verifier, VT_END_OFFSET, 4) &&
            VerifyField<float>(verifier, VT_SPEED, 4) &&
+           VerifyField<uint8_t>(verifier, VT_REVERSE, 1) &&
            verifier.EndTable();
   }
 };
@@ -4099,6 +4104,9 @@ struct PartAttributeInstanceBuilder {
   void add_speed(float speed) {
     fbb_.AddElement<float>(PartAttributeInstance::VT_SPEED, speed, 0.0f);
   }
+  void add_reverse(bool reverse) {
+    fbb_.AddElement<uint8_t>(PartAttributeInstance::VT_REVERSE, static_cast<uint8_t>(reverse), 0);
+  }
   explicit PartAttributeInstanceBuilder(::flatbuffers::FlatBufferBuilder &_fbb)
         : fbb_(_fbb) {
     start_ = fbb_.StartTable();
@@ -4119,7 +4127,8 @@ inline ::flatbuffers::Offset<PartAttributeInstance> CreatePartAttributeInstance(
     int32_t start_offset = 0,
     uint32_t end_label_hash = 0,
     int32_t end_offset = 0,
-    float speed = 0.0f) {
+    float speed = 0.0f,
+    bool reverse = false) {
   PartAttributeInstanceBuilder builder_(_fbb);
   builder_.add_speed(speed);
   builder_.add_end_offset(end_offset);
@@ -4127,6 +4136,7 @@ inline ::flatbuffers::Offset<PartAttributeInstance> CreatePartAttributeInstance(
   builder_.add_start_offset(start_offset);
   builder_.add_start_label_hash(start_label_hash);
   builder_.add_loop_num(loop_num);
+  builder_.add_reverse(reverse);
   builder_.add_independent(independent);
   builder_.add_pingpong(pingpong);
   return builder_.Finish();

--- a/ss_player/ss_player_node_2d.cpp
+++ b/ss_player/ss_player_node_2d.cpp
@@ -558,6 +558,7 @@ void SpriteStudioPlayer2D::drawAnimation(float frame_no) {
     ss_runtime_get_world_matrices(runtime_ctx, &f.world_matrices, &f.world_matrices_len);
     ss_runtime_get_local_uvs(runtime_ctx, &f.local_uvs, &f.local_uvs_len);
     ss_runtime_get_cell_meta(runtime_ctx, &f.cell_meta, &f.cell_meta_len);
+    ss_runtime_get_cell_texture_hashes(runtime_ctx, &f.cell_texture_hashes, &f.cell_texture_hashes_len);
     ss_runtime_get_shape_vertices(runtime_ctx, &f.shape_vertices, &f.shape_vertices_len);
     ss_runtime_get_shape_vertex_box_coords(runtime_ctx, &f.shape_box_coords, &f.shape_box_coords_len);
     ss_runtime_get_shape_vertex_counts(runtime_ctx, &f.shape_vertex_counts, &f.shape_vertex_counts_len);
@@ -653,15 +654,14 @@ void SpriteStudioPlayer2D::_draw_part_normal(const DrawFrame &f, RID ci, int p_i
         part_uvs = f.local_uvs + (p_idx * 10);
     }
 
-    // 1. Cell / texture lookup.
-    const auto frameDataCellIndex = part->cell();
-    if (frameDataCellIndex < 0) return;
+    // 1. Cell / texture lookup. The runtime exposes the owning cellmap's
+    //    name_hash directly via `cell_texture_hashes`, so the player can
+    //    skip walking `FrameData::cells` and `SsAnimeBinary::cellmaps` per
+    //    frame; non-zero hash implies a resolvable cell.
     if (!part_cell_meta) return;
-    auto frameDataCell = f.frameData->cells()->Get(frameDataCellIndex);
-    if (!frameDataCell) return;
-    auto cellmap = f.binary->cellmaps()->Get(frameDataCell->map_id());
-    if (!cellmap) return;
-    uint32_t texHash = cellmap->name_hash();
+    if (!f.cell_texture_hashes || (uintptr_t)p_idx >= f.cell_texture_hashes_len) return;
+    const uint32_t texHash = f.cell_texture_hashes[p_idx];
+    if (texHash == 0) return;
     if (!_textures.has(texHash)) return;
     Ref<Texture2D> tex = _textures[texHash];
 

--- a/ss_player/ss_player_node_2d.cpp
+++ b/ss_player/ss_player_node_2d.cpp
@@ -63,6 +63,13 @@ void SpriteStudioPlayer2D::setSSABResource( const Ref<SSABResource>& ssabRes ) {
         }
     }
 
+    // Resolve external instance dependencies so _setup_instance_players
+    // (called from fetchAnimation below) can find ref animations that live
+    // in sibling .ssab files.
+    if (!_instance_child_mode) {
+        _load_external_ssabs();
+    }
+
 	fetchAnimation();
 	NOTIFY_PROPERTY_LIST_CHANGED();
 }
@@ -120,6 +127,16 @@ float SpriteStudioPlayer2D::getSpeed() const {
 void SpriteStudioPlayer2D::setFrame( float p_frame ) {
     if (runtime_ctx) {
         ss_runtime_set_frame_no(runtime_ctx, p_frame);
+        float frame_no = ss_runtime_get_frame_no(runtime_ctx);
+        float draw_frame = _sub_frame_enabled ? frame_no : (float)((int)frame_no);
+        previous_frame_no = draw_frame;
+        drawAnimation(draw_frame);
+    }
+}
+
+void SpriteStudioPlayer2D::setFrameRelative( float p_diff ) {
+    if (runtime_ctx) {
+        ss_runtime_set_frame_relative(runtime_ctx, p_diff);
         float frame_no = ss_runtime_get_frame_no(runtime_ctx);
         float draw_frame = _sub_frame_enabled ? frame_no : (float)((int)frame_no);
         previous_frame_no = draw_frame;
@@ -213,6 +230,7 @@ void SpriteStudioPlayer2D::_bind_methods() {
     ClassDB::bind_method( D_METHOD( "set_speed", "speed" ), &SpriteStudioPlayer2D::setSpeed );
     ClassDB::bind_method( D_METHOD( "get_speed" ), &SpriteStudioPlayer2D::getSpeed );
     ClassDB::bind_method( D_METHOD( "set_frame", "frame" ), &SpriteStudioPlayer2D::setFrame );
+    ClassDB::bind_method( D_METHOD( "set_frame_relative", "diff" ), &SpriteStudioPlayer2D::setFrameRelative );
     ClassDB::bind_method( D_METHOD( "get_frame" ), &SpriteStudioPlayer2D::getFrame );
 
     ClassDB::bind_method( D_METHOD( "get_total_frames" ), &SpriteStudioPlayer2D::getTotalFrames );
@@ -442,7 +460,10 @@ void SpriteStudioPlayer2D::_get_property_list( List<PropertyInfo>* p_list ) cons
 void SpriteStudioPlayer2D::_notification( int p_notification ) {
     switch ( p_notification ) {
  	case NOTIFICATION_READY:
-        set_process_internal( true );
+        // Instance child Players are driven by the parent Player via
+        // setFrameRelative every frame, so skip the per-process auto-update
+        // they would otherwise do — running both would race the controller.
+        set_process_internal( !_instance_child_mode );
 
         break;
     case NOTIFICATION_INTERNAL_PROCESS:
@@ -452,6 +473,13 @@ void SpriteStudioPlayer2D::_notification( int p_notification ) {
     default:
         break;
 	}
+}
+
+void SpriteStudioPlayer2D::setInstanceChildMode( bool p_enabled ) {
+    _instance_child_mode = p_enabled;
+    if (is_inside_tree()) {
+        set_process_internal( !_instance_child_mode );
+    }
 }
 
 void SpriteStudioPlayer2D::loadTextures(const Ref<SSABResource>& ssabRes) {
@@ -555,6 +583,7 @@ void SpriteStudioPlayer2D::drawAnimation(float frame_no) {
     f.rs = RenderingServer::get_singleton();
     f.frameData = ss::runtime::GetFrameData(data);
     f.binary = _ssabRes->get_ss_anime_binary();
+    f.frame_no = frame_no;
     ss_runtime_get_world_matrices(runtime_ctx, &f.world_matrices, &f.world_matrices_len);
     ss_runtime_get_local_uvs(runtime_ctx, &f.local_uvs, &f.local_uvs_len);
     ss_runtime_get_cell_meta(runtime_ctx, &f.cell_meta, &f.cell_meta_len);
@@ -631,16 +660,325 @@ void SpriteStudioPlayer2D::_draw_part(const DrawFrame &f, RID ci, int p_idx, con
         case ss::format::PartType_PartTypeMask:
             return;
 
-        // TODO: requires per-frame child Player synchronization
-        // (ss_util_calculate_instance_frame / ss_effect_update). The runtime
-        // exposes the APIs but this player does not yet wire them up.
         case ss::format::PartType_PartTypeInstance:
+            _draw_part_instance(f, ci, p_idx, part, partBinary, draw_m);
+            return;
+
+        // TODO: effect part wiring shares the deterministic resolve_frame
+        // pattern but needs an effect-specific child Context. Not yet
+        // implemented in this Player.
         case ss::format::PartType_PartTypeEffect:
             return;
 
         default:
             return;
     }
+}
+
+// fnv1a 32-bit byte-wise hash matching libssconverter's
+// `crate::utils::fnv1a_hash_str`, which is what the converter uses to
+// compute `ref_anime_hash` from the animation name.
+static uint32_t fnv1a_hash_str_c(const String& s) {
+    CharString cs = s.utf8();
+    uint32_t hash = 2166136261u;
+    const uint32_t prime = 16777619u;
+    for (int i = 0; i < cs.length(); i++) {
+        hash ^= (uint8_t)cs[i];
+        hash *= prime;
+    }
+    return hash;
+}
+
+// Searches `res` for an animation whose `name_hash` matches. Returns the
+// utf8 name (empty when not found).
+static String find_anim_name_in(const Ref<SSABResource>& res, uint32_t name_hash) {
+    if (res.is_null()) return String();
+    auto binary = res->get_ss_anime_binary();
+    if (!binary || !binary->animations()) return String();
+    auto anims = binary->animations();
+    for (uint32_t i = 0; i < anims->size(); i++) {
+        auto a = anims->Get(i);
+        if (a && a->name_hash() == name_hash) {
+            return a->name() ? String::utf8(a->name()->c_str()) : String();
+        }
+    }
+    return String();
+}
+
+String SpriteStudioPlayer2D::_resolve_animation_by_hash(uint32_t name_hash, Ref<SSABResource>& out_source) const {
+    out_source = Ref<SSABResource>();
+
+    // SS7's PartTypeInstance only carries `ref_anime_hash` (= fnv1a of the
+    // anime name), not the owning pack name. When the parent and an
+    // external SSAB both happen to define an animation with the same name
+    // (and therefore the same hash), we have to disambiguate using the
+    // parent's `external_instances` list, which encodes the intended
+    // `<pack>/<anime>` pair the part is referring to. Prefer a match there
+    // over a self-match — the converter only writes an entry when the part
+    // explicitly points outside the pack.
+    if (!_ssabRes.is_null()) {
+        auto binary = _ssabRes->get_ss_anime_binary();
+        if (binary && binary->external_instances()) {
+            auto exts = binary->external_instances();
+            for (uint32_t i = 0; i < exts->size(); i++) {
+                auto entry = exts->Get(i);
+                if (!entry) continue;
+                String s = String::utf8(entry->c_str());
+                int slash = s.find("/");
+                if (slash < 0) continue;
+                String pack = s.substr(0, slash);
+                String anime = s.substr(slash + 1, -1);
+                if (fnv1a_hash_str_c(anime) != name_hash) continue;
+
+                for (int j = 0; j < _external_ssabs.size(); j++) {
+                    const Ref<SSABResource>& ext = _external_ssabs[j];
+                    if (ext.is_null()) continue;
+                    auto eb = ext->get_ss_anime_binary();
+                    if (!eb || !eb->name()) continue;
+                    if (String::utf8(eb->name()->c_str()) != pack) continue;
+                    String found = find_anim_name_in(ext, name_hash);
+                    if (!found.is_empty()) {
+                        out_source = ext;
+                        return found;
+                    }
+                }
+            }
+        }
+    }
+
+    // Fallback: search self, then external SSABs in order. Hits when the
+    // part references a same-pack animation (no external_instances entry)
+    // or when the external lookup above could not find a matching pack.
+    String found = find_anim_name_in(_ssabRes, name_hash);
+    if (!found.is_empty()) {
+        out_source = _ssabRes;
+        return found;
+    }
+    for (int i = 0; i < _external_ssabs.size(); i++) {
+        const Ref<SSABResource>& ext = _external_ssabs[i];
+        found = find_anim_name_in(ext, name_hash);
+        if (!found.is_empty()) {
+            out_source = ext;
+            return found;
+        }
+    }
+    return String();
+}
+
+void SpriteStudioPlayer2D::_load_external_ssabs() {
+    _external_ssabs.clear();
+    if (_ssabRes.is_null()) return;
+    auto binary = _ssabRes->get_ss_anime_binary();
+    if (!binary) return;
+    if (!binary->external_instances() || binary->external_instances()->size() == 0) return;
+
+    // libssconverter writes one .ssab per ssae alongside the project's other
+    // outputs. external_instances entries are "<pack>/<anime>" — we only
+    // need the unique pack names to know which sibling .ssab files to load.
+    HashMap<String, bool> seen;
+    auto exts = binary->external_instances();
+    String parent_dir = _ssabRes->get_parent_dir();
+    for (uint32_t i = 0; i < exts->size(); i++) {
+        auto entry = exts->Get(i);
+        if (!entry) continue;
+        String s = String::utf8(entry->c_str());
+        int slash = s.find("/");
+        String pack = (slash >= 0) ? s.substr(0, slash) : s;
+        if (pack.is_empty() || seen.has(pack)) continue;
+        seen[pack] = true;
+
+        String path = parent_dir.path_join(pack + ".ssab");
+        Ref<Resource> res =
+        #ifdef SPRITESTUDIO_GODOT_EXTENSION
+            ResourceLoader::get_singleton()->load(path, "", ResourceLoader::CACHE_MODE_REUSE);
+        #else
+            ResourceLoader::load(path, "", ResourceFormatLoader::CACHE_MODE_REUSE, nullptr);
+        #endif
+        Ref<SSABResource> ssab = res;
+        if (ssab.is_null()) {
+            ERR_PRINT(vformat("[SS] external SSAB load failed: %s", path));
+            continue;
+        }
+        if (!ssab->is_valid()) {
+            ERR_PRINT(vformat("[SS] external SSAB invalid: %s", path));
+            continue;
+        }
+        _external_ssabs.push_back(ssab);
+    }
+}
+
+void SpriteStudioPlayer2D::_clear_instance_players() {
+    for (int i = 0; i < _instance_players.size(); i++) {
+        SpriteStudioPlayer2D *child = _instance_players[i];
+        if (child) {
+            // remove_child detaches without freeing; queue_free defers actual
+            // delete to a safe point, which avoids destruction during the
+            // current process tick.
+            remove_child(child);
+            child->queue_free();
+        }
+    }
+    _instance_players.clear();
+}
+
+void SpriteStudioPlayer2D::_setup_instance_players() {
+    _clear_instance_players();
+    if (_ssabRes.is_null()) return;
+    auto binary = _ssabRes->get_ss_anime_binary();
+    if (!binary || !binary->parts()) return;
+
+    auto parts = binary->parts();
+    _instance_players.resize(parts->size());
+    for (int i = 0; i < (int)parts->size(); i++) {
+        _instance_players.set(i, nullptr);
+    }
+    for (int i = 0; i < (int)parts->size(); i++) {
+        auto p = parts->Get(i);
+        if (!p) continue;
+        if (p->part_type_type() != ss::format::PartType_PartTypeInstance) continue;
+        auto pt = p->part_type_as_PartTypeInstance();
+        if (!pt) continue;
+
+        Ref<SSABResource> source;
+        uint32_t ref_hash = pt->ref_anime_hash();
+        String anim_name = _resolve_animation_by_hash(ref_hash, source);
+        if (anim_name.is_empty() || source.is_null()) {
+            ERR_PRINT(vformat("[SS] instance part %d: ref_anime_hash=0x%x not found in current or external SSABs", i, ref_hash));
+            continue;
+        }
+
+        SpriteStudioPlayer2D *child = memnew(SpriteStudioPlayer2D);
+        child->setInstanceChildMode(true);
+        add_child(child);
+        // Hand the child the SSAB that actually contains the referenced
+        // animation — this may be the parent's own resource OR an external
+        // one auto-loaded from the parent's directory.
+        child->setSSABResource(source);
+        child->setAnimation(anim_name);
+        // Pause the controller so its play-state doesn't interfere with the
+        // parent-driven setFrameRelative path; we still call drawAnimation
+        // explicitly each frame.
+        child->stop();
+        _instance_players.set(i, child);
+    }
+}
+
+void SpriteStudioPlayer2D::_draw_part_instance(const DrawFrame &f, RID ci, int p_idx, const ss::runtime::PartState *part, const ss::format::PartData *partBinary, const float *draw_m) {
+    if (p_idx < 0 || p_idx >= _instance_players.size()) return;
+    SpriteStudioPlayer2D *child = _instance_players[p_idx];
+    if (!child) return;
+
+    // Find the active EventInstance for this part:
+    //   1. Walk EventsPerFrame backward for the latest entry with
+    //      frame_index <= parent_frame whose `instances` array contains an
+    //      EventInstance matching this part_index.
+    //   2. If none found, fall back to AnimationData.initial_events[p_idx]
+    //      — SS7 stores per-part frame-0 setup (instance, effect, audio,
+    //      user, signal) in this array indexed by array position == part_index.
+    //   3. If still no attr, the instance has not been triggered on the
+    //      parent's timeline; skip rendering.
+    if (!_currentAnimationData) {
+        child->set_visible(false);
+        return;
+    }
+    int parent_frame_int = (int)f.frame_no;
+
+    const ss::format::PartAttributeInstance *active_attr = nullptr;
+    int active_event_frame = 0;
+    if (auto events = _currentAnimationData->events()) {
+        for (int i = (int)events->size() - 1; i >= 0; i--) {
+            auto epf = events->Get(i);
+            if (!epf) continue;
+            int frame_index = epf->frame_index();
+            if (frame_index > parent_frame_int) continue;
+            if (!epf->instances()) continue;
+            for (uint32_t j = 0; j < epf->instances()->size(); j++) {
+                auto ev = epf->instances()->Get(j);
+                if (!ev || ev->part_index() != (uint16_t)p_idx) continue;
+                active_attr = ev->value();
+                active_event_frame = frame_index;
+                break;
+            }
+            if (active_attr) break;
+        }
+    }
+    if (!active_attr) {
+        if (auto inits = _currentAnimationData->initial_events()) {
+            if ((uint32_t)p_idx < inits->size()) {
+                auto entry = inits->Get(p_idx);
+                if (entry && entry->instance()) {
+                    active_attr = entry->instance();
+                    active_event_frame = 0;
+                }
+            }
+        }
+    }
+
+    // Default playback config used when no EventInstance / InitialEvent entry
+    // exists. Matches the default-constructed `SsInstanceAttr` in SS6
+    // (sstypes.h:1294): loopNum=1, infinity=false, full "_start".."_end"
+    // range, speed=1, curKeyframe=0. This makes the instance play through
+    // once and clamp at end_frame (animedecode.cpp:1670 clamps `reftime` to
+    // `inst_scale - 1` once `nowloop >= loopNum`), rather than looping.
+    int child_total = child->getTotalFrames();
+    int default_end = child_total > 0 ? child_total - 1 : 0;
+
+    int start_frame = 0;
+    int end_frame = default_end;
+    int loops = 1;
+    bool pingpong = false;
+    bool reverse = false;
+    float speed = 1.0f;
+
+    if (active_attr) {
+        // Resolve the play range. Label hash 0 (or unresolved) falls back
+        // to the referenced animation's own start/end. start_offset /
+        // end_offset apply to the resolved label time.
+        auto resolve_label = [&](uint32_t label_hash, int fallback) -> int {
+            if (label_hash == 0) return fallback;
+            auto child_res = child->getSSABResource();
+            if (child_res.is_null()) return fallback;
+            auto child_anim_name = child->getAnimation();
+            auto child_binary = child_res->get_ss_anime_binary();
+            if (!child_binary || !child_binary->animations()) return fallback;
+            for (uint32_t i = 0; i < child_binary->animations()->size(); i++) {
+                auto a = child_binary->animations()->Get(i);
+                if (!a || !a->name()) continue;
+                if (String::utf8(a->name()->c_str()) != child_anim_name) continue;
+                if (!a->labels()) return fallback;
+                for (uint32_t k = 0; k < a->labels()->size(); k++) {
+                    auto lab = a->labels()->Get(k);
+                    if (lab && lab->name_hash() == label_hash) return lab->time();
+                }
+                return fallback;
+            }
+            return fallback;
+        };
+
+        start_frame = resolve_label(active_attr->start_label_hash(), 0) + active_attr->start_offset();
+        end_frame = resolve_label(active_attr->end_label_hash(), default_end) + active_attr->end_offset();
+        if (end_frame < start_frame) end_frame = start_frame;
+
+        loops = active_attr->loop_num();
+        pingpong = active_attr->pingpong();
+        reverse = active_attr->reverse();
+        speed = active_attr->speed();
+    }
+
+    child->setAnimationSection(start_frame, end_frame);
+    child->setLoop(loops);
+    // The runtime FFI's convention is `direction == 0 => Forward,
+    // anything-non-zero => Backward`, *not* the values of the Rust
+    // `PlaybackDirection` enum (Forward=1, Backward=-1). Pass 0/1 here so
+    // forward-playing instances don't get silently flipped.
+    // PlaybackStyle: 0 = Normal, 1 = PingPong.
+    child->setPlaybackDirection(reverse ? 1 : 0, pingpong ? 1 : 0);
+
+    float diff = (f.frame_no - (float)active_event_frame) * speed;
+    Transform2D xf = matrix_to_transform2d(draw_m);
+    child->set_transform(xf);
+    child->set_visible(true);
+    child->setFrameRelative(diff);
 }
 
 void SpriteStudioPlayer2D::_draw_part_normal(const DrawFrame &f, RID ci, int p_idx, const ss::runtime::PartState *part, const ss::format::PartData *partBinary, const float *draw_m) {
@@ -872,6 +1210,7 @@ void SpriteStudioPlayer2D::fetchAnimation() {
         }
         _currentAnimationData = nullptr;
         _clear_canvas_items();
+        _clear_instance_players();
         return;
     }
 
@@ -916,6 +1255,15 @@ void SpriteStudioPlayer2D::fetchAnimation() {
         if ( !setup ) {
             ERR_PRINT( "SSAB Setup Animation Failed: " + _strAnimationSelected );
             return;
+        }
+
+        // Build the per-Instance-part child Players before the first draw —
+        // _draw_part_instance assumes _instance_players is sized to parts.
+        // Skip when this Player is itself an instance child to cap recursion
+        // at depth 1 — nested Instance parts are not yet supported and would
+        // self-reference / cycle through the same SSABResource.
+        if (!_instance_child_mode) {
+            _setup_instance_players();
         }
 
         float frame_no = ss_runtime_get_frame_no(runtime_ctx);

--- a/ss_player/ss_player_node_2d.cpp
+++ b/ss_player/ss_player_node_2d.cpp
@@ -492,34 +492,6 @@ namespace {
     constexpr int INDICES_COUNT_PENTAGON = 12;
     constexpr int INDICES_COUNT_QUAD = 6;
 
-    struct SsUvComputeParams {
-        Rect2 src_rect;
-        Vector2 uv_translation;
-        float uv_rotation_z = 0.0f;
-        Vector2 uv_scale;
-        bool part_flip_h = false;
-        bool part_flip_v = false;
-        bool img_flip_h = false;
-        bool img_flip_v = false;
-        bool rotated = false;
-    };
-
-    bool compute_uvs(const SsUvComputeParams& params, float* out_u, float* out_v) {
-        return ss_uv_compute_local(
-            params.src_rect.position.x, params.src_rect.position.y,
-            params.src_rect.position.x + params.src_rect.size.x,
-            params.src_rect.position.y + params.src_rect.size.y,
-            params.uv_translation.x * params.src_rect.size.x,
-            params.uv_translation.y * params.src_rect.size.y,
-            Math::rad_to_deg(params.uv_rotation_z),
-            params.uv_scale.x, params.uv_scale.y,
-            params.part_flip_h, params.part_flip_v,
-            params.img_flip_h, params.img_flip_v,
-            params.rotated,
-            out_u, out_v
-        );
-    }
-
     Transform2D matrix_to_transform2d(const float* m) {
         Transform2D t;
         t.columns[0] = Vector2(m[0], m[1]);
@@ -587,6 +559,10 @@ void SpriteStudioPlayer2D::drawAnimation(float frame_no) {
     uintptr_t z_order_len = 0;
     ss_runtime_get_z_order(runtime_ctx, &z_order, &z_order_len);
 
+    const float *local_uvs = nullptr;
+    uintptr_t local_uvs_len = 0;
+    ss_runtime_get_local_uvs(runtime_ctx, &local_uvs, &local_uvs_len);
+
     auto frameData = ss::runtime::GetFrameData(data);
     auto parts = frameData->parts();
     if (!parts) return;
@@ -621,23 +597,69 @@ void SpriteStudioPlayer2D::drawAnimation(float frame_no) {
 
         auto partBinary = binary->parts()->Get(p_idx);
 
-        auto frameDataCellIndex = part->cell();
-        auto frameDataCell = frameData->cells()->Get(frameDataCellIndex);
-        auto cellmap = binary->cellmaps()->Get(frameDataCell->map_id());
+        const float *part_uvs = nullptr;
+        if (local_uvs && (uintptr_t)p_idx * 10 + 10 <= local_uvs_len) {
+            part_uvs = local_uvs + (p_idx * 10);
+        }
 
-        uint32_t texHash = cellmap->name_hash();
-        if (!_textures.has(texHash)) continue;
-        Ref<Texture2D> tex = _textures[texHash];
-
-        auto cell = cellmap->cells()->LookupByKey(frameDataCell->name_hash());
-        if (!cell) continue;
-
-        _draw_part(rs, ci, frameData, part, partBinary, tex, cell, drawing_m);
+        _draw_part(rs, ci, frameData, part, partBinary, binary, drawing_m, part_uvs);
     }
 }
 
-void SpriteStudioPlayer2D::_draw_part(RenderingServer *rs, RID ci, const ss::runtime::FrameData *frameData, const ss::runtime::PartState *part, const ss::format::PartData *partBinary, const Ref<Texture2D> &tex, const ss::format::Cell *cell, const float *draw_m) {
-    // 1. Blend Mode
+void SpriteStudioPlayer2D::_draw_part(RenderingServer *rs, RID ci, const ss::runtime::FrameData *frameData, const ss::runtime::PartState *part, const ss::format::PartData *partBinary, const ss::format::SsAnimeBinary *binary, const float *draw_m, const float *part_uvs) {
+    switch (partBinary->part_type_type()) {
+        case ss::format::PartType_PartTypeNormal:
+            _draw_part_normal(rs, ci, frameData, part, partBinary, binary, draw_m, part_uvs);
+            return;
+
+        // No drawing role — matrix-only / skinning graph / host systems.
+        case ss::format::PartType_PartTypeNull:
+        case ss::format::PartType_PartTypeArmature:
+        case ss::format::PartType_PartTypeJoint:
+        case ss::format::PartType_PartTypeMovenode:
+        case ss::format::PartType_PartTypeConstraint:
+        case ss::format::PartType_PartTypeBonepoint:
+        case ss::format::PartType_PartTypeTransformConstraint:
+        case ss::format::PartType_PartTypeCamera:
+        case ss::format::PartType_PartTypeAudio:
+            return;
+
+        // TODO: not yet implemented in this player. Add a dedicated
+        // _draw_part_<type>() and dispatch here when each is built out.
+        case ss::format::PartType_PartTypeShape:
+        case ss::format::PartType_PartTypeText:
+        case ss::format::PartType_PartTypeNines:
+        case ss::format::PartType_PartTypeMesh:
+        case ss::format::PartType_PartTypeMask:
+            return;
+
+        // TODO: requires per-frame child Player synchronization
+        // (ss_util_calculate_instance_frame / ss_effect_update). The runtime
+        // exposes the APIs but this player does not yet wire them up.
+        case ss::format::PartType_PartTypeInstance:
+        case ss::format::PartType_PartTypeEffect:
+            return;
+
+        default:
+            return;
+    }
+}
+
+void SpriteStudioPlayer2D::_draw_part_normal(RenderingServer *rs, RID ci, const ss::runtime::FrameData *frameData, const ss::runtime::PartState *part, const ss::format::PartData *partBinary, const ss::format::SsAnimeBinary *binary, const float *draw_m, const float *part_uvs) {
+    // 1. Cell / texture lookup.
+    const auto frameDataCellIndex = part->cell();
+    if (frameDataCellIndex < 0) return;
+    auto frameDataCell = frameData->cells()->Get(frameDataCellIndex);
+    if (!frameDataCell) return;
+    auto cellmap = binary->cellmaps()->Get(frameDataCell->map_id());
+    if (!cellmap) return;
+    uint32_t texHash = cellmap->name_hash();
+    if (!_textures.has(texHash)) return;
+    Ref<Texture2D> tex = _textures[texHash];
+    auto cell = cellmap->cells()->LookupByKey(frameDataCell->name_hash());
+    if (!cell) return;
+
+    // 2. Blend Mode
     ss::format::BlendType ss_blend = partBinary->blend_type();
     if (!_blend_materials.has((int)ss_blend)) {
         Ref<CanvasItemMaterial> mat; mat.instantiate();
@@ -652,7 +674,7 @@ void SpriteStudioPlayer2D::_draw_part(RenderingServer *rs, RID ci, const ss::run
     }
     rs->canvas_item_set_material(ci, _blend_materials[(int)ss_blend]->get_rid());
 
-    // 2. Matrix Calculation (Hierarchy aware)
+    // 3. Vertex / UV / color preparation.
     uint64_t flags = part->update_flag();
     auto rect = cell->rectangle();
     auto pivot = cell->pivot();
@@ -661,27 +683,25 @@ void SpriteStudioPlayer2D::_draw_part(RenderingServer *rs, RID ci, const ss::run
     bool use_advanced = (flags & (ss::runtime::UpdateAttributeFlags_AttributeVertex | ss::runtime::UpdateAttributeFlags_AttributePartColor |
                                   ss::runtime::UpdateAttributeFlags_AttributeUvtX | ss::runtime::UpdateAttributeFlags_AttributeUvtY |
                                   ss::runtime::UpdateAttributeFlags_AttributeUvrZ | ss::runtime::UpdateAttributeFlags_AttributeUvsX |
-                                  ss::runtime::UpdateAttributeFlags_AttributeUvsY));
+                                  ss::runtime::UpdateAttributeFlags_AttributeUvsY |
+                                  ss::runtime::UpdateAttributeFlags_AttributeFlipH | ss::runtime::UpdateAttributeFlags_AttributeFlipV |
+                                  ss::runtime::UpdateAttributeFlags_AttributeImgFlipH | ss::runtime::UpdateAttributeFlags_AttributeImgFlipV |
+                                  ss::runtime::UpdateAttributeFlags_AttributeSizeX | ss::runtime::UpdateAttributeFlags_AttributeSizeY |
+                                  ss::runtime::UpdateAttributeFlags_AttributePivotX | ss::runtime::UpdateAttributeFlags_AttributePivotY));
 
-    if (!use_advanced && partBinary->part_type_type() != ss::format::PartType_PartTypeMesh) {
+    if (!use_advanced) {
         Transform2D t = matrix_to_transform2d(draw_m);
         rs->canvas_item_set_transform(ci, t);
 
         Vector2 draw_pos = Vector2(-src_rect.size.x * (pivot->v1() + 0.5f),
                                    -src_rect.size.y * (0.5f - pivot->v2()));
         rs->canvas_item_add_texture_rect_region(ci, Rect2(draw_pos, src_rect.size), tex->get_rid(), src_rect, Color(1, 1, 1, part->alpha()));
-    } else if (partBinary->part_type_type() != ss::format::PartType_PartTypeMesh) {
+    } else {
         rs->canvas_item_set_transform(ci, Transform2D());
 
-        // Use the 5-vertex triangle fan around the center only when needed
-        // (per-vertex deform or per-vertex parts color). Otherwise the cheaper
-        // 4-vertex 2-triangle quad is enough — center vertex is unused / zero
-        // in the FrameData for those parts.
         const bool needs_center = (flags & (ss::runtime::UpdateAttributeFlags_AttributeVertex | ss::runtime::UpdateAttributeFlags_AttributePartColor)) != 0;
         const int vert_count = needs_center ? MAX_VERTICES_COUNT : CORNERS_COUNT;
 
-        // Triangle fan around center vertex (LT=0, RT=1, LB=2, RB=3, Center=4).
-        // Constant per build, so initialize once via function-local static.
         #ifdef SPRITESTUDIO_GODOT_EXTENSION
         static const PackedInt32Array INDICES_FAN_5 = []() {
             PackedInt32Array a; a.resize(INDICES_COUNT_PENTAGON);
@@ -689,7 +709,7 @@ void SpriteStudioPlayer2D::_draw_part(RenderingServer *rs, RID ci, const ss::run
             for (int k = 0; k < INDICES_COUNT_PENTAGON; k++) a.set(k, idxs[k]);
             return a;
         }();
-        // 2-triangle quad split (LT-RT-LB and RT-RB-LB).
+
         static const PackedInt32Array INDICES_QUAD_4 = []() {
             PackedInt32Array a; a.resize(INDICES_COUNT_QUAD);
             const int idxs[INDICES_COUNT_QUAD] = { 0,1,2, 1,3,2 };
@@ -717,33 +737,21 @@ void SpriteStudioPlayer2D::_draw_part(RenderingServer *rs, RID ci, const ss::run
         Vector<Color> p_colors; p_colors.resize(vert_count);
         #endif
 
-        // Pre-computed local vertices come directly from the Brain; pivot, size,
-        // image-flip, and raw deform offsets are already applied. Center is only
-        // populated by the Brain when needs_center is true.
-        const ss::runtime::PartAttributeVertex* vd = frameData->vertices()->Get(part->vertex());
+        const auto vertexIndex = part->vertex();
+        if (vertexIndex < 0) return;
+        const ss::runtime::PartAttributeVertex* vd = frameData->vertices()->Get(vertexIndex);
         const float out_x[MAX_VERTICES_COUNT] = { vd->lt().x(), vd->rt().x(), vd->lb().x(), vd->rb().x(), vd->center().x() };
         const float out_y[MAX_VERTICES_COUNT] = { vd->lt().y(), vd->rt().y(), vd->lb().y(), vd->rb().y(), vd->center().y() };
 
-        float out_u[MAX_VERTICES_COUNT], out_v[MAX_VERTICES_COUNT];
-        SsUvComputeParams uv_params;
-        uv_params.src_rect = src_rect;
-        uv_params.uv_translation = Vector2(part->uv_translation_x(), part->uv_translation_y());
-        uv_params.uv_rotation_z = part->uv_rotation_z();
-        uv_params.uv_scale = Vector2(part->uv_scale_x(), part->uv_scale_y());
-        uv_params.part_flip_h = part->flip_h();
-        uv_params.part_flip_v = part->flip_v();
-        uv_params.img_flip_h = part->img_flip_h();
-        uv_params.img_flip_v = part->img_flip_v();
-        uv_params.rotated = cell->rotated();
-
-        if (!compute_uvs(uv_params, out_u, out_v)) {
-            return;
-        }
+        if (!part_uvs) return;
+        const float out_u[MAX_VERTICES_COUNT] = { part_uvs[0], part_uvs[2], part_uvs[4], part_uvs[6], part_uvs[8] };
+        const float out_v[MAX_VERTICES_COUNT] = { part_uvs[1], part_uvs[3], part_uvs[5], part_uvs[7], part_uvs[9] };
 
         Vector2 tex_size = tex->get_size();
         Color corner_colors[CORNERS_COUNT] = { Color(1, 1, 1, part->alpha()), Color(1, 1, 1, part->alpha()), Color(1, 1, 1, part->alpha()), Color(1, 1, 1, part->alpha()) };
-        if (flags & ss::runtime::UpdateAttributeFlags_AttributePartColor) {
-            auto pc = frameData->parts_color()->Get(part->part_color());
+        const auto partColorIndex = part->part_color();
+        if ((flags & ss::runtime::UpdateAttributeFlags_AttributePartColor) && partColorIndex >= 0) {
+            auto pc = frameData->parts_color()->Get(partColorIndex);
             // The hierarchical alpha is already pre-multiplied into c.rgba().a() by the Brain.
             auto to_color = [](const ss::runtime::SsAttributePartColorKeyValueColor &c) { return Color(c.rgba().r()/255.0f, c.rgba().g()/255.0f, c.rgba().b()/255.0f, c.rgba().a()/255.0f); };
             corner_colors[0] = to_color(pc->lt()); corner_colors[1] = to_color(pc->rt()); corner_colors[2] = to_color(pc->lb()); corner_colors[3] = to_color(pc->rb());

--- a/ss_player/ss_player_node_2d.cpp
+++ b/ss_player/ss_player_node_2d.cpp
@@ -559,6 +559,7 @@ void SpriteStudioPlayer2D::drawAnimation(float frame_no) {
     ss_runtime_get_local_uvs(runtime_ctx, &f.local_uvs, &f.local_uvs_len);
     ss_runtime_get_cell_meta(runtime_ctx, &f.cell_meta, &f.cell_meta_len);
     ss_runtime_get_cell_texture_hashes(runtime_ctx, &f.cell_texture_hashes, &f.cell_texture_hashes_len);
+    ss_runtime_get_local_vertices(runtime_ctx, &f.local_vertices, &f.local_vertices_len);
     ss_runtime_get_shape_vertices(runtime_ctx, &f.shape_vertices, &f.shape_vertices_len);
     ss_runtime_get_shape_vertex_box_coords(runtime_ctx, &f.shape_box_coords, &f.shape_box_coords_len);
     ss_runtime_get_shape_vertex_counts(runtime_ctx, &f.shape_vertex_counts, &f.shape_vertex_counts_len);
@@ -653,12 +654,16 @@ void SpriteStudioPlayer2D::_draw_part_normal(const DrawFrame &f, RID ci, int p_i
     if (f.local_uvs && (uintptr_t)p_idx * 10 + 10 <= f.local_uvs_len) {
         part_uvs = f.local_uvs + (p_idx * 10);
     }
+    const float *part_verts = nullptr;
+    if (f.local_vertices && (uintptr_t)p_idx * 10 + 10 <= f.local_vertices_len) {
+        part_verts = f.local_vertices + (p_idx * 10);
+    }
 
     // 1. Cell / texture lookup. The runtime exposes the owning cellmap's
     //    name_hash directly via `cell_texture_hashes`, so the player can
     //    skip walking `FrameData::cells` and `SsAnimeBinary::cellmaps` per
     //    frame; non-zero hash implies a resolvable cell.
-    if (!part_cell_meta) return;
+    if (!part_cell_meta || !part_verts) return;
     if (!f.cell_texture_hashes || (uintptr_t)p_idx >= f.cell_texture_hashes_len) return;
     const uint32_t texHash = f.cell_texture_hashes[p_idx];
     if (texHash == 0) return;
@@ -668,10 +673,11 @@ void SpriteStudioPlayer2D::_draw_part_normal(const DrawFrame &f, RID ci, int p_i
     // 2. Blend Mode
     _apply_blend_material(rs, ci, partBinary->blend_type());
 
-    // 3. Vertex / UV / color preparation.
+    // 3. Vertex / UV / color preparation. The runtime hands us pre-pivot,
+    //    pre-coord-system local vertices via `local_vertices` (5 verts:
+    //    lt, rt, lb, rb, center), so the player just multiplies them by
+    //    the world matrix.
     uint64_t flags = part->update_flag();
-    const float pivot_x_norm = part_cell_meta[0];
-    const float pivot_y_norm = part_cell_meta[1];
     Rect2 src_rect(part_cell_meta[4], part_cell_meta[5], part_cell_meta[2], part_cell_meta[3]);
 
     bool use_advanced = (flags & (ss::runtime::UpdateAttributeFlags_AttributeVertex | ss::runtime::UpdateAttributeFlags_AttributePartColor |
@@ -687,8 +693,7 @@ void SpriteStudioPlayer2D::_draw_part_normal(const DrawFrame &f, RID ci, int p_i
         Transform2D t = matrix_to_transform2d(draw_m);
         rs->canvas_item_set_transform(ci, t);
 
-        Vector2 draw_pos = Vector2(-src_rect.size.x * (pivot_x_norm + 0.5f),
-                                   -src_rect.size.y * (0.5f - pivot_y_norm));
+        Vector2 draw_pos(part_verts[0], part_verts[1]);
         rs->canvas_item_add_texture_rect_region(ci, Rect2(draw_pos, src_rect.size), tex->get_rid(), src_rect, Color(1, 1, 1, part->alpha()));
     } else {
         rs->canvas_item_set_transform(ci, Transform2D());
@@ -731,11 +736,8 @@ void SpriteStudioPlayer2D::_draw_part_normal(const DrawFrame &f, RID ci, int p_i
         Vector<Color> p_colors; p_colors.resize(vert_count);
         #endif
 
-        const auto vertexIndex = part->vertex();
-        if (vertexIndex < 0) return;
-        const ss::runtime::PartAttributeVertex* vd = f.frameData->vertices()->Get(vertexIndex);
-        const float out_x[MAX_VERTICES_COUNT] = { vd->lt().x(), vd->rt().x(), vd->lb().x(), vd->rb().x(), vd->center().x() };
-        const float out_y[MAX_VERTICES_COUNT] = { vd->lt().y(), vd->rt().y(), vd->lb().y(), vd->rb().y(), vd->center().y() };
+        const float out_x[MAX_VERTICES_COUNT] = { part_verts[0], part_verts[2], part_verts[4], part_verts[6], part_verts[8] };
+        const float out_y[MAX_VERTICES_COUNT] = { part_verts[1], part_verts[3], part_verts[5], part_verts[7], part_verts[9] };
 
         if (!part_uvs) return;
         const float out_u[MAX_VERTICES_COUNT] = { part_uvs[0], part_uvs[2], part_uvs[4], part_uvs[6], part_uvs[8] };

--- a/ss_player/ss_player_node_2d.cpp
+++ b/ss_player/ss_player_node_2d.cpp
@@ -551,33 +551,28 @@ void SpriteStudioPlayer2D::drawAnimation(float frame_no) {
     ss_runtime_get_frame_data(runtime_ctx, frame_no, &data, &len);
     if (!data) return;
 
-    const float *world_matrices = nullptr;
-    uintptr_t world_matrices_len = 0;
-    ss_runtime_get_world_matrices(runtime_ctx, &world_matrices, &world_matrices_len);
+    DrawFrame f = {};
+    f.rs = RenderingServer::get_singleton();
+    f.frameData = ss::runtime::GetFrameData(data);
+    f.binary = _ssabRes->get_ss_anime_binary();
+    ss_runtime_get_world_matrices(runtime_ctx, &f.world_matrices, &f.world_matrices_len);
+    ss_runtime_get_local_uvs(runtime_ctx, &f.local_uvs, &f.local_uvs_len);
+    ss_runtime_get_cell_meta(runtime_ctx, &f.cell_meta, &f.cell_meta_len);
+    ss_runtime_get_shape_vertices(runtime_ctx, &f.shape_vertices, &f.shape_vertices_len);
+    ss_runtime_get_shape_vertex_box_coords(runtime_ctx, &f.shape_box_coords, &f.shape_box_coords_len);
+    ss_runtime_get_shape_vertex_counts(runtime_ctx, &f.shape_vertex_counts, &f.shape_vertex_counts_len);
 
     const int32_t *z_order = nullptr;
     uintptr_t z_order_len = 0;
     ss_runtime_get_z_order(runtime_ctx, &z_order, &z_order_len);
 
-    const float *local_uvs = nullptr;
-    uintptr_t local_uvs_len = 0;
-    ss_runtime_get_local_uvs(runtime_ctx, &local_uvs, &local_uvs_len);
-
-    const float *cell_meta = nullptr;
-    uintptr_t cell_meta_len = 0;
-    ss_runtime_get_cell_meta(runtime_ctx, &cell_meta, &cell_meta_len);
-
-    auto frameData = ss::runtime::GetFrameData(data);
-    auto parts = frameData->parts();
+    auto parts = f.frameData->parts();
     if (!parts) return;
 
-    RenderingServer *rs = RenderingServer::get_singleton();
     // Clear all canvas items once per frame to ensure a clean state
     for (RID ci : _canvas_items) {
-        rs->canvas_item_clear(ci);
+        f.rs->canvas_item_clear(ci);
     }
-
-    auto binary = _ssabRes->get_ss_anime_binary();
 
     for (uint32_t i = 0; i < parts->size(); i++) {
         auto part = parts->Get(i);
@@ -587,38 +582,27 @@ void SpriteStudioPlayer2D::drawAnimation(float frame_no) {
         RID ci = _canvas_items[p_idx];
         // Use the Z-order rank provided by the runtime to strictly enforce the determined order
         if (z_order && (uintptr_t)p_idx < z_order_len) {
-            rs->canvas_item_set_z_index(ci, z_order[p_idx]);
+            f.rs->canvas_item_set_z_index(ci, z_order[p_idx]);
         }
 
         if (part->hide()) continue;
 
         const float *drawing_m = nullptr;
-        if (world_matrices && ((uintptr_t)p_idx * 16 < world_matrices_len)) {
-            drawing_m = world_matrices + (p_idx * 16);
+        if (f.world_matrices && ((uintptr_t)p_idx * 16 < f.world_matrices_len)) {
+            drawing_m = f.world_matrices + (p_idx * 16);
         } else {
             continue;
         }
 
-        auto partBinary = binary->parts()->Get(p_idx);
-
-        const float *part_uvs = nullptr;
-        if (local_uvs && (uintptr_t)p_idx * 10 + 10 <= local_uvs_len) {
-            part_uvs = local_uvs + (p_idx * 10);
-        }
-
-        const float *part_cell_meta = nullptr;
-        if (cell_meta && (uintptr_t)p_idx * 6 + 6 <= cell_meta_len) {
-            part_cell_meta = cell_meta + (p_idx * 6);
-        }
-
-        _draw_part(rs, ci, frameData, part, partBinary, binary, drawing_m, part_uvs, part_cell_meta);
+        auto partBinary = f.binary->parts()->Get(p_idx);
+        _draw_part(f, ci, p_idx, part, partBinary, drawing_m);
     }
 }
 
-void SpriteStudioPlayer2D::_draw_part(RenderingServer *rs, RID ci, const ss::runtime::FrameData *frameData, const ss::runtime::PartState *part, const ss::format::PartData *partBinary, const ss::format::SsAnimeBinary *binary, const float *draw_m, const float *part_uvs, const float *part_cell_meta) {
+void SpriteStudioPlayer2D::_draw_part(const DrawFrame &f, RID ci, int p_idx, const ss::runtime::PartState *part, const ss::format::PartData *partBinary, const float *draw_m) {
     switch (partBinary->part_type_type()) {
         case ss::format::PartType_PartTypeNormal:
-            _draw_part_normal(rs, ci, frameData, part, partBinary, binary, draw_m, part_uvs, part_cell_meta);
+            _draw_part_normal(f, ci, p_idx, part, partBinary, draw_m);
             return;
 
         // No drawing role — matrix-only / skinning graph / host systems.
@@ -633,9 +617,12 @@ void SpriteStudioPlayer2D::_draw_part(RenderingServer *rs, RID ci, const ss::run
         case ss::format::PartType_PartTypeAudio:
             return;
 
+        case ss::format::PartType_PartTypeShape:
+            _draw_part_shape(f, ci, p_idx, part, partBinary, draw_m);
+            return;
+
         // TODO: not yet implemented in this player. Add a dedicated
         // _draw_part_<type>() and dispatch here when each is built out.
-        case ss::format::PartType_PartTypeShape:
         case ss::format::PartType_PartTypeText:
         case ss::format::PartType_PartTypeNines:
         case ss::format::PartType_PartTypeMesh:
@@ -654,33 +641,32 @@ void SpriteStudioPlayer2D::_draw_part(RenderingServer *rs, RID ci, const ss::run
     }
 }
 
-void SpriteStudioPlayer2D::_draw_part_normal(RenderingServer *rs, RID ci, const ss::runtime::FrameData *frameData, const ss::runtime::PartState *part, const ss::format::PartData *partBinary, const ss::format::SsAnimeBinary *binary, const float *draw_m, const float *part_uvs, const float *part_cell_meta) {
+void SpriteStudioPlayer2D::_draw_part_normal(const DrawFrame &f, RID ci, int p_idx, const ss::runtime::PartState *part, const ss::format::PartData *partBinary, const float *draw_m) {
+    RenderingServer *rs = f.rs;
+
+    const float *part_cell_meta = nullptr;
+    if (f.cell_meta && (uintptr_t)p_idx * 6 + 6 <= f.cell_meta_len) {
+        part_cell_meta = f.cell_meta + (p_idx * 6);
+    }
+    const float *part_uvs = nullptr;
+    if (f.local_uvs && (uintptr_t)p_idx * 10 + 10 <= f.local_uvs_len) {
+        part_uvs = f.local_uvs + (p_idx * 10);
+    }
+
     // 1. Cell / texture lookup.
     const auto frameDataCellIndex = part->cell();
     if (frameDataCellIndex < 0) return;
     if (!part_cell_meta) return;
-    auto frameDataCell = frameData->cells()->Get(frameDataCellIndex);
+    auto frameDataCell = f.frameData->cells()->Get(frameDataCellIndex);
     if (!frameDataCell) return;
-    auto cellmap = binary->cellmaps()->Get(frameDataCell->map_id());
+    auto cellmap = f.binary->cellmaps()->Get(frameDataCell->map_id());
     if (!cellmap) return;
     uint32_t texHash = cellmap->name_hash();
     if (!_textures.has(texHash)) return;
     Ref<Texture2D> tex = _textures[texHash];
 
     // 2. Blend Mode
-    ss::format::BlendType ss_blend = partBinary->blend_type();
-    if (!_blend_materials.has((int)ss_blend)) {
-        Ref<CanvasItemMaterial> mat; mat.instantiate();
-        switch (ss_blend) {
-            case ss::format::BlendType_Mix: mat->set_blend_mode(CanvasItemMaterial::BLEND_MODE_MIX); break;
-            case ss::format::BlendType_Add: mat->set_blend_mode(CanvasItemMaterial::BLEND_MODE_ADD); break;
-            case ss::format::BlendType_Sub: mat->set_blend_mode(CanvasItemMaterial::BLEND_MODE_SUB); break;
-            case ss::format::BlendType_Mul: mat->set_blend_mode(CanvasItemMaterial::BLEND_MODE_MUL); break;
-            default: mat->set_blend_mode(CanvasItemMaterial::BLEND_MODE_MIX); break;
-        }
-        _blend_materials[(int)ss_blend] = mat;
-    }
-    rs->canvas_item_set_material(ci, _blend_materials[(int)ss_blend]->get_rid());
+    _apply_blend_material(rs, ci, partBinary->blend_type());
 
     // 3. Vertex / UV / color preparation.
     uint64_t flags = part->update_flag();
@@ -747,7 +733,7 @@ void SpriteStudioPlayer2D::_draw_part_normal(RenderingServer *rs, RID ci, const 
 
         const auto vertexIndex = part->vertex();
         if (vertexIndex < 0) return;
-        const ss::runtime::PartAttributeVertex* vd = frameData->vertices()->Get(vertexIndex);
+        const ss::runtime::PartAttributeVertex* vd = f.frameData->vertices()->Get(vertexIndex);
         const float out_x[MAX_VERTICES_COUNT] = { vd->lt().x(), vd->rt().x(), vd->lb().x(), vd->rb().x(), vd->center().x() };
         const float out_y[MAX_VERTICES_COUNT] = { vd->lt().y(), vd->rt().y(), vd->lb().y(), vd->rb().y(), vd->center().y() };
 
@@ -759,7 +745,7 @@ void SpriteStudioPlayer2D::_draw_part_normal(RenderingServer *rs, RID ci, const 
         Color corner_colors[CORNERS_COUNT] = { Color(1, 1, 1, part->alpha()), Color(1, 1, 1, part->alpha()), Color(1, 1, 1, part->alpha()), Color(1, 1, 1, part->alpha()) };
         const auto partColorIndex = part->part_color();
         if ((flags & ss::runtime::UpdateAttributeFlags_AttributePartColor) && partColorIndex >= 0) {
-            auto pc = frameData->parts_color()->Get(partColorIndex);
+            auto pc = f.frameData->parts_color()->Get(partColorIndex);
             // The hierarchical alpha is already pre-multiplied into c.rgba().a() by the Brain.
             auto to_color = [](const ss::runtime::SsAttributePartColorKeyValueColor &c) { return Color(c.rgba().r()/255.0f, c.rgba().g()/255.0f, c.rgba().b()/255.0f, c.rgba().a()/255.0f); };
             corner_colors[0] = to_color(pc->lt()); corner_colors[1] = to_color(pc->rt()); corner_colors[2] = to_color(pc->lb()); corner_colors[3] = to_color(pc->rb());
@@ -781,6 +767,97 @@ void SpriteStudioPlayer2D::_draw_part_normal(RenderingServer *rs, RID ci, const 
 
         rs->canvas_item_add_triangle_array(ci, needs_center ? INDICES_FAN_5 : INDICES_QUAD_4, p_verts, p_colors, p_uvs, {}, {}, tex->get_rid());
     }
+}
+
+void SpriteStudioPlayer2D::_apply_blend_material(RenderingServer *rs, RID ci, ss::format::BlendType ss_blend) {
+    if (!_blend_materials.has((int)ss_blend)) {
+        Ref<CanvasItemMaterial> mat; mat.instantiate();
+        switch (ss_blend) {
+            case ss::format::BlendType_Mix: mat->set_blend_mode(CanvasItemMaterial::BLEND_MODE_MIX); break;
+            case ss::format::BlendType_Add: mat->set_blend_mode(CanvasItemMaterial::BLEND_MODE_ADD); break;
+            case ss::format::BlendType_Sub: mat->set_blend_mode(CanvasItemMaterial::BLEND_MODE_SUB); break;
+            case ss::format::BlendType_Mul: mat->set_blend_mode(CanvasItemMaterial::BLEND_MODE_MUL); break;
+            default: mat->set_blend_mode(CanvasItemMaterial::BLEND_MODE_MIX); break;
+        }
+        _blend_materials[(int)ss_blend] = mat;
+    }
+    rs->canvas_item_set_material(ci, _blend_materials[(int)ss_blend]->get_rid());
+}
+
+void SpriteStudioPlayer2D::_draw_part_shape(const DrawFrame &f, RID ci, int p_idx, const ss::runtime::PartState *part, const ss::format::PartData *partBinary, const float *draw_m) {
+    RenderingServer *rs = f.rs;
+
+    const float *part_shape_verts = nullptr;
+    const float *part_shape_box_coords = nullptr;
+    int32_t part_shape_count = 0;
+    if (f.shape_vertices && (uintptr_t)p_idx * 24 + 24 <= f.shape_vertices_len) {
+        part_shape_verts = f.shape_vertices + (p_idx * 24);
+    }
+    if (f.shape_box_coords && (uintptr_t)p_idx * 24 + 24 <= f.shape_box_coords_len) {
+        part_shape_box_coords = f.shape_box_coords + (p_idx * 24);
+    }
+    if (f.shape_vertex_counts && (uintptr_t)p_idx < f.shape_vertex_counts_len) {
+        part_shape_count = f.shape_vertex_counts[p_idx];
+    }
+    if (!part_shape_verts || !part_shape_box_coords || part_shape_count < 3) return;
+
+    _apply_blend_material(rs, ci, partBinary->blend_type());
+
+    // Corner colors (LT, RT, LB, RB) for bilinear interpolation across the
+    // shape's bounding box. The runtime hands us pre-pivot, pre-coord-system
+    // box coordinates per vertex, so we just blend the corners by them.
+    const uint64_t flags = part->update_flag();
+    Color corner_colors[CORNERS_COUNT] = { Color(1, 1, 1, part->alpha()), Color(1, 1, 1, part->alpha()), Color(1, 1, 1, part->alpha()), Color(1, 1, 1, part->alpha()) };
+    const auto partColorIndex = part->part_color();
+    if ((flags & ss::runtime::UpdateAttributeFlags_AttributePartColor) && partColorIndex >= 0) {
+        auto pc = f.frameData->parts_color()->Get(partColorIndex);
+        auto to_color = [](const ss::runtime::SsAttributePartColorKeyValueColor &c) { return Color(c.rgba().r()/255.0f, c.rgba().g()/255.0f, c.rgba().b()/255.0f, c.rgba().a()/255.0f); };
+        corner_colors[0] = to_color(pc->lt()); corner_colors[1] = to_color(pc->rt()); corner_colors[2] = to_color(pc->lb()); corner_colors[3] = to_color(pc->rb());
+    }
+
+    Transform2D draw_transform = matrix_to_transform2d(draw_m);
+    rs->canvas_item_set_transform(ci, Transform2D());
+
+    #ifdef SPRITESTUDIO_GODOT_EXTENSION
+    PackedVector2Array p_verts; p_verts.resize(part_shape_count);
+    PackedColorArray  p_colors; p_colors.resize(part_shape_count);
+    PackedInt32Array  p_indices;
+    #else
+    Vector<Vector2> p_verts; p_verts.resize(part_shape_count);
+    Vector<Color>   p_colors; p_colors.resize(part_shape_count);
+    Vector<int>     p_indices;
+    #endif
+
+    for (int i = 0; i < part_shape_count; i++) {
+        const float vx = part_shape_verts[i * 2 + 0];
+        const float vy = part_shape_verts[i * 2 + 1];
+        const float fx = part_shape_box_coords[i * 2 + 0];
+        const float fy = part_shape_box_coords[i * 2 + 1];
+        const float wLT = (1.0f - fx) * (1.0f - fy);
+        const float wRT =          fx * (1.0f - fy);
+        const float wLB = (1.0f - fx) *          fy;
+        const float wRB =          fx *          fy;
+        p_colors.set(i, corner_colors[0] * wLT + corner_colors[1] * wRT + corner_colors[2] * wLB + corner_colors[3] * wRB);
+        p_verts.set(i, draw_transform.xform(Vector2(vx, vy)));
+    }
+
+    if (part_shape_count == 4) {
+        // Rectangle: vertex layout is [LT=0, RT=1, LB=2, RB=3].
+        const int idx[6] = { 0,1,2, 1,3,2 };
+        p_indices.resize(6);
+        for (int i = 0; i < 6; i++) p_indices.set(i, idx[i]);
+    } else {
+        // Triangle / Star / Arrow: TRIANGLE_FAN topology with vertex 0 as fan apex.
+        const int tri_count = part_shape_count - 2;
+        p_indices.resize(tri_count * 3);
+        for (int i = 0; i < tri_count; i++) {
+            p_indices.set(i*3 + 0, 0);
+            p_indices.set(i*3 + 1, i + 1);
+            p_indices.set(i*3 + 2, i + 2);
+        }
+    }
+
+    rs->canvas_item_add_triangle_array(ci, p_indices, p_verts, p_colors);
 }
 
 void SpriteStudioPlayer2D::fetchAnimation() {

--- a/ss_player/ss_player_node_2d.cpp
+++ b/ss_player/ss_player_node_2d.cpp
@@ -487,47 +487,10 @@ void SpriteStudioPlayer2D::loadTextures(const Ref<SSABResource>& ssabRes) {
 
 
 namespace {
-    struct SsVertexComputeParams {
-        Vector2 size;
-        Vector2 pivot;
-        bool flip_h = false;
-        bool flip_v = false;
-        bool has_deform = false;
-        Vector2 deform_lt, deform_rt, deform_lb, deform_rb;
-    };
-
     constexpr int CORNERS_COUNT = 4;
     constexpr int MAX_VERTICES_COUNT = 5;
     constexpr int INDICES_COUNT_PENTAGON = 12;
-
-    bool compute_vertices(const SsVertexComputeParams& params, float* out_x, float* out_y) {
-        float deform_x[4], deform_y[4];
-        const float *p_dx = nullptr, *p_dy = nullptr;
-        if (params.has_deform) {
-            deform_x[0] = params.deform_lt.x; deform_x[1] = params.deform_rt.x;
-            deform_x[2] = params.deform_lb.x; deform_x[3] = params.deform_rb.x;
-            deform_y[0] = -params.deform_lt.y; deform_y[1] = -params.deform_rt.y;
-            deform_y[2] = -params.deform_lb.y; deform_y[3] = -params.deform_rb.y;
-            p_dx = deform_x; p_dy = deform_y;
-        }
-
-        bool success = ss_vertex_compute_local(
-            params.size.x, params.size.y,
-            params.pivot.x, params.pivot.y,
-            0, 0, // pivot_offset
-            params.flip_h, params.flip_v,
-            p_dx, p_dy,
-            out_x, out_y
-        );
-
-        if (success) {
-            // Convert from Y-up (ssruntime) to Y-down (Godot)
-            for (int i = 0; i < MAX_VERTICES_COUNT; i++) {
-                out_y[i] = -out_y[i];
-            }
-        }
-        return success;
-    }
+    constexpr int INDICES_COUNT_QUAD = 6;
 
     struct SsUvComputeParams {
         Rect2 src_rect;
@@ -710,37 +673,56 @@ void SpriteStudioPlayer2D::_draw_part(RenderingServer *rs, RID ci, const ss::run
     } else if (partBinary->part_type_type() != ss::format::PartType_PartTypeMesh) {
         rs->canvas_item_set_transform(ci, Transform2D());
 
-        float out_x[MAX_VERTICES_COUNT], out_y[MAX_VERTICES_COUNT];
-        SsVertexComputeParams params;
-        params.size = src_rect.size;
-        params.pivot = Vector2(pivot->v1(), pivot->v2());
-        params.flip_h = part->flip_h();
-        params.flip_v = part->flip_v();
+        // Use the 5-vertex triangle fan around the center only when needed
+        // (per-vertex deform or per-vertex parts color). Otherwise the cheaper
+        // 4-vertex 2-triangle quad is enough — center vertex is unused / zero
+        // in the FrameData for those parts.
+        const bool needs_center = (flags & (ss::runtime::UpdateAttributeFlags_AttributeVertex | ss::runtime::UpdateAttributeFlags_AttributePartColor)) != 0;
+        const int vert_count = needs_center ? MAX_VERTICES_COUNT : CORNERS_COUNT;
 
-        if (flags & ss::runtime::UpdateAttributeFlags_AttributeVertex) {
-            auto vd = frameData->vertices()->Get(part->vertex());
-            params.has_deform = true;
-            params.deform_lt = Vector2(vd->lt().x(), vd->lt().y());
-            params.deform_rt = Vector2(vd->rt().x(), vd->rt().y());
-            params.deform_lb = Vector2(vd->lb().x(), vd->lb().y());
-            params.deform_rb = Vector2(vd->rb().x(), vd->rb().y());
-        }
-
-        if (!compute_vertices(params, out_x, out_y)) {
-            return;
-        }
-
+        // Triangle fan around center vertex (LT=0, RT=1, LB=2, RB=3, Center=4).
+        // Constant per build, so initialize once via function-local static.
         #ifdef SPRITESTUDIO_GODOT_EXTENSION
-        PackedVector2Array p_verts; p_verts.resize(MAX_VERTICES_COUNT);
-        PackedVector2Array p_uvs; p_uvs.resize(MAX_VERTICES_COUNT);
-        PackedColorArray p_colors; p_colors.resize(MAX_VERTICES_COUNT);
-        PackedInt32Array p_indices; p_indices.resize(INDICES_COUNT_PENTAGON);
+        static const PackedInt32Array INDICES_FAN_5 = []() {
+            PackedInt32Array a; a.resize(INDICES_COUNT_PENTAGON);
+            const int idxs[INDICES_COUNT_PENTAGON] = { 0,1,4, 1,3,4, 3,2,4, 2,0,4 };
+            for (int k = 0; k < INDICES_COUNT_PENTAGON; k++) a.set(k, idxs[k]);
+            return a;
+        }();
+        // 2-triangle quad split (LT-RT-LB and RT-RB-LB).
+        static const PackedInt32Array INDICES_QUAD_4 = []() {
+            PackedInt32Array a; a.resize(INDICES_COUNT_QUAD);
+            const int idxs[INDICES_COUNT_QUAD] = { 0,1,2, 1,3,2 };
+            for (int k = 0; k < INDICES_COUNT_QUAD; k++) a.set(k, idxs[k]);
+            return a;
+        }();
+        PackedVector2Array p_verts; p_verts.resize(vert_count);
+        PackedVector2Array p_uvs; p_uvs.resize(vert_count);
+        PackedColorArray p_colors; p_colors.resize(vert_count);
         #else
-        Vector<Vector2> p_verts; p_verts.resize(MAX_VERTICES_COUNT);
-        Vector<Vector2> p_uvs; p_uvs.resize(MAX_VERTICES_COUNT);
-        Vector<Color> p_colors; p_colors.resize(MAX_VERTICES_COUNT);
-        Vector<int> p_indices; p_indices.resize(INDICES_COUNT_PENTAGON);
+        static const Vector<int> INDICES_FAN_5 = []() {
+            Vector<int> a; a.resize(INDICES_COUNT_PENTAGON);
+            const int idxs[INDICES_COUNT_PENTAGON] = { 0,1,4, 1,3,4, 3,2,4, 2,0,4 };
+            for (int k = 0; k < INDICES_COUNT_PENTAGON; k++) a.set(k, idxs[k]);
+            return a;
+        }();
+        static const Vector<int> INDICES_QUAD_4 = []() {
+            Vector<int> a; a.resize(INDICES_COUNT_QUAD);
+            const int idxs[INDICES_COUNT_QUAD] = { 0,1,2, 1,3,2 };
+            for (int k = 0; k < INDICES_COUNT_QUAD; k++) a.set(k, idxs[k]);
+            return a;
+        }();
+        Vector<Vector2> p_verts; p_verts.resize(vert_count);
+        Vector<Vector2> p_uvs; p_uvs.resize(vert_count);
+        Vector<Color> p_colors; p_colors.resize(vert_count);
         #endif
+
+        // Pre-computed local vertices come directly from the Brain; pivot, size,
+        // image-flip, and raw deform offsets are already applied. Center is only
+        // populated by the Brain when needs_center is true.
+        const ss::runtime::PartAttributeVertex* vd = frameData->vertices()->Get(part->vertex());
+        const float out_x[MAX_VERTICES_COUNT] = { vd->lt().x(), vd->rt().x(), vd->lb().x(), vd->rb().x(), vd->center().x() };
+        const float out_y[MAX_VERTICES_COUNT] = { vd->lt().y(), vd->rt().y(), vd->lb().y(), vd->rb().y(), vd->center().y() };
 
         float out_u[MAX_VERTICES_COUNT], out_v[MAX_VERTICES_COUNT];
         SsUvComputeParams uv_params;
@@ -762,7 +744,8 @@ void SpriteStudioPlayer2D::_draw_part(RenderingServer *rs, RID ci, const ss::run
         Color corner_colors[CORNERS_COUNT] = { Color(1, 1, 1, part->alpha()), Color(1, 1, 1, part->alpha()), Color(1, 1, 1, part->alpha()), Color(1, 1, 1, part->alpha()) };
         if (flags & ss::runtime::UpdateAttributeFlags_AttributePartColor) {
             auto pc = frameData->parts_color()->Get(part->part_color());
-            auto to_color = [&](const ss::runtime::SsAttributePartColorKeyValueColor &c) { return Color(c.rgba().r()/255.0f, c.rgba().g()/255.0f, c.rgba().b()/255.0f, (c.rgba().a()/255.0f)*part->alpha()); };
+            // The hierarchical alpha is already pre-multiplied into c.rgba().a() by the Brain.
+            auto to_color = [](const ss::runtime::SsAttributePartColorKeyValueColor &c) { return Color(c.rgba().r()/255.0f, c.rgba().g()/255.0f, c.rgba().b()/255.0f, c.rgba().a()/255.0f); };
             corner_colors[0] = to_color(pc->lt()); corner_colors[1] = to_color(pc->rt()); corner_colors[2] = to_color(pc->lb()); corner_colors[3] = to_color(pc->rb());
         }
 
@@ -774,13 +757,13 @@ void SpriteStudioPlayer2D::_draw_part(RenderingServer *rs, RID ci, const ss::run
             p_colors.set(j, corner_colors[j]);
         }
 
-        p_verts.set(CORNERS_COUNT, draw_transform.xform(Vector2(out_x[CORNERS_COUNT], out_y[CORNERS_COUNT])));
-        p_uvs.set(CORNERS_COUNT, Vector2(out_u[CORNERS_COUNT] / tex_size.x, out_v[CORNERS_COUNT] / tex_size.y));
-        p_colors.set(CORNERS_COUNT, (corner_colors[0] + corner_colors[1] + corner_colors[2] + corner_colors[3]) * 0.25f);
-        int idxs[] = { 0,1,4, 1,3,4, 3,2,4, 2,0,4 };
-        for(int k=0; k<INDICES_COUNT_PENTAGON; k++) p_indices.set(k, idxs[k]);
+        if (needs_center) {
+            p_verts.set(CORNERS_COUNT, draw_transform.xform(Vector2(out_x[CORNERS_COUNT], out_y[CORNERS_COUNT])));
+            p_uvs.set(CORNERS_COUNT, Vector2(out_u[CORNERS_COUNT] / tex_size.x, out_v[CORNERS_COUNT] / tex_size.y));
+            p_colors.set(CORNERS_COUNT, (corner_colors[0] + corner_colors[1] + corner_colors[2] + corner_colors[3]) * 0.25f);
+        }
 
-        rs->canvas_item_add_triangle_array(ci, p_indices, p_verts, p_colors, p_uvs, {}, {}, tex->get_rid());
+        rs->canvas_item_add_triangle_array(ci, needs_center ? INDICES_FAN_5 : INDICES_QUAD_4, p_verts, p_colors, p_uvs, {}, {}, tex->get_rid());
     }
 }
 

--- a/ss_player/ss_player_node_2d.cpp
+++ b/ss_player/ss_player_node_2d.cpp
@@ -563,6 +563,10 @@ void SpriteStudioPlayer2D::drawAnimation(float frame_no) {
     uintptr_t local_uvs_len = 0;
     ss_runtime_get_local_uvs(runtime_ctx, &local_uvs, &local_uvs_len);
 
+    const float *cell_meta = nullptr;
+    uintptr_t cell_meta_len = 0;
+    ss_runtime_get_cell_meta(runtime_ctx, &cell_meta, &cell_meta_len);
+
     auto frameData = ss::runtime::GetFrameData(data);
     auto parts = frameData->parts();
     if (!parts) return;
@@ -602,14 +606,19 @@ void SpriteStudioPlayer2D::drawAnimation(float frame_no) {
             part_uvs = local_uvs + (p_idx * 10);
         }
 
-        _draw_part(rs, ci, frameData, part, partBinary, binary, drawing_m, part_uvs);
+        const float *part_cell_meta = nullptr;
+        if (cell_meta && (uintptr_t)p_idx * 6 + 6 <= cell_meta_len) {
+            part_cell_meta = cell_meta + (p_idx * 6);
+        }
+
+        _draw_part(rs, ci, frameData, part, partBinary, binary, drawing_m, part_uvs, part_cell_meta);
     }
 }
 
-void SpriteStudioPlayer2D::_draw_part(RenderingServer *rs, RID ci, const ss::runtime::FrameData *frameData, const ss::runtime::PartState *part, const ss::format::PartData *partBinary, const ss::format::SsAnimeBinary *binary, const float *draw_m, const float *part_uvs) {
+void SpriteStudioPlayer2D::_draw_part(RenderingServer *rs, RID ci, const ss::runtime::FrameData *frameData, const ss::runtime::PartState *part, const ss::format::PartData *partBinary, const ss::format::SsAnimeBinary *binary, const float *draw_m, const float *part_uvs, const float *part_cell_meta) {
     switch (partBinary->part_type_type()) {
         case ss::format::PartType_PartTypeNormal:
-            _draw_part_normal(rs, ci, frameData, part, partBinary, binary, draw_m, part_uvs);
+            _draw_part_normal(rs, ci, frameData, part, partBinary, binary, draw_m, part_uvs, part_cell_meta);
             return;
 
         // No drawing role — matrix-only / skinning graph / host systems.
@@ -645,10 +654,11 @@ void SpriteStudioPlayer2D::_draw_part(RenderingServer *rs, RID ci, const ss::run
     }
 }
 
-void SpriteStudioPlayer2D::_draw_part_normal(RenderingServer *rs, RID ci, const ss::runtime::FrameData *frameData, const ss::runtime::PartState *part, const ss::format::PartData *partBinary, const ss::format::SsAnimeBinary *binary, const float *draw_m, const float *part_uvs) {
+void SpriteStudioPlayer2D::_draw_part_normal(RenderingServer *rs, RID ci, const ss::runtime::FrameData *frameData, const ss::runtime::PartState *part, const ss::format::PartData *partBinary, const ss::format::SsAnimeBinary *binary, const float *draw_m, const float *part_uvs, const float *part_cell_meta) {
     // 1. Cell / texture lookup.
     const auto frameDataCellIndex = part->cell();
     if (frameDataCellIndex < 0) return;
+    if (!part_cell_meta) return;
     auto frameDataCell = frameData->cells()->Get(frameDataCellIndex);
     if (!frameDataCell) return;
     auto cellmap = binary->cellmaps()->Get(frameDataCell->map_id());
@@ -656,8 +666,6 @@ void SpriteStudioPlayer2D::_draw_part_normal(RenderingServer *rs, RID ci, const 
     uint32_t texHash = cellmap->name_hash();
     if (!_textures.has(texHash)) return;
     Ref<Texture2D> tex = _textures[texHash];
-    auto cell = cellmap->cells()->LookupByKey(frameDataCell->name_hash());
-    if (!cell) return;
 
     // 2. Blend Mode
     ss::format::BlendType ss_blend = partBinary->blend_type();
@@ -676,9 +684,9 @@ void SpriteStudioPlayer2D::_draw_part_normal(RenderingServer *rs, RID ci, const 
 
     // 3. Vertex / UV / color preparation.
     uint64_t flags = part->update_flag();
-    auto rect = cell->rectangle();
-    auto pivot = cell->pivot();
-    Rect2 src_rect(rect->x1(), rect->y1(), rect->x2(), rect->y2());
+    const float pivot_x_norm = part_cell_meta[0];
+    const float pivot_y_norm = part_cell_meta[1];
+    Rect2 src_rect(part_cell_meta[4], part_cell_meta[5], part_cell_meta[2], part_cell_meta[3]);
 
     bool use_advanced = (flags & (ss::runtime::UpdateAttributeFlags_AttributeVertex | ss::runtime::UpdateAttributeFlags_AttributePartColor |
                                   ss::runtime::UpdateAttributeFlags_AttributeUvtX | ss::runtime::UpdateAttributeFlags_AttributeUvtY |
@@ -693,8 +701,8 @@ void SpriteStudioPlayer2D::_draw_part_normal(RenderingServer *rs, RID ci, const 
         Transform2D t = matrix_to_transform2d(draw_m);
         rs->canvas_item_set_transform(ci, t);
 
-        Vector2 draw_pos = Vector2(-src_rect.size.x * (pivot->v1() + 0.5f),
-                                   -src_rect.size.y * (0.5f - pivot->v2()));
+        Vector2 draw_pos = Vector2(-src_rect.size.x * (pivot_x_norm + 0.5f),
+                                   -src_rect.size.y * (0.5f - pivot_y_norm));
         rs->canvas_item_add_texture_rect_region(ci, Rect2(draw_pos, src_rect.size), tex->get_rid(), src_rect, Color(1, 1, 1, part->alpha()));
     } else {
         rs->canvas_item_set_transform(ci, Transform2D());

--- a/ss_player/ss_player_node_2d.h
+++ b/ss_player/ss_player_node_2d.h
@@ -103,6 +103,7 @@ private:
         const float *local_uvs;              uintptr_t local_uvs_len;
         const float *cell_meta;              uintptr_t cell_meta_len;
         const uint32_t *cell_texture_hashes; uintptr_t cell_texture_hashes_len;
+        const float *local_vertices;         uintptr_t local_vertices_len;
         const float *shape_vertices;         uintptr_t shape_vertices_len;
         const float *shape_box_coords;       uintptr_t shape_box_coords_len;
         const int32_t *shape_vertex_counts;  uintptr_t shape_vertex_counts_len;

--- a/ss_player/ss_player_node_2d.h
+++ b/ss_player/ss_player_node_2d.h
@@ -54,7 +54,14 @@ public:
     void setSpeed( float p_speed );
     float getSpeed() const;
     void setFrame( float p_frame );
+    void setFrameRelative( float p_diff );
     float getFrame() const;
+
+    // Marks this Player as a child of an Instance part on its parent Player
+    // so it skips its own auto-update — the parent will drive it via
+    // setFrameRelative every frame. Defaults to false (root Players run
+    // their own playback).
+    void setInstanceChildMode( bool p_enabled );
 
     int getTotalFrames() const;
 
@@ -90,6 +97,19 @@ private:
     float previous_frame_no = -1.0f;
     float _speed_rate = 1.0f;
     bool _sub_frame_enabled = false;
+    bool _instance_child_mode = false;
+
+    // One Player per Instance part on this Player, indexed by part_index.
+    // Slots for non-Instance parts hold nullptr. The parent owns the
+    // children via Godot's node tree (added with add_child); cleared and
+    // rebuilt every fetchAnimation.
+    Vector<SpriteStudioPlayer2D*> _instance_players;
+    // Externally-referenced SSAB resources discovered through the parent's
+    // `external_instances` array. Auto-loaded from the parent's directory
+    // (libssconverter places one .ssab per ssae alongside each other) so a
+    // PartTypeInstance whose ref_anime lives in another file can still be
+    // resolved without the user wiring it manually.
+    Vector<Ref<SSABResource>> _external_ssabs;
 
     // Per-frame draw context: SoA pointers and frame-shared bindings fetched
     // once at the top of `drawAnimation`. Each `_draw_part_TYPE` extracts its
@@ -98,6 +118,10 @@ private:
         RenderingServer *rs;
         const ss::runtime::FrameData *frameData;
         const ss::format::SsAnimeBinary *binary;
+        // Parent's current frame, needed by _draw_part_instance to compute
+        // diff = (parent_frame - event_frame) * speed before driving the
+        // child Player via setFrameRelative.
+        float frame_no;
 
         const float *world_matrices;         uintptr_t world_matrices_len;
         const float *local_uvs;              uintptr_t local_uvs_len;
@@ -116,6 +140,21 @@ private:
     void _draw_part(const DrawFrame &f, RID ci, int p_idx, const ss::runtime::PartState *part, const ss::format::PartData *partBinary, const float *draw_m);
     void _draw_part_normal(const DrawFrame &f, RID ci, int p_idx, const ss::runtime::PartState *part, const ss::format::PartData *partBinary, const float *draw_m);
     void _draw_part_shape(const DrawFrame &f, RID ci, int p_idx, const ss::runtime::PartState *part, const ss::format::PartData *partBinary, const float *draw_m);
+    void _draw_part_instance(const DrawFrame &f, RID ci, int p_idx, const ss::runtime::PartState *part, const ss::format::PartData *partBinary, const float *draw_m);
+
+    // Setup / teardown of the per-Instance-part child Players. Called from
+    // fetchAnimation; results are stored in `_instance_players`.
+    void _setup_instance_players();
+    void _clear_instance_players();
+    // Auto-load every SSAB referenced by `_ssabRes->external_instances` from
+    // the same directory as the parent file. Cleared and rebuilt on every
+    // setSSABResource.
+    void _load_external_ssabs();
+    // Searches `_ssabRes` first, then `_external_ssabs`, for an animation
+    // whose `name_hash` matches. Sets `out_source` to the SSAB containing
+    // the match (null when not found). Returns the animation name as
+    // utf8 String (empty when not found).
+    String _resolve_animation_by_hash(uint32_t name_hash, Ref<SSABResource>& out_source) const;
     void _apply_blend_material(RenderingServer *rs, RID ci, ss::format::BlendType blend_type);
 
     void _reconfigure();

--- a/ss_player/ss_player_node_2d.h
+++ b/ss_player/ss_player_node_2d.h
@@ -95,8 +95,8 @@ private:
     void updateAnimation(float delta);
     void fetchAnimation();
     void drawAnimation(float frame_no);
-    void _draw_part(RenderingServer *rs, RID ci, const ss::runtime::FrameData *frameData, const ss::runtime::PartState *part, const ss::format::PartData *partBinary, const ss::format::SsAnimeBinary *binary, const float *draw_m, const float *part_uvs);
-    void _draw_part_normal(RenderingServer *rs, RID ci, const ss::runtime::FrameData *frameData, const ss::runtime::PartState *part, const ss::format::PartData *partBinary, const ss::format::SsAnimeBinary *binary, const float *draw_m, const float *part_uvs);
+    void _draw_part(RenderingServer *rs, RID ci, const ss::runtime::FrameData *frameData, const ss::runtime::PartState *part, const ss::format::PartData *partBinary, const ss::format::SsAnimeBinary *binary, const float *draw_m, const float *part_uvs, const float *part_cell_meta);
+    void _draw_part_normal(RenderingServer *rs, RID ci, const ss::runtime::FrameData *frameData, const ss::runtime::PartState *part, const ss::format::PartData *partBinary, const ss::format::SsAnimeBinary *binary, const float *draw_m, const float *part_uvs, const float *part_cell_meta);
 
     void _reconfigure();
     void _clear_canvas_items();

--- a/ss_player/ss_player_node_2d.h
+++ b/ss_player/ss_player_node_2d.h
@@ -99,12 +99,13 @@ private:
         const ss::runtime::FrameData *frameData;
         const ss::format::SsAnimeBinary *binary;
 
-        const float *world_matrices;        uintptr_t world_matrices_len;
-        const float *local_uvs;             uintptr_t local_uvs_len;
-        const float *cell_meta;             uintptr_t cell_meta_len;
-        const float *shape_vertices;        uintptr_t shape_vertices_len;
-        const float *shape_box_coords;      uintptr_t shape_box_coords_len;
-        const int32_t *shape_vertex_counts; uintptr_t shape_vertex_counts_len;
+        const float *world_matrices;         uintptr_t world_matrices_len;
+        const float *local_uvs;              uintptr_t local_uvs_len;
+        const float *cell_meta;              uintptr_t cell_meta_len;
+        const uint32_t *cell_texture_hashes; uintptr_t cell_texture_hashes_len;
+        const float *shape_vertices;         uintptr_t shape_vertices_len;
+        const float *shape_box_coords;       uintptr_t shape_box_coords_len;
+        const int32_t *shape_vertex_counts;  uintptr_t shape_vertex_counts_len;
     };
 
     void loadTextures(const Ref<SSABResource>& ssabRes);

--- a/ss_player/ss_player_node_2d.h
+++ b/ss_player/ss_player_node_2d.h
@@ -23,6 +23,7 @@ struct PartState;
 namespace format {
 struct PartData;
 struct Cell;
+struct SsAnimeBinary;
 }
 }
 
@@ -94,7 +95,8 @@ private:
     void updateAnimation(float delta);
     void fetchAnimation();
     void drawAnimation(float frame_no);
-    void _draw_part(RenderingServer *rs, RID ci, const ss::runtime::FrameData *frameData, const ss::runtime::PartState *part, const ss::format::PartData *partBinary, const Ref<Texture2D> &tex, const ss::format::Cell *cell, const float *draw_m);
+    void _draw_part(RenderingServer *rs, RID ci, const ss::runtime::FrameData *frameData, const ss::runtime::PartState *part, const ss::format::PartData *partBinary, const ss::format::SsAnimeBinary *binary, const float *draw_m, const float *part_uvs);
+    void _draw_part_normal(RenderingServer *rs, RID ci, const ss::runtime::FrameData *frameData, const ss::runtime::PartState *part, const ss::format::PartData *partBinary, const ss::format::SsAnimeBinary *binary, const float *draw_m, const float *part_uvs);
 
     void _reconfigure();
     void _clear_canvas_items();

--- a/ss_player/ss_player_node_2d.h
+++ b/ss_player/ss_player_node_2d.h
@@ -91,12 +91,30 @@ private:
     float _speed_rate = 1.0f;
     bool _sub_frame_enabled = false;
 
+    // Per-frame draw context: SoA pointers and frame-shared bindings fetched
+    // once at the top of `drawAnimation`. Each `_draw_part_TYPE` extracts its
+    // own per-part slice from this struct so dispatch arguments stay flat.
+    struct DrawFrame {
+        RenderingServer *rs;
+        const ss::runtime::FrameData *frameData;
+        const ss::format::SsAnimeBinary *binary;
+
+        const float *world_matrices;        uintptr_t world_matrices_len;
+        const float *local_uvs;             uintptr_t local_uvs_len;
+        const float *cell_meta;             uintptr_t cell_meta_len;
+        const float *shape_vertices;        uintptr_t shape_vertices_len;
+        const float *shape_box_coords;      uintptr_t shape_box_coords_len;
+        const int32_t *shape_vertex_counts; uintptr_t shape_vertex_counts_len;
+    };
+
     void loadTextures(const Ref<SSABResource>& ssabRes);
     void updateAnimation(float delta);
     void fetchAnimation();
     void drawAnimation(float frame_no);
-    void _draw_part(RenderingServer *rs, RID ci, const ss::runtime::FrameData *frameData, const ss::runtime::PartState *part, const ss::format::PartData *partBinary, const ss::format::SsAnimeBinary *binary, const float *draw_m, const float *part_uvs, const float *part_cell_meta);
-    void _draw_part_normal(RenderingServer *rs, RID ci, const ss::runtime::FrameData *frameData, const ss::runtime::PartState *part, const ss::format::PartData *partBinary, const ss::format::SsAnimeBinary *binary, const float *draw_m, const float *part_uvs, const float *part_cell_meta);
+    void _draw_part(const DrawFrame &f, RID ci, int p_idx, const ss::runtime::PartState *part, const ss::format::PartData *partBinary, const float *draw_m);
+    void _draw_part_normal(const DrawFrame &f, RID ci, int p_idx, const ss::runtime::PartState *part, const ss::format::PartData *partBinary, const float *draw_m);
+    void _draw_part_shape(const DrawFrame &f, RID ci, int p_idx, const ss::runtime::PartState *part, const ss::format::PartData *partBinary, const float *draw_m);
+    void _apply_blend_material(RenderingServer *rs, RID ci, ss::format::BlendType blend_type);
 
     void _reconfigure();
     void _clear_canvas_items();


### PR DESCRIPTION
- **feat: refactor vertex calculation to use pre-calculated internal vertices**
- **feat: align Player with SDKs pre-computed UVs and PartType dispatch**

ref
https://github.com/SpriteStudio/SpriteStudio7-SDK/pull/172
