### PR TITLE
feature/instance rework

### DIFF
--- a/ss_player/ss_internal_player.cpp
+++ b/ss_player/ss_internal_player.cpp
@@ -97,10 +97,10 @@ void SsInternalPlayer::setSSABResource(const Ref<SSABResource>& ssabRes) {
 
     // Resolve external instance dependencies before _setup_instance_players
     // (called from _fetchAnimation below) needs to find ref animations that
-    // live in sibling .ssab files.
-    if (!_instance_child_mode) {
-        _load_external_ssabs();
-    }
+    // live in sibling .ssab files. Done unconditionally so a nested instance
+    // child whose own SSAB references its own siblings can resolve them
+    // (Godot's ResourceLoader CACHE_MODE_REUSE keeps duplicate loads cheap).
+    _load_external_ssabs();
 
     _fetchAnimation();
 }
@@ -166,16 +166,7 @@ void SsInternalPlayer::setFrame(float p_frame) {
         float frame_no = ss_runtime_get_frame_no(runtime_ctx);
         float draw_frame = _sub_frame_enabled ? frame_no : floorf(frame_no);
         previous_frame_no = draw_frame;
-        _drawAnimation(draw_frame);
-    }
-}
-
-void SsInternalPlayer::setFrameRelative(float p_diff) {
-    if (runtime_ctx) {
-        ss_runtime_set_frame_relative(runtime_ctx, p_diff);
-        float frame_no = ss_runtime_get_frame_no(runtime_ctx);
-        float draw_frame = _sub_frame_enabled ? frame_no : floorf(frame_no);
-        previous_frame_no = draw_frame;
+        _advance_instance_children(draw_frame, 0.0f, false);
         _drawAnimation(draw_frame);
     }
 }
@@ -242,6 +233,7 @@ void SsInternalPlayer::setSubFrameEnabled(bool p_enabled) {
         float frame_no = ss_runtime_get_frame_no(runtime_ctx);
         float draw_frame = _sub_frame_enabled ? frame_no : floorf(frame_no);
         previous_frame_no = draw_frame;
+        _advance_instance_children(draw_frame, 0.0f, false);
         _drawAnimation(draw_frame);
     }
 }
@@ -312,15 +304,17 @@ namespace {
 }
 
 void SsInternalPlayer::update(float delta_seconds) {
-    // Instance-child players are advanced by the parent via setFrameRelative;
-    // they must not run their own controller tick.
+    // Instance-child players are driven by the parent's
+    // `_advance_instance_children`; they must not run their own controller
+    // tick (would race the parent's deterministic seek).
     if (_instance_child_mode) return;
     if (!ss_runtime_is_playing(runtime_ctx)) return;
 
     auto d = delta_seconds * 1000.0f;
     float frame_no = ss_runtime_update(runtime_ctx, d);
 
-    if (ss_runtime_is_looped(runtime_ctx)) {
+    const bool was_looped = ss_runtime_is_looped(runtime_ctx);
+    if (was_looped) {
         if (_event_sink) _event_sink->onAnimationLooped(_strAnimationSelected);
     }
     if (ss_runtime_is_end_frame_reached(runtime_ctx)) {
@@ -376,6 +370,7 @@ void SsInternalPlayer::update(float delta_seconds) {
     }
 
     previous_frame_no = draw_frame;
+    _advance_instance_children(draw_frame, delta_seconds, was_looped);
     _drawAnimation(draw_frame);
 }
 
@@ -444,8 +439,7 @@ void SsInternalPlayer::_drawAnimation(float frame_no) {
             const float* drawing_m = (f.world_matrices && (uintptr_t)p_idx * 16 < f.world_matrices_len)
                 ? f.world_matrices + (p_idx * 16) : nullptr;
             if (!drawing_m) continue;
-            auto partBinary = f.binary->parts()->Get(p_idx);
-            _draw_part_instance(f, ci, p_idx, part, partBinary, drawing_m);
+            _emit_instance_slot(f, ci, p_idx, drawing_m);
         }
         // DrawBatchKind_Effect / Mesh / Text / Nines / Mask: not yet implemented.
     }
@@ -543,13 +537,13 @@ void SsInternalPlayer::_load_external_ssabs() {
 }
 
 void SsInternalPlayer::_clear_instance_players() {
-    for (int i = 0; i < _instance_players.size(); i++) {
-        SsInternalPlayer* child = _instance_players[i];
+    for (uint32_t i = 0; i < _instance_children.size(); i++) {
+        SsInternalPlayer* child = _instance_children[i].player;
         if (child) {
             memdelete(child);
         }
     }
-    _instance_players.clear();
+    _instance_children.clear();
 }
 
 void SsInternalPlayer::_setup_instance_players() {
@@ -559,9 +553,9 @@ void SsInternalPlayer::_setup_instance_players() {
     if (!binary || !binary->parts()) return;
 
     auto parts = binary->parts();
-    _instance_players.resize(parts->size());
-    for (int i = 0; i < (int)parts->size(); i++) {
-        _instance_players.set(i, nullptr);
+    _instance_children.resize(parts->size());
+    for (uint32_t i = 0; i < parts->size(); i++) {
+        _instance_children[i] = InstanceChildState{};
     }
     for (int i = 0; i < (int)parts->size(); i++) {
         auto p = parts->Get(i);
@@ -585,74 +579,45 @@ void SsInternalPlayer::_setup_instance_players() {
         child->setSSABResource(source);
         child->setAnimation(anim_name);
         child->stop();
-        // Keep the child hidden by default; _draw_part_instance toggles it
-        // visible only when an EventInstance / InitialEvent triggers it.
+        // Keep the child hidden by default; _advance_instance_children flips
+        // it visible only once an EventInstance becomes active for the slot.
         child->setRootVisible(false);
         // Parenting under the slot's batch canvas_item is performed each
-        // frame in _draw_part_instance — batch CIs are recyclable so a
+        // frame in _emit_instance_slot — batch CIs are recyclable so a
         // setup-time parenting wouldn't survive batch-list shifts.
-        _instance_players.set(i, child);
+        InstanceChildState st;
+        st.player = child;
+        _instance_children[i] = st;
     }
 }
 
-void SsInternalPlayer::_draw_part_instance(const DrawFrame& f, RID ci, int p_idx, const ss::runtime::PartState* part, const ss::format::PartData* partBinary, const float* draw_m) {
-    if (p_idx < 0 || p_idx >= _instance_players.size()) return;
-    SsInternalPlayer* child = _instance_players[p_idx];
-    if (!child) return;
+namespace {
+    struct InstancePlaybackConfig {
+        int start_frame;
+        int end_frame;
+        int loops;
+        bool pingpong;
+        bool reverse;
+        float speed;
+    };
 
-    // Re-parent the child's root canvas_item under this Instance batch's CI
-    // every frame: the batch CI pool may shuffle as draw_batches changes
-    // ordering, so the slot CI for a given Instance part is not guaranteed
-    // to be the same RID across frames.
-    child->setParentCanvasItem(ci);
+    // Convert an EventInstance attribute into resolved playback parameters
+    // for the child. `active_attr` may be null — in which case we return the
+    // SS6 default-constructed `SsInstanceAttr` semantics (sstypes.h:1294):
+    // loopNum=1, full "_start".."_end" range, speed=1, no pingpong/reverse.
+    // This makes a slot with no EventInstance play through once and clamp at
+    // its end_frame (animedecode.cpp:1670 clamp behaviour), rather than loop.
+    InstancePlaybackConfig resolve_instance_playback(
+        const ss::format::PartAttributeInstance* active_attr,
+        const ss::format::AnimationData* child_anim,
+        int child_total_frames)
+    {
+        const int default_end = child_total_frames > 0 ? child_total_frames - 1 : 0;
+        InstancePlaybackConfig cfg{ 0, default_end, 1, false, false, 1.0f };
+        if (!active_attr) return cfg;
 
-    if (!_currentAnimationData) {
-        child->setRootVisible(false);
-        return;
-    }
-    int parent_frame_int = (int)f.frame_no;
-
-    const ss::format::PartAttributeInstance* active_attr = nullptr;
-    int active_event_frame = 0;
-    if (auto events = _currentAnimationData->events()) {
-        for (int i = (int)events->size() - 1; i >= 0; i--) {
-            auto epf = events->Get(i);
-            if (!epf) continue;
-            int frame_index = epf->frame_index();
-            if (frame_index > parent_frame_int) continue;
-            if (!epf->instances()) continue;
-            for (uint32_t j = 0; j < epf->instances()->size(); j++) {
-                auto ev = epf->instances()->Get(j);
-                if (!ev || ev->part_index() != (uint16_t)p_idx) continue;
-                active_attr = ev->value();
-                active_event_frame = frame_index;
-                break;
-            }
-            if (active_attr) break;
-        }
-    }
-    // Default playback config used when no EventInstance has fired yet for this
-    // slot. Matches the default-constructed `SsInstanceAttr` in SS6
-    // (sstypes.h:1294): loopNum=1, infinity=false, full "_start".."_end"
-    // range, speed=1, curKeyframe=0. This makes the instance play through
-    // once and clamp at end_frame (animedecode.cpp:1670 clamps `reftime` to
-    // `inst_scale - 1` once `nowloop >= loopNum`), rather than looping.
-    int child_total = child->getTotalFrames();
-    int default_end = child_total > 0 ? child_total - 1 : 0;
-
-    int start_frame = 0;
-    int end_frame = default_end;
-    int loops = 1;
-    bool pingpong = false;
-    bool reverse = false;
-    float speed = 1.0f;
-
-    if (active_attr) {
-        // The child has already resolved its selected animation in
-        // _fetchAnimation(); reuse that pointer instead of scanning the child's
-        // animations array by name. Labels are sorted by name_hash (ssab schema
-        // marks `Label.name_hash (key)`), so LookupByKey gives us O(log n).
-        const ss::format::AnimationData* child_anim = child->getCurrentAnimationData();
+        // Labels are sorted by name_hash (ssab schema marks
+        // `Label.name_hash (key)`), so LookupByKey gives us O(log n).
         auto resolve_label = [&](uint32_t label_hash, int fallback) -> int {
             if (label_hash == 0) return fallback;
             if (!child_anim || !child_anim->labels()) return fallback;
@@ -660,25 +625,165 @@ void SsInternalPlayer::_draw_part_instance(const DrawFrame& f, RID ci, int p_idx
             return lab ? lab->time() : fallback;
         };
 
-        start_frame = resolve_label(active_attr->start_label_hash(), 0) + active_attr->start_offset();
-        end_frame = resolve_label(active_attr->end_label_hash(), default_end) + active_attr->end_offset();
-        if (end_frame < start_frame) end_frame = start_frame;
+        cfg.start_frame = resolve_label(active_attr->start_label_hash(), 0) + active_attr->start_offset();
+        cfg.end_frame = resolve_label(active_attr->end_label_hash(), default_end) + active_attr->end_offset();
+        if (cfg.end_frame < cfg.start_frame) cfg.end_frame = cfg.start_frame;
 
-        loops = active_attr->loop_num();
-        pingpong = active_attr->pingpong();
-        reverse = active_attr->reverse();
-        speed = active_attr->speed();
+        cfg.loops = active_attr->loop_num();
+        cfg.pingpong = active_attr->pingpong();
+        cfg.reverse = active_attr->reverse();
+        cfg.speed = active_attr->speed();
+        return cfg;
+    }
+}
+
+void SsInternalPlayer::_advance_instance_children(float parent_frame_no, float delta_seconds, bool parent_looped) {
+    if (!_currentAnimationData) {
+        // No animation selected on the parent: keep all children hidden.
+        for (uint32_t i = 0; i < _instance_children.size(); i++) {
+            SsInternalPlayer* child = _instance_children[i].player;
+            if (child) child->setRootVisible(false);
+        }
+        return;
     }
 
-    child->setAnimationSection(start_frame, end_frame);
-    child->setLoop(loops);
-    child->setPlaybackDirection(reverse ? 1 : 0, pingpong ? 1 : 0);
+    // Re-arm transition detection on parent loop. The same EventInstance
+    // attribute pointer (and frame_index) triggers again on the next
+    // playthrough; without this reset the equality check below would treat
+    // the loop edge as a no-op and finite-loop independent children would
+    // stay frozen at their previous end_frame.
+    if (parent_looped) {
+        for (uint32_t i = 0; i < _instance_children.size(); i++) {
+            _instance_children[i].last_active_attr = nullptr;
+            _instance_children[i].last_active_event_frame = -1;
+            _instance_children[i].default_applied = false;
+        }
+    }
 
-    float diff = (f.frame_no - (float)active_event_frame) * speed;
-    Transform2D xf = matrix_to_transform2d(draw_m);
-    child->setRootTransform(xf);
-    child->setRootVisible(true);
-    child->setFrameRelative(diff);
+    auto events = _currentAnimationData->events();
+    const int parent_frame_int = (int)parent_frame_no;
+
+    for (uint32_t p_idx = 0; p_idx < _instance_children.size(); p_idx++) {
+        InstanceChildState& state = _instance_children[p_idx];
+        SsInternalPlayer* child = state.player;
+        if (!child) continue;
+
+        // Find the most recent EventInstance for this slot whose frame_index
+        // is <= the parent's current frame. Events list is in frame order;
+        // scan backward for early exit on the first match.
+        const ss::format::PartAttributeInstance* active_attr = nullptr;
+        int active_event_frame = 0;
+        if (events) {
+            for (int i = (int)events->size() - 1; i >= 0; i--) {
+                auto epf = events->Get(i);
+                if (!epf) continue;
+                int frame_index = epf->frame_index();
+                if (frame_index > parent_frame_int) continue;
+                if (!epf->instances()) continue;
+                for (uint32_t j = 0; j < epf->instances()->size(); j++) {
+                    auto ev = epf->instances()->Get(j);
+                    if (!ev || ev->part_index() != (uint16_t)p_idx) continue;
+                    active_attr = ev->value();
+                    active_event_frame = frame_index;
+                    break;
+                }
+                if (active_attr) break;
+            }
+        }
+
+        if (!active_attr) {
+            // No explicit EventInstance for this slot: SS6 implicit default
+            // (sstypes.h:1294 SsInstanceAttr) — synced from parent's frame 0,
+            // loops=1, full range, speed=1. Always visible from the start of
+            // the parent animation. Apply config once per "default era"; the
+            // parent_looped reset above re-applies on each loop so an
+            // already-finished default child plays again.
+            if (!state.default_applied) {
+                const int default_end = child->getTotalFrames() > 0 ? child->getTotalFrames() - 1 : 0;
+                child->setAnimationSection(0, default_end);
+                child->setLoop(1);
+                child->setPlaybackDirection(0, 0);
+                child->play();
+                state.default_applied = true;
+                state.last_active_attr = nullptr;
+                state.last_active_event_frame = 0;
+            }
+            child->setRootVisible(true);
+
+            // Synced advance with implicit event_frame=0 and speed=1.
+            ss_runtime_set_frame_relative(child->runtime_ctx, parent_frame_no);
+            const float child_frame_no = ss_runtime_get_frame_no(child->runtime_ctx);
+            const float child_draw_frame = child->_sub_frame_enabled ? child_frame_no : floorf(child_frame_no);
+            if (child->previous_frame_no != child_draw_frame) {
+                child->previous_frame_no = child_draw_frame;
+                child->_drawAnimation(child_draw_frame);
+            }
+            continue;
+        }
+
+        // Active EventInstance — the SS6 default no longer applies.
+        state.default_applied = false;
+
+        // Transition edge: a new EventInstance just took over this slot, or
+        // the parent looped (state was reset above).
+        const bool transitioned =
+            (active_attr != state.last_active_attr) ||
+            (active_event_frame != state.last_active_event_frame);
+
+        if (transitioned) {
+            const InstancePlaybackConfig cfg = resolve_instance_playback(
+                active_attr, child->getCurrentAnimationData(), child->getTotalFrames());
+            child->setAnimationSection(cfg.start_frame, cfg.end_frame);
+            child->setLoop(cfg.loops);
+            child->setPlaybackDirection(cfg.reverse ? 1 : 0, cfg.pingpong ? 1 : 0);
+            child->play();
+            state.last_active_attr = active_attr;
+            state.last_active_event_frame = active_event_frame;
+        }
+
+        child->setRootVisible(true);
+
+        // Branch on `independent`. Synced children are seeked deterministically
+        // from the parent's frame each tick — same `parent_frame_no` always
+        // yields the same `child_frame`. Independent children own their own
+        // controller time: forward `delta_seconds` to `ss_runtime_update` on
+        // tick callers, except on the transition tick itself where `play()`
+        // has already snapped the child to `start_frame` — advancing on the
+        // same tick would push it past start by one delta and visibly skip
+        // the first frame of the child's animation.
+        float child_frame_no;
+        if (active_attr->independent()) {
+            if (delta_seconds > 0.0f && !transitioned) {
+                const float d_ms = delta_seconds * 1000.0f * active_attr->speed();
+                child_frame_no = ss_runtime_update(child->runtime_ctx, d_ms);
+            } else {
+                child_frame_no = ss_runtime_get_frame_no(child->runtime_ctx);
+            }
+        } else {
+            const float speed = active_attr->speed();
+            const float diff = (parent_frame_no - (float)active_event_frame) * speed;
+            ss_runtime_set_frame_relative(child->runtime_ctx, diff);
+            child_frame_no = ss_runtime_get_frame_no(child->runtime_ctx);
+        }
+
+        const float child_draw_frame = child->_sub_frame_enabled ? child_frame_no : floorf(child_frame_no);
+        if (child->previous_frame_no != child_draw_frame) {
+            child->previous_frame_no = child_draw_frame;
+            child->_drawAnimation(child_draw_frame);
+        }
+    }
+}
+
+void SsInternalPlayer::_emit_instance_slot(const DrawFrame& /*f*/, RID ci, int p_idx, const float* slot_matrix) {
+    if (p_idx < 0 || (uint32_t)p_idx >= _instance_children.size()) return;
+    SsInternalPlayer* child = _instance_children[p_idx].player;
+    if (!child) return;
+
+    // Re-parent every frame: the batch CI pool can shuffle as draw_batches
+    // ordering changes, so the slot CI for a given Instance part is not
+    // guaranteed to be the same RID across frames.
+    child->setParentCanvasItem(ci);
+    child->setRootTransform(matrix_to_transform2d(slot_matrix));
 }
 
 int SsInternalPlayer::_build_normal(const DrawFrame& f, int p_idx,
@@ -964,15 +1069,16 @@ void SsInternalPlayer::_fetchAnimation() {
         return;
     }
 
-    // Skip when this player is itself an instance child to cap recursion at
-    // depth 1 — nested Instance parts are not yet supported and would
-    // self-reference / cycle through the same SSABResource.
-    if (!_instance_child_mode) {
-        _setup_instance_players();
-    }
+    // Recursive setup — instance children also populate their own
+    // `_instance_children`, so any depth of nested Instance parts is
+    // supported. Cross-SSAB cycles (A → B → A authoring mistakes) are not
+    // detected; they recurse until stack overflow on load. Trust the
+    // converter / authoring tool to keep references acyclic.
+    _setup_instance_players();
 
     float frame_no = ss_runtime_get_frame_no(runtime_ctx);
     float draw_frame = _sub_frame_enabled ? frame_no : floorf(frame_no);
     previous_frame_no = draw_frame;
+    _advance_instance_children(draw_frame, 0.0f, false);
     _drawAnimation(draw_frame);
 }

--- a/ss_player/ss_internal_player.cpp
+++ b/ss_player/ss_internal_player.cpp
@@ -25,7 +25,7 @@ SsInternalPlayer::SsInternalPlayer() {
 }
 
 SsInternalPlayer::~SsInternalPlayer() {
-    _clear_instance_players();
+    _clear_instance_children();
     _clear_batch_canvas_items();
 
     RenderingServer* rs = RenderingServer::get_singleton();
@@ -95,7 +95,7 @@ void SsInternalPlayer::setSSABResource(const Ref<SSABResource>& ssabRes) {
         }
     }
 
-    // Resolve external instance dependencies before _setup_instance_players
+    // Resolve external instance dependencies before _setup_instance_children
     // (called from _fetchAnimation below) needs to find ref animations that
     // live in sibling .ssab files. Done unconditionally so a nested instance
     // child whose own SSAB references its own siblings can resolve them
@@ -166,7 +166,7 @@ void SsInternalPlayer::setFrame(float p_frame) {
         float frame_no = ss_runtime_get_frame_no(runtime_ctx);
         float draw_frame = _sub_frame_enabled ? frame_no : floorf(frame_no);
         previous_frame_no = draw_frame;
-        _advance_instance_children(draw_frame, 0.0f, false);
+        _update_instance_children(draw_frame, 0.0f, false);
         _drawAnimation(draw_frame);
     }
 }
@@ -233,7 +233,7 @@ void SsInternalPlayer::setSubFrameEnabled(bool p_enabled) {
         float frame_no = ss_runtime_get_frame_no(runtime_ctx);
         float draw_frame = _sub_frame_enabled ? frame_no : floorf(frame_no);
         previous_frame_no = draw_frame;
-        _advance_instance_children(draw_frame, 0.0f, false);
+        _update_instance_children(draw_frame, 0.0f, false);
         _drawAnimation(draw_frame);
     }
 }
@@ -242,8 +242,8 @@ bool SsInternalPlayer::isSubFrameEnabled() const {
     return _sub_frame_enabled;
 }
 
-void SsInternalPlayer::setInstanceChildMode(bool p_enabled) {
-    _instance_child_mode = p_enabled;
+void SsInternalPlayer::setParentDriven(bool p_enabled) {
+    _parent_driven = p_enabled;
 }
 
 void SsInternalPlayer::setRootTransform(const Transform2D& p_xf) {
@@ -304,10 +304,10 @@ namespace {
 }
 
 void SsInternalPlayer::update(float delta_seconds) {
-    // Instance-child players are driven by the parent's
-    // `_advance_instance_children`; they must not run their own controller
+    // Parent-driven players are stepped by the parent's
+    // `_update_instance_children`; they must not run their own controller
     // tick (would race the parent's deterministic seek).
-    if (_instance_child_mode) return;
+    if (_parent_driven) return;
     if (!ss_runtime_is_playing(runtime_ctx)) return;
 
     auto d = delta_seconds * 1000.0f;
@@ -370,7 +370,7 @@ void SsInternalPlayer::update(float delta_seconds) {
     }
 
     previous_frame_no = draw_frame;
-    _advance_instance_children(draw_frame, delta_seconds, was_looped);
+    _update_instance_children(draw_frame, delta_seconds, was_looped);
     _drawAnimation(draw_frame);
 }
 
@@ -536,7 +536,7 @@ void SsInternalPlayer::_load_external_ssabs() {
     }
 }
 
-void SsInternalPlayer::_clear_instance_players() {
+void SsInternalPlayer::_clear_instance_children() {
     for (uint32_t i = 0; i < _instance_children.size(); i++) {
         SsInternalPlayer* child = _instance_children[i].player;
         if (child) {
@@ -546,8 +546,8 @@ void SsInternalPlayer::_clear_instance_players() {
     _instance_children.clear();
 }
 
-void SsInternalPlayer::_setup_instance_players() {
-    _clear_instance_players();
+void SsInternalPlayer::_setup_instance_children() {
+    _clear_instance_children();
     if (_ssabRes.is_null()) return;
     auto binary = _ssabRes->get_ss_anime_binary();
     if (!binary || !binary->parts()) return;
@@ -573,13 +573,13 @@ void SsInternalPlayer::_setup_instance_players() {
         }
 
         SsInternalPlayer* child = memnew(SsInternalPlayer);
-        child->setInstanceChildMode(true);
+        child->setParentDriven(true);
         // Hand the child the SSAB that actually contains the referenced
         // animation — may be `_ssabRes` itself or an external sibling.
         child->setSSABResource(source);
         child->setAnimation(anim_name);
         child->stop();
-        // Keep the child hidden by default; _advance_instance_children flips
+        // Keep the child hidden by default; _update_instance_children flips
         // it visible only once an EventInstance becomes active for the slot.
         child->setRootVisible(false);
         // Parenting under the slot's batch canvas_item is performed each
@@ -637,7 +637,7 @@ namespace {
     }
 }
 
-void SsInternalPlayer::_advance_instance_children(float parent_frame_no, float delta_seconds, bool parent_looped) {
+void SsInternalPlayer::_update_instance_children(float parent_frame_no, float delta_seconds, bool parent_looped) {
     if (!_currentAnimationData) {
         // No animation selected on the parent: keep all children hidden.
         for (uint32_t i = 0; i < _instance_children.size(); i++) {
@@ -649,9 +649,10 @@ void SsInternalPlayer::_advance_instance_children(float parent_frame_no, float d
 
     // Re-arm transition detection on parent loop. The same EventInstance
     // attribute pointer (and frame_index) triggers again on the next
-    // playthrough; without this reset the equality check below would treat
-    // the loop edge as a no-op and finite-loop independent children would
-    // stay frozen at their previous end_frame.
+    // playthrough; without this reset the equality check inside
+    // `_drive_active_instance_slot` would treat the loop edge as a no-op
+    // and finite-loop independent children would stay frozen at their
+    // previous end_frame.
     if (parent_looped) {
         for (uint32_t i = 0; i < _instance_children.size(); i++) {
             _instance_children[i].last_active_attr = nullptr;
@@ -660,118 +661,137 @@ void SsInternalPlayer::_advance_instance_children(float parent_frame_no, float d
         }
     }
 
-    auto events = _currentAnimationData->events();
     const int parent_frame_int = (int)parent_frame_no;
+    _build_active_instance_event_map(parent_frame_int);
 
     for (uint32_t p_idx = 0; p_idx < _instance_children.size(); p_idx++) {
         InstanceChildState& state = _instance_children[p_idx];
         SsInternalPlayer* child = state.player;
         if (!child) continue;
 
-        // Find the most recent EventInstance for this slot whose frame_index
-        // is <= the parent's current frame. Events list is in frame order;
-        // scan backward for early exit on the first match.
-        const ss::format::PartAttributeInstance* active_attr = nullptr;
-        int active_event_frame = 0;
-        if (events) {
-            for (int i = (int)events->size() - 1; i >= 0; i--) {
-                auto epf = events->Get(i);
-                if (!epf) continue;
-                int frame_index = epf->frame_index();
-                if (frame_index > parent_frame_int) continue;
-                if (!epf->instances()) continue;
-                for (uint32_t j = 0; j < epf->instances()->size(); j++) {
-                    auto ev = epf->instances()->Get(j);
-                    if (!ev || ev->part_index() != (uint16_t)p_idx) continue;
-                    active_attr = ev->value();
-                    active_event_frame = frame_index;
-                    break;
-                }
-                if (active_attr) break;
-            }
-        }
-
-        if (!active_attr) {
-            // No explicit EventInstance for this slot: SS6 implicit default
-            // (sstypes.h:1294 SsInstanceAttr) — synced from parent's frame 0,
-            // loops=1, full range, speed=1. Always visible from the start of
-            // the parent animation. Apply config once per "default era"; the
-            // parent_looped reset above re-applies on each loop so an
-            // already-finished default child plays again.
-            if (!state.default_applied) {
-                const int default_end = child->getTotalFrames() > 0 ? child->getTotalFrames() - 1 : 0;
-                child->setAnimationSection(0, default_end);
-                child->setLoop(1);
-                child->setPlaybackDirection(0, 0);
-                child->play();
-                state.default_applied = true;
-                state.last_active_attr = nullptr;
-                state.last_active_event_frame = 0;
-            }
-            child->setRootVisible(true);
-
-            // Synced advance with implicit event_frame=0 and speed=1.
-            ss_runtime_set_frame_relative(child->runtime_ctx, parent_frame_no);
-            const float child_frame_no = ss_runtime_get_frame_no(child->runtime_ctx);
-            const float child_draw_frame = child->_sub_frame_enabled ? child_frame_no : floorf(child_frame_no);
-            if (child->previous_frame_no != child_draw_frame) {
-                child->previous_frame_no = child_draw_frame;
-                child->_drawAnimation(child_draw_frame);
-            }
-            continue;
-        }
-
-        // Active EventInstance — the SS6 default no longer applies.
-        state.default_applied = false;
-
-        // Transition edge: a new EventInstance just took over this slot, or
-        // the parent looped (state was reset above).
-        const bool transitioned =
-            (active_attr != state.last_active_attr) ||
-            (active_event_frame != state.last_active_event_frame);
-
-        if (transitioned) {
-            const InstancePlaybackConfig cfg = resolve_instance_playback(
-                active_attr, child->getCurrentAnimationData(), child->getTotalFrames());
-            child->setAnimationSection(cfg.start_frame, cfg.end_frame);
-            child->setLoop(cfg.loops);
-            child->setPlaybackDirection(cfg.reverse ? 1 : 0, cfg.pingpong ? 1 : 0);
-            child->play();
-            state.last_active_attr = active_attr;
-            state.last_active_event_frame = active_event_frame;
-        }
-
-        child->setRootVisible(true);
-
-        // Branch on `independent`. Synced children are seeked deterministically
-        // from the parent's frame each tick — same `parent_frame_no` always
-        // yields the same `child_frame`. Independent children own their own
-        // controller time: forward `delta_seconds` to `ss_runtime_update` on
-        // tick callers, except on the transition tick itself where `play()`
-        // has already snapped the child to `start_frame` — advancing on the
-        // same tick would push it past start by one delta and visibly skip
-        // the first frame of the child's animation.
-        float child_frame_no;
-        if (active_attr->independent()) {
-            if (delta_seconds > 0.0f && !transitioned) {
-                const float d_ms = delta_seconds * 1000.0f * active_attr->speed();
-                child_frame_no = ss_runtime_update(child->runtime_ctx, d_ms);
-            } else {
-                child_frame_no = ss_runtime_get_frame_no(child->runtime_ctx);
-            }
+        const ActiveInstanceEvent& active = _active_instance_events[p_idx];
+        if (!active.attr) {
+            _drive_default_instance_slot(state, child, parent_frame_no);
         } else {
-            const float speed = active_attr->speed();
-            const float diff = (parent_frame_no - (float)active_event_frame) * speed;
-            ss_runtime_set_frame_relative(child->runtime_ctx, diff);
-            child_frame_no = ss_runtime_get_frame_no(child->runtime_ctx);
-        }
-
-        const float child_draw_frame = child->_sub_frame_enabled ? child_frame_no : floorf(child_frame_no);
-        if (child->previous_frame_no != child_draw_frame) {
-            child->previous_frame_no = child_draw_frame;
-            child->_drawAnimation(child_draw_frame);
+            _drive_active_instance_slot(state, child, active.attr, active.event_frame,
+                                        parent_frame_no, delta_seconds);
         }
     }
+}
+
+void SsInternalPlayer::_build_active_instance_event_map(int parent_frame_int) {
+    const uint32_t slot_count = _instance_children.size();
+    _active_instance_events.resize(slot_count);
+    for (uint32_t i = 0; i < slot_count; i++) {
+        _active_instance_events[i] = ActiveInstanceEvent{};
+    }
+    if (!_currentAnimationData) return;
+    auto events = _currentAnimationData->events();
+    if (!events) return;
+
+    // Forward scan; events are sorted by frame_index, so we can stop once
+    // an event exceeds the parent's frame. Later events override earlier
+    // ones, leaving each slot pointing at its most-recent EventInstance.
+    for (uint32_t i = 0; i < events->size(); i++) {
+        auto epf = events->Get(i);
+        if (!epf) continue;
+        const int frame_index = epf->frame_index();
+        if (frame_index > parent_frame_int) break;
+        if (!epf->instances()) continue;
+        for (uint32_t j = 0; j < epf->instances()->size(); j++) {
+            auto ev = epf->instances()->Get(j);
+            if (!ev) continue;
+            const uint32_t p_idx = ev->part_index();
+            if (p_idx >= slot_count) continue;
+            _active_instance_events[p_idx].attr = ev->value();
+            _active_instance_events[p_idx].event_frame = frame_index;
+        }
+    }
+}
+
+void SsInternalPlayer::_drive_default_instance_slot(InstanceChildState& state,
+                                                    SsInternalPlayer* child,
+                                                    float parent_frame_no) {
+    // SS6 implicit default (sstypes.h:1294 SsInstanceAttr): synced from
+    // parent's frame 0, loops=1, full range, speed=1. Always visible.
+    // Apply config once per "default era"; `parent_looped` resets the flag
+    // so an already-finished default child plays again on the next cycle.
+    if (!state.default_applied) {
+        const int default_end = child->getTotalFrames() > 0 ? child->getTotalFrames() - 1 : 0;
+        child->setAnimationSection(0, default_end);
+        child->setLoop(1);
+        child->setPlaybackDirection(0, 0);
+        child->play();
+        state.default_applied = true;
+        state.last_active_attr = nullptr;
+        state.last_active_event_frame = 0;
+    }
+    child->setRootVisible(true);
+
+    // Synced step with implicit event_frame=0 and speed=1.
+    ss_runtime_set_frame_relative(child->runtime_ctx, parent_frame_no);
+    const float child_frame_no = ss_runtime_get_frame_no(child->runtime_ctx);
+    _redraw_child_if_frame_changed(child, child_frame_no);
+}
+
+void SsInternalPlayer::_drive_active_instance_slot(InstanceChildState& state,
+                                                   SsInternalPlayer* child,
+                                                   const ss::format::PartAttributeInstance* active_attr,
+                                                   int active_event_frame,
+                                                   float parent_frame_no,
+                                                   float delta_seconds) {
+    // The SS6 default no longer applies once an EventInstance is active.
+    state.default_applied = false;
+
+    // Transition edge: a new EventInstance just took over this slot, or
+    // the parent looped (state was reset by the caller).
+    const bool transitioned =
+        (active_attr != state.last_active_attr) ||
+        (active_event_frame != state.last_active_event_frame);
+
+    if (transitioned) {
+        const InstancePlaybackConfig cfg = resolve_instance_playback(
+            active_attr, child->getCurrentAnimationData(), child->getTotalFrames());
+        child->setAnimationSection(cfg.start_frame, cfg.end_frame);
+        child->setLoop(cfg.loops);
+        child->setPlaybackDirection(cfg.reverse ? 1 : 0, cfg.pingpong ? 1 : 0);
+        child->play();
+        state.last_active_attr = active_attr;
+        state.last_active_event_frame = active_event_frame;
+    }
+
+    child->setRootVisible(true);
+
+    // Branch on `independent`. Synced children are seeked deterministically
+    // from the parent's frame each tick — same `parent_frame_no` always
+    // yields the same `child_frame`. Independent children own their own
+    // controller time: forward `delta_seconds` to `ss_runtime_update` on
+    // tick callers, except on the transition tick itself where `play()` has
+    // already snapped the child to `start_frame` — stepping on the same tick
+    // would push it past start by one delta and visibly skip the first
+    // frame of the child's animation.
+    float child_frame_no;
+    if (active_attr->independent()) {
+        if (delta_seconds > 0.0f && !transitioned) {
+            const float d_ms = delta_seconds * 1000.0f * active_attr->speed();
+            child_frame_no = ss_runtime_update(child->runtime_ctx, d_ms);
+        } else {
+            child_frame_no = ss_runtime_get_frame_no(child->runtime_ctx);
+        }
+    } else {
+        const float diff = (parent_frame_no - (float)active_event_frame) * active_attr->speed();
+        ss_runtime_set_frame_relative(child->runtime_ctx, diff);
+        child_frame_no = ss_runtime_get_frame_no(child->runtime_ctx);
+    }
+
+    _redraw_child_if_frame_changed(child, child_frame_no);
+}
+
+void SsInternalPlayer::_redraw_child_if_frame_changed(SsInternalPlayer* child, float frame_no) {
+    const float draw_frame = child->_sub_frame_enabled ? frame_no : floorf(frame_no);
+    if (child->previous_frame_no == draw_frame) return;
+    child->previous_frame_no = draw_frame;
+    child->_drawAnimation(draw_frame);
 }
 
 void SsInternalPlayer::_emit_instance_slot(const DrawFrame& /*f*/, RID ci, int p_idx, const float* slot_matrix) {
@@ -1028,12 +1048,12 @@ void SsInternalPlayer::_fetchAnimation() {
         // `_batch_canvas_items` per-frame, so freeing those first would
         // leave the children with a dangling parent RID until their own
         // dtor runs.
-        _clear_instance_players();
+        _clear_instance_children();
         _clear_batch_canvas_items();
         return;
     }
 
-    _clear_instance_players();
+    _clear_instance_children();
     _clear_batch_canvas_items();
 
     if (runtime_res != nullptr) {
@@ -1074,11 +1094,11 @@ void SsInternalPlayer::_fetchAnimation() {
     // supported. Cross-SSAB cycles (A → B → A authoring mistakes) are not
     // detected; they recurse until stack overflow on load. Trust the
     // converter / authoring tool to keep references acyclic.
-    _setup_instance_players();
+    _setup_instance_children();
 
     float frame_no = ss_runtime_get_frame_no(runtime_ctx);
     float draw_frame = _sub_frame_enabled ? frame_no : floorf(frame_no);
     previous_frame_no = draw_frame;
-    _advance_instance_children(draw_frame, 0.0f, false);
+    _update_instance_children(draw_frame, 0.0f, false);
     _drawAnimation(draw_frame);
 }

--- a/ss_player/ss_internal_player.cpp
+++ b/ss_player/ss_internal_player.cpp
@@ -163,11 +163,7 @@ float SsInternalPlayer::getSpeed() const {
 void SsInternalPlayer::setFrame(float p_frame) {
     if (runtime_ctx) {
         ss_runtime_set_frame_no(runtime_ctx, p_frame);
-        float frame_no = ss_runtime_get_frame_no(runtime_ctx);
-        float draw_frame = _sub_frame_enabled ? frame_no : floorf(frame_no);
-        previous_frame_no = draw_frame;
-        _update_instance_children(draw_frame, 0.0f, false);
-        _drawAnimation(draw_frame);
+        _seek_and_redraw(ss_runtime_get_frame_no(runtime_ctx), 0.0f, false);
     }
 }
 
@@ -230,11 +226,7 @@ bool SsInternalPlayer::isSkipFrames() const {
 void SsInternalPlayer::setSubFrameEnabled(bool p_enabled) {
     _sub_frame_enabled = p_enabled;
     if (runtime_ctx) {
-        float frame_no = ss_runtime_get_frame_no(runtime_ctx);
-        float draw_frame = _sub_frame_enabled ? frame_no : floorf(frame_no);
-        previous_frame_no = draw_frame;
-        _update_instance_children(draw_frame, 0.0f, false);
-        _drawAnimation(draw_frame);
+        _seek_and_redraw(ss_runtime_get_frame_no(runtime_ctx), 0.0f, false);
     }
 }
 
@@ -369,9 +361,7 @@ void SsInternalPlayer::update(float delta_seconds) {
         }
     }
 
-    previous_frame_no = draw_frame;
-    _update_instance_children(draw_frame, delta_seconds, was_looped);
-    _drawAnimation(draw_frame);
+    _seek_and_redraw(frame_no, delta_seconds, was_looped);
 }
 
 void SsInternalPlayer::_drawAnimation(float frame_no) {
@@ -794,6 +784,13 @@ void SsInternalPlayer::_redraw_child_if_frame_changed(SsInternalPlayer* child, f
     child->_drawAnimation(draw_frame);
 }
 
+void SsInternalPlayer::_seek_and_redraw(float frame_no, float delta_seconds, bool parent_looped) {
+    const float draw_frame = _sub_frame_enabled ? frame_no : floorf(frame_no);
+    previous_frame_no = draw_frame;
+    _update_instance_children(draw_frame, delta_seconds, parent_looped);
+    _drawAnimation(draw_frame);
+}
+
 void SsInternalPlayer::_emit_instance_slot(const DrawFrame& /*f*/, RID ci, int p_idx, const float* slot_matrix) {
     if (p_idx < 0 || (uint32_t)p_idx >= _instance_children.size()) return;
     SsInternalPlayer* child = _instance_children[p_idx].player;
@@ -1096,9 +1093,5 @@ void SsInternalPlayer::_fetchAnimation() {
     // converter / authoring tool to keep references acyclic.
     _setup_instance_children();
 
-    float frame_no = ss_runtime_get_frame_no(runtime_ctx);
-    float draw_frame = _sub_frame_enabled ? frame_no : floorf(frame_no);
-    previous_frame_no = draw_frame;
-    _update_instance_children(draw_frame, 0.0f, false);
-    _drawAnimation(draw_frame);
+    _seek_and_redraw(ss_runtime_get_frame_no(runtime_ctx), 0.0f, false);
 }

--- a/ss_player/ss_internal_player.h
+++ b/ss_player/ss_internal_player.h
@@ -38,6 +38,7 @@ namespace format {
 struct PartData;
 struct SsAnimeBinary;
 struct AnimationData;
+struct PartAttributeInstance;
 }
 }
 
@@ -104,7 +105,6 @@ public:
     float getSpeed() const;
 
     void setFrame(float p_frame);
-    void setFrameRelative(float p_diff);
     float getFrame() const;
 
     int getTotalFrames() const;
@@ -134,9 +134,10 @@ public:
     bool isSubFrameEnabled() const;
 
     // Marks this player as parent-driven — its own per-tick `update` is a
-    // no-op (the parent calls `setFrameRelative` every frame). Also disables
-    // recursive instance setup so a misauthored cycle in the SSAB doesn't
-    // self-reference. Defaults to false.
+    // no-op (the parent's `_advance_instance_children` seeks the child's
+    // frame deterministically each tick). Also disables recursive instance
+    // setup so a misauthored cycle in the SSAB doesn't self-reference.
+    // Defaults to false.
     void setInstanceChildMode(bool p_enabled);
     bool isInstanceChildMode() const { return _instance_child_mode; }
 
@@ -189,10 +190,25 @@ private:
 
     SsPlayerEventSink* _event_sink = nullptr;
 
-    // One child SsInternalPlayer per Instance part of this player's
-    // animation, indexed by part_index. Slots for non-Instance parts hold
-    // nullptr. Owned: each pointer is `memdelete`d in `_clear_instance_players`.
-    Vector<SsInternalPlayer*> _instance_players;
+    // Per-Instance-part state: child player + transition tracking. Indexed by
+    // part_index; non-Instance slots hold a default-constructed entry with
+    // `player == nullptr`. `last_active_attr` is the most recently triggered
+    // EventInstance attribute pointer — pointer comparison detects when the
+    // active EventInstance changes mid-playback so we re-apply playback config
+    // and restart the child only on the transition edge, not every frame.
+    struct InstanceChildState {
+        SsInternalPlayer* player = nullptr;
+        const ss::format::PartAttributeInstance* last_active_attr = nullptr;
+        int last_active_event_frame = -1;
+        // True after the SS6-implicit default playback config has been
+        // applied to the child for a slot that has no explicit EventInstance
+        // (sstypes.h:1294 SsInstanceAttr default: synced from frame 0,
+        // loops=1, full range, speed=1). Cleared the moment an EventInstance
+        // becomes active or the parent loops, so the next "no active attr"
+        // tick re-applies and re-`play()`s the child.
+        bool default_applied = false;
+    };
+    LocalVector<InstanceChildState> _instance_children;
     // External SSAB resources auto-loaded from the parent's directory based
     // on `external_instances`. Cleared and rebuilt on every setSSABResource.
     Vector<Ref<SSABResource>> _external_ssabs;
@@ -231,7 +247,12 @@ private:
     // Per-part-type emit. Normal is consumed by `_emit_normal_batch` directly
     // through the geometry helper, so no `_draw_part_normal` exists.
     void _draw_part_shape(const DrawFrame& f, RID ci, int p_idx, const ss::runtime::PartState* part, const ss::format::PartData* partBinary, const float* draw_m);
-    void _draw_part_instance(const DrawFrame& f, RID ci, int p_idx, const ss::runtime::PartState* part, const ss::format::PartData* partBinary, const float* draw_m);
+    // Instance slot emit: re-parent the child's _root_ci under this slot's
+    // batch CI and apply the slot's world matrix as the child's root
+    // transform. The child's own draw + simulation already happened earlier
+    // in `_advance_instance_children` (sim phase), so this is positioning
+    // only — no event scanning, no playback config, no frame advance.
+    void _emit_instance_slot(const DrawFrame& f, RID ci, int p_idx, const float* slot_matrix);
 
     int _build_normal(const DrawFrame& f, int p_idx,
                       const ss::runtime::PartState* part,
@@ -261,6 +282,29 @@ private:
 
     void _setup_instance_players();
     void _clear_instance_players();
+    // Per-tick instance child driver. Runs in the sim phase (called from
+    // `update`), before `_drawAnimation`. For each Instance part it scans the
+    // current animation's events for the most recent EventInstance whose
+    // frame_index <= parent_frame_no, detects transitions against the
+    // tracked `last_active_attr`, applies playback config + `play()` only on
+    // the transition edge, then advances the child to its target frame and
+    // triggers the child's own `_drawAnimation`. `_emit_instance_slot` later
+    // only positions the already-drawn child under the slot's batch CI.
+    //
+    // `delta_seconds` is the wall-clock tick this update represents and is
+    // forwarded to children whose EventInstance has `independent = true`
+    // (those children run their own controller via `ss_runtime_update`
+    // rather than being seeked deterministically from `parent_frame_no`).
+    // Pass 0 from non-tick callers (`setFrame`, `setSubFrameEnabled`,
+    // `_fetchAnimation`) — synced children still update via parent-frame
+    // seek; independent children stay where they are.
+    //
+    // `parent_looped` re-arms transition detection. When the parent's
+    // controller wraps (`ss_runtime_is_looped` true) the same EventInstance
+    // pointer + same event_frame match a child's stored last_active state, so
+    // without this flag the loop edge would be invisible and finite-loop
+    // independent children would stay frozen at their previous end_frame.
+    void _advance_instance_children(float parent_frame_no, float delta_seconds, bool parent_looped);
     void _load_external_ssabs();
     String _resolve_animation_by_hash(uint32_t name_hash, Ref<SSABResource>& out_source) const;
     void _apply_blend_material(RenderingServer* rs, RID ci, ss::format::BlendType blend_type);

--- a/ss_player/ss_internal_player.h
+++ b/ss_player/ss_internal_player.h
@@ -134,14 +134,14 @@ public:
     bool isSubFrameEnabled() const;
 
     // Marks this player as parent-driven — its own per-tick `update` is a
-    // no-op (the parent's `_advance_instance_children` seeks the child's
-    // frame deterministically each tick). Also disables recursive instance
-    // setup so a misauthored cycle in the SSAB doesn't self-reference.
-    // Defaults to false.
-    void setInstanceChildMode(bool p_enabled);
-    bool isInstanceChildMode() const { return _instance_child_mode; }
+    // no-op because the parent's `_update_instance_children` seeks the
+    // child's frame each tick (synced) or steps it via `ss_runtime_update`
+    // (independent). Defaults to false; `_setup_instance_children` flips
+    // it to true on every Instance child it spawns.
+    void setParentDriven(bool p_enabled);
+    bool isParentDriven() const { return _parent_driven; }
 
-    // Per-tick advance (in seconds; the host typically passes
+    // Per-tick update (in seconds; the host typically passes
     // `process_delta_time`). No-op when paused or in instance-child mode.
     void update(float delta_seconds);
 
@@ -186,7 +186,7 @@ private:
     float previous_frame_no = -1.0f;
     float _speed_rate = 1.0f;
     bool _sub_frame_enabled = false;
-    bool _instance_child_mode = false;
+    bool _parent_driven = false;
 
     SsPlayerEventSink* _event_sink = nullptr;
 
@@ -209,6 +209,18 @@ private:
         bool default_applied = false;
     };
     LocalVector<InstanceChildState> _instance_children;
+
+    // Per-tick scratch: for each Instance slot, the active EventInstance at
+    // the parent's current frame. Built once at the top of
+    // `_update_instance_children` by a single forward scan over the events
+    // list (later events override earlier — matches "latest event ≤
+    // parent_frame" semantics). Reused across calls to avoid per-tick
+    // allocation; sized to `_instance_children.size()` on each rebuild.
+    struct ActiveInstanceEvent {
+        const ss::format::PartAttributeInstance* attr = nullptr;
+        int event_frame = 0;
+    };
+    LocalVector<ActiveInstanceEvent> _active_instance_events;
     // External SSAB resources auto-loaded from the parent's directory based
     // on `external_instances`. Cleared and rebuilt on every setSSABResource.
     Vector<Ref<SSABResource>> _external_ssabs;
@@ -250,8 +262,8 @@ private:
     // Instance slot emit: re-parent the child's _root_ci under this slot's
     // batch CI and apply the slot's world matrix as the child's root
     // transform. The child's own draw + simulation already happened earlier
-    // in `_advance_instance_children` (sim phase), so this is positioning
-    // only — no event scanning, no playback config, no frame advance.
+    // in `_update_instance_children` (sim phase), so this is positioning
+    // only — no event scanning, no playback config, no frame stepping.
     void _emit_instance_slot(const DrawFrame& f, RID ci, int p_idx, const float* slot_matrix);
 
     int _build_normal(const DrawFrame& f, int p_idx,
@@ -280,16 +292,14 @@ private:
     // Pool helpers
     RID _ensure_batch_ci(int batch_idx);
 
-    void _setup_instance_players();
-    void _clear_instance_players();
+    void _setup_instance_children();
+    void _clear_instance_children();
     // Per-tick instance child driver. Runs in the sim phase (called from
-    // `update`), before `_drawAnimation`. For each Instance part it scans the
-    // current animation's events for the most recent EventInstance whose
-    // frame_index <= parent_frame_no, detects transitions against the
-    // tracked `last_active_attr`, applies playback config + `play()` only on
-    // the transition edge, then advances the child to its target frame and
-    // triggers the child's own `_drawAnimation`. `_emit_instance_slot` later
-    // only positions the already-drawn child under the slot's batch CI.
+    // `update`), before `_drawAnimation`. The body delegates each slot to
+    // either `_drive_active_instance_slot` (an EventInstance is active) or
+    // `_drive_default_instance_slot` (SS6 implicit default playback for
+    // slots without explicit EventInstance). `_emit_instance_slot` later
+    // positions the already-drawn child under the slot's batch CI.
     //
     // `delta_seconds` is the wall-clock tick this update represents and is
     // forwarded to children whose EventInstance has `independent = true`
@@ -304,7 +314,37 @@ private:
     // pointer + same event_frame match a child's stored last_active state, so
     // without this flag the loop edge would be invisible and finite-loop
     // independent children would stay frozen at their previous end_frame.
-    void _advance_instance_children(float parent_frame_no, float delta_seconds, bool parent_looped);
+    void _update_instance_children(float parent_frame_no, float delta_seconds, bool parent_looped);
+
+    // Single forward pass over the current animation's events list,
+    // populating `_active_instance_events` with the most recent
+    // EventInstance attribute per Instance slot whose frame_index is <=
+    // `parent_frame_int`. Sized to `_instance_children.size()`; entries
+    // for slots without an event keep `attr == nullptr`. Events are
+    // assumed sorted by `frame_index` (current ssconverter output).
+    void _build_active_instance_event_map(int parent_frame_int);
+
+    // Slot driver: SS6 implicit default playback (synced from frame 0,
+    // loops=1, full range, speed=1) for slots without an active
+    // EventInstance. Applies config once per "default era" via
+    // `state.default_applied`.
+    void _drive_default_instance_slot(InstanceChildState& state,
+                                      SsInternalPlayer* child,
+                                      float parent_frame_no);
+
+    // Slot driver: active-EventInstance path. Detects the transition edge
+    // (new attr or new event_frame), applies playback config + `play()`
+    // only on transition, then steps the child synced or independent.
+    void _drive_active_instance_slot(InstanceChildState& state,
+                                     SsInternalPlayer* child,
+                                     const ss::format::PartAttributeInstance* active_attr,
+                                     int active_event_frame,
+                                     float parent_frame_no,
+                                     float delta_seconds);
+
+    // Common: clamp `frame_no` to integer (unless sub-frame mode), redraw
+    // only if changed since the last frame.
+    static void _redraw_child_if_frame_changed(SsInternalPlayer* child, float frame_no);
     void _load_external_ssabs();
     String _resolve_animation_by_hash(uint32_t name_hash, Ref<SSABResource>& out_source) const;
     void _apply_blend_material(RenderingServer* rs, RID ci, ss::format::BlendType blend_type);

--- a/ss_player/ss_internal_player.h
+++ b/ss_player/ss_internal_player.h
@@ -345,6 +345,15 @@ private:
     // Common: clamp `frame_no` to integer (unless sub-frame mode), redraw
     // only if changed since the last frame.
     static void _redraw_child_if_frame_changed(SsInternalPlayer* child, float frame_no);
+
+    // Apply the current `frame_no` to this player's draw state in one shot:
+    // resolve `draw_frame` per `_sub_frame_enabled`, store it as
+    // `previous_frame_no`, drive Instance children for that frame, and
+    // redraw. Used by `setFrame`, `setSubFrameEnabled`, `_fetchAnimation`
+    // (delta=0, parent_looped=false — non-tick callers don't step
+    // independent children) and the per-tick `update` path.
+    void _seek_and_redraw(float frame_no, float delta_seconds, bool parent_looped);
+
     void _load_external_ssabs();
     String _resolve_animation_by_hash(uint32_t name_hash, Ref<SSABResource>& out_source) const;
     void _apply_blend_material(RenderingServer* rs, RID ci, ss::format::BlendType blend_type);

--- a/ss_player/ss_player_node_2d.cpp
+++ b/ss_player/ss_player_node_2d.cpp
@@ -88,7 +88,6 @@ void SpriteStudioPlayer2D::setSpeed(float p_speed) { _internal->setSpeed(p_speed
 float SpriteStudioPlayer2D::getSpeed() const { return _internal->getSpeed(); }
 
 void SpriteStudioPlayer2D::setFrame(float p_frame) { _internal->setFrame(p_frame); }
-void SpriteStudioPlayer2D::setFrameRelative(float p_diff) { _internal->setFrameRelative(p_diff); }
 float SpriteStudioPlayer2D::getFrame() const { return _internal->getFrame(); }
 
 int SpriteStudioPlayer2D::getTotalFrames() const { return _internal->getTotalFrames(); }
@@ -129,7 +128,6 @@ void SpriteStudioPlayer2D::_bind_methods() {
     ClassDB::bind_method( D_METHOD( "set_speed", "speed" ), &SpriteStudioPlayer2D::setSpeed );
     ClassDB::bind_method( D_METHOD( "get_speed" ), &SpriteStudioPlayer2D::getSpeed );
     ClassDB::bind_method( D_METHOD( "set_frame", "frame" ), &SpriteStudioPlayer2D::setFrame );
-    ClassDB::bind_method( D_METHOD( "set_frame_relative", "diff" ), &SpriteStudioPlayer2D::setFrameRelative );
     ClassDB::bind_method( D_METHOD( "get_frame" ), &SpriteStudioPlayer2D::getFrame );
 
     ClassDB::bind_method( D_METHOD( "get_total_frames" ), &SpriteStudioPlayer2D::getTotalFrames );

--- a/ss_player/ss_player_node_2d.h
+++ b/ss_player/ss_player_node_2d.h
@@ -37,7 +37,6 @@ public:
     void setSpeed( float p_speed );
     float getSpeed() const;
     void setFrame( float p_frame );
-    void setFrameRelative( float p_diff );
     float getFrame() const;
 
     int getTotalFrames() const;


### PR DESCRIPTION
- ** refactor(ss_player): split Instance sim/draw and add independent + nested support**
- **refactor(ss_player): tidy Instance child driver — rename, helpers, single-pass events**
- **refactor(ss_player): extract _seek_and_redraw helper for duplicated frame-apply sites**
