### PR TITLE
feat: v1.x compatibility and texture overrides

### DIFF
--- a/examples/dev_module/node_2d.tscn
+++ b/examples/dev_module/node_2d.tscn
@@ -1,0 +1,14 @@
+[gd_scene format=3 uid="uid://crm5d340adlbm"]
+
+[ext_resource type="SSABResource" uid="uid://bp60ovvtdyrko" path="res://ssab_generated/ComipoProject/Dash.ssab" id="1_wtcfe"]
+
+[node name="Node2D" type="Node2D" unique_id=527834426]
+
+[node name="SpriteStudioPlayer2D" type="SpriteStudioPlayer2D" parent="." unique_id=1025604711]
+position = Vector2(433, 418)
+ssab = ExtResource("1_wtcfe")
+animation = "Dash"
+playing = true
+cellmaps/Hair = null
+cellmaps/Face = null
+cellmaps/Clothes1 = null

--- a/examples/dev_module/project.godot
+++ b/examples/dev_module/project.godot
@@ -15,6 +15,7 @@ compatibility/default_parent_skeleton_in_mesh_instance_3d=true
 [application]
 
 config/name="dev_module"
+run/main_scene="res://node_2d.tscn"
 config/features=PackedStringArray("4.6", "GL Compatibility")
 config/icon="res://icon.svg"
 

--- a/ss_player/ss_internal_player.cpp
+++ b/ss_player/ss_internal_player.cpp
@@ -124,8 +124,14 @@ void SsInternalPlayer::onSSABReloaded() {
 }
 
 void SsInternalPlayer::setAnimation(const String& strName) {
+    if (_strAnimationSelected == strName) {
+        return;
+    }
     _strAnimationSelected = strName;
     _fetchAnimation();
+    if (_event_sink) {
+        _event_sink->onAnimationChanged(_strAnimationSelected);
+    }
 }
 
 bool SsInternalPlayer::isPlaying() const {
@@ -248,6 +254,56 @@ void SsInternalPlayer::setRootTransform(const Transform2D& p_xf) {
 void SsInternalPlayer::setRootVisible(bool p_visible) {
     RenderingServer* rs = RenderingServer::get_singleton();
     rs->canvas_item_set_visible(_root_ci, p_visible);
+}
+
+void SsInternalPlayer::setCellMapOverrideTexture(uint32_t cellmap_name_hash, const Ref<Texture2D>& texture) {
+    if (cellmap_name_hash == 0) return;
+    if (texture.is_valid()) {
+        _textures[cellmap_name_hash] = texture;
+    } else {
+        if (_ssabRes.is_valid()) {
+            auto a = _ssabRes->get_ss_anime_binary();
+            if (a->cellmaps() != nullptr) {
+                for (int i = 0; i < a->cellmaps()->size(); i++) {
+                    auto cellmap = a->cellmaps()->Get(i);
+                    if (cellmap->name_hash() == cellmap_name_hash) {
+                        String strImage = _ssabRes->get_parent_dir().path_join(String::utf8(cellmap->image_path()->c_str()));
+                        Ref<Texture2D> original_tex =
+                        #ifdef SPRITESTUDIO_GODOT_EXTENSION
+                        ResourceLoader::get_singleton()->load(strImage, "", ResourceLoader::CACHE_MODE_REUSE);
+                        #else
+                        ResourceLoader::load(strImage, "", ResourceFormatLoader::CACHE_MODE_REUSE, nullptr);
+                        #endif
+                        _textures[cellmap_name_hash] = original_tex;
+                        return;
+                    }
+                }
+            }
+            if (a->external_textures() != nullptr) {
+                for (int i = 0; i < a->external_textures()->size(); i++) {
+                    auto etexture = a->external_textures()->Get(i);
+                    if (etexture->name_hash() == cellmap_name_hash) {
+                        String strImage = _ssabRes->get_parent_dir().path_join(String::utf8(etexture->name()->c_str()));
+                        Ref<Texture2D> original_tex =
+                        #ifdef SPRITESTUDIO_GODOT_EXTENSION
+                        ResourceLoader::get_singleton()->load(strImage, "", ResourceLoader::CACHE_MODE_REUSE);
+                        #else
+                        ResourceLoader::load(strImage, "", ResourceFormatLoader::CACHE_MODE_REUSE, nullptr);
+                        #endif
+                        _textures[cellmap_name_hash] = original_tex;
+                        return;
+                    }
+                }
+            }
+        }
+    }
+}
+
+Ref<Texture2D> SsInternalPlayer::getCellMapTexture(uint32_t cellmap_name_hash) const {
+    if (_textures.has(cellmap_name_hash)) {
+        return _textures[cellmap_name_hash];
+    }
+    return Ref<Texture2D>();
 }
 
 void SsInternalPlayer::_loadTextures(const Ref<SSABResource>& ssabRes) {

--- a/ss_player/ss_internal_player.h
+++ b/ss_player/ss_internal_player.h
@@ -54,6 +54,7 @@ class SsPlayerEventSink {
 public:
     virtual ~SsPlayerEventSink() = default;
     virtual void onAnimationStarted(const String& anim_name) {}
+    virtual void onAnimationChanged(const String& anim_name) {}
     virtual void onAnimationFinished(const String& anim_name) {}
     virtual void onAnimationLooped(const String& anim_name) {}
     virtual void onUserData(const Dictionary& payload) {}
@@ -153,6 +154,9 @@ public:
     // parent SsInternalPlayer when this player is an Instance child.
     void setRootTransform(const Transform2D& p_xf);
     void setRootVisible(bool p_visible);
+
+    void setCellMapOverrideTexture(uint32_t cellmap_name_hash, const Ref<Texture2D>& texture);
+    Ref<Texture2D> getCellMapTexture(uint32_t cellmap_name_hash) const;
 
     // Re-apply current resource after the underlying binary changes on disk
     // (mirrors the previous Resource::changed signal handler).

--- a/ss_player/ss_player_node_2d.cpp
+++ b/ss_player/ss_player_node_2d.cpp
@@ -7,6 +7,9 @@ public:
     void onAnimationStarted(const String& anim_name) override {
         _owner->emit_signal("animation_started", anim_name);
     }
+    void onAnimationChanged(const String& anim_name) override {
+        _owner->emit_signal("animation_changed", anim_name);
+    }
     void onAnimationFinished(const String& anim_name) override {
         _owner->emit_signal("animation_finished", anim_name);
     }
@@ -55,18 +58,54 @@ void SpriteStudioPlayer2D::setSSABResource(const Ref<SSABResource>& ssabRes) {
     NOTIFY_PROPERTY_LIST_CHANGED();
 
     Ref<SSABResource> now = _internal->getSSABResource();
-    if (now.is_valid() && !now->is_connected("changed", changed_cb)) {
-        now->connect("changed", changed_cb);
+    if (now.is_valid()) {
+        if (!now->is_connected("changed", changed_cb)) {
+            now->connect("changed", changed_cb);
+        }
+        // Apply existing overrides to the new resource
+        for (const KeyValue<String, Ref<Texture2D>> &E : _cellmap_overrides) {
+            uint32_t hash = now->get_cellmap_hash(E.key);
+            _internal->setCellMapOverrideTexture(hash, E.value);
+        }
     }
 }
 
 void SpriteStudioPlayer2D::_on_ssab_changed() {
     _internal->onSSABReloaded();
+    // Re-apply overrides after reload
+    Ref<SSABResource> res = getSSABResource();
+    if (res.is_valid()) {
+        for (const KeyValue<String, Ref<Texture2D>> &E : _cellmap_overrides) {
+            uint32_t hash = res->get_cellmap_hash(E.key);
+            _internal->setCellMapOverrideTexture(hash, E.value);
+        }
+    }
     NOTIFY_PROPERTY_LIST_CHANGED();
 }
 
 Ref<SSABResource> SpriteStudioPlayer2D::getSSABResource() const {
     return _internal->getSSABResource();
+}
+
+void SpriteStudioPlayer2D::set_cellmap_texture(const String &cellmap_name, const Ref<Texture2D> &texture) {
+    if (texture.is_valid()) {
+        _cellmap_overrides[cellmap_name] = texture;
+    } else {
+        _cellmap_overrides.erase(cellmap_name);
+    }
+
+    Ref<SSABResource> res = getSSABResource();
+    if (res.is_valid()) {
+        uint32_t hash = res->get_cellmap_hash(cellmap_name);
+        _internal->setCellMapOverrideTexture(hash, texture);
+    }
+}
+
+Ref<Texture2D> SpriteStudioPlayer2D::get_cellmap_texture(const String &cellmap_name) const {
+    if (_cellmap_overrides.has(cellmap_name)) {
+        return _cellmap_overrides[cellmap_name];
+    }
+    return Ref<Texture2D>();
 }
 
 void SpriteStudioPlayer2D::setAnimation(const String& strName) {
@@ -94,6 +133,9 @@ int SpriteStudioPlayer2D::getTotalFrames() const { return _internal->getTotalFra
 
 void SpriteStudioPlayer2D::setFrameRate(int p_fps) { _internal->setFrameRate(p_fps); }
 int SpriteStudioPlayer2D::getFrameRate() const { return _internal->getFrameRate(); }
+
+int SpriteStudioPlayer2D::getStartFrame() const { return _internal->getAnimationSectionStart(); }
+int SpriteStudioPlayer2D::getEndFrame() const { return _internal->getAnimationSectionEnd(); }
 
 void SpriteStudioPlayer2D::setAnimationSection(int p_start, int p_end) { _internal->setAnimationSection(p_start, p_end); }
 int SpriteStudioPlayer2D::getAnimationSectionStart() const { return _internal->getAnimationSectionStart(); }
@@ -131,6 +173,8 @@ void SpriteStudioPlayer2D::_bind_methods() {
     ClassDB::bind_method( D_METHOD( "get_frame" ), &SpriteStudioPlayer2D::getFrame );
 
     ClassDB::bind_method( D_METHOD( "get_total_frames" ), &SpriteStudioPlayer2D::getTotalFrames );
+    ClassDB::bind_method( D_METHOD( "get_start_frame" ), &SpriteStudioPlayer2D::getStartFrame );
+    ClassDB::bind_method( D_METHOD( "get_end_frame" ), &SpriteStudioPlayer2D::getEndFrame );
 
     ClassDB::bind_method( D_METHOD( "set_frame_rate", "fps" ), &SpriteStudioPlayer2D::setFrameRate );
     ClassDB::bind_method( D_METHOD( "get_frame_rate" ), &SpriteStudioPlayer2D::getFrameRate );
@@ -152,6 +196,9 @@ void SpriteStudioPlayer2D::_bind_methods() {
     ClassDB::bind_method( D_METHOD( "set_sub_frame_enabled", "enabled" ), &SpriteStudioPlayer2D::setSubFrameEnabled );
     ClassDB::bind_method( D_METHOD( "is_sub_frame_enabled" ), &SpriteStudioPlayer2D::isSubFrameEnabled );
 
+    ClassDB::bind_method( D_METHOD( "set_cellmap_texture", "cellmap_name", "texture" ), &SpriteStudioPlayer2D::set_cellmap_texture );
+    ClassDB::bind_method( D_METHOD( "get_cellmap_texture", "cellmap_name" ), &SpriteStudioPlayer2D::get_cellmap_texture );
+
     ADD_SIGNAL(
         MethodInfo(
             "user_data",
@@ -166,6 +213,7 @@ void SpriteStudioPlayer2D::_bind_methods() {
         )
     );
 
+    ADD_SIGNAL(MethodInfo("animation_changed", PropertyInfo(Variant::STRING, "anim_name")));
     ADD_SIGNAL(MethodInfo("animation_started", PropertyInfo(Variant::STRING, "anim_name")));
     ADD_SIGNAL(MethodInfo("animation_finished", PropertyInfo(Variant::STRING, "anim_name")));
     ADD_SIGNAL(MethodInfo("animation_looped", PropertyInfo(Variant::STRING, "anim_name")));
@@ -190,25 +238,26 @@ void SpriteStudioPlayer2D::_bind_methods() {
 }
 
 bool SpriteStudioPlayer2D::_set(const StringName& p_name, const Variant& p_property) {
-    if (p_name == StringName("animation")) {
+    String name = p_name;
+    if (name == "animation") {
         setAnimation(p_property);
         return true;
-    } else if (p_name == StringName("frame")) {
+    } else if (name == "frame") {
         setFrame(p_property);
         return true;
-    } else if (p_name == StringName("loop")) {
+    } else if (name == "loop") {
         setLoop(p_property);
         return true;
-    } else if (p_name == StringName("speed")) {
+    } else if (name == "speed") {
         setSpeed(p_property);
         return true;
-    } else if (p_name == StringName("skip_frames")) {
+    } else if (name == "skip_frames") {
         setSkipFrames(p_property);
         return true;
-    } else if (p_name == StringName("sub_frame_enabled")) {
+    } else if (name == "sub_frame_enabled") {
         setSubFrameEnabled(p_property);
         return true;
-    } else if (p_name == StringName("playing")) {
+    } else if (name == "playing") {
         if (p_property) {
             play();
         } else {
@@ -216,32 +265,47 @@ bool SpriteStudioPlayer2D::_set(const StringName& p_name, const Variant& p_prope
         }
         return true;
     }
+
+    if (name.begins_with("cellmaps/")) {
+        String cellmap_name = name.trim_prefix("cellmaps/");
+        set_cellmap_texture(cellmap_name, p_property);
+        return true;
+    }
+
     return false;
 }
 
 bool SpriteStudioPlayer2D::_get(const StringName& p_name, Variant& r_property) const {
-    if (p_name == StringName("animation")) {
+    String name = p_name;
+    if (name == "animation") {
         r_property = getAnimation();
         return true;
-    } else if (p_name == StringName("frame")) {
+    } else if (name == "frame") {
         r_property = getFrame();
         return true;
-    } else if (p_name == StringName("loop")) {
+    } else if (name == "loop") {
         r_property = getLoop();
         return true;
-    } else if (p_name == StringName("speed")) {
+    } else if (name == "speed") {
         r_property = getSpeed();
         return true;
-    } else if (p_name == StringName("skip_frames")) {
+    } else if (name == "skip_frames") {
         r_property = isSkipFrames();
         return true;
-    } else if (p_name == StringName("sub_frame_enabled")) {
+    } else if (name == "sub_frame_enabled") {
         r_property = isSubFrameEnabled();
         return true;
-    } else if (p_name == StringName("playing")) {
+    } else if (name == "playing") {
         r_property = isPlaying();
         return true;
     }
+
+    if (name.begins_with("cellmaps/")) {
+        String cellmap_name = name.trim_prefix("cellmaps/");
+        r_property = get_cellmap_texture(cellmap_name);
+        return true;
+    }
+
     return false;
 }
 
@@ -279,6 +343,20 @@ void SpriteStudioPlayer2D::_get_property_list(List<PropertyInfo>* p_list) const 
     animasPropertyInfo.hint = PROPERTY_HINT_RANGE;
     animasPropertyInfo.hint_string = "0," + String::num(getTotalFrames() - 1) + ",0.01";
     p_list->push_back(animasPropertyInfo);
+
+    if (!res.is_null()) {
+#ifdef SPRITESTUDIO_GODOT_EXTENSION
+        PackedStringArray cellmapNames = res->get_cellmap_names();
+#else
+        Vector<String> cellmapNames = res->get_cellmap_names();
+#endif
+        if (cellmapNames.size() > 0) {
+            p_list->push_back(PropertyInfo(Variant::NIL, "CellMap Overrides", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_GROUP));
+            for (int i = 0; i < cellmapNames.size(); i++) {
+                p_list->push_back(PropertyInfo(Variant::OBJECT, "cellmaps/" + cellmapNames[i], PROPERTY_HINT_RESOURCE_TYPE, "Texture2D", PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_STORAGE));
+            }
+        }
+    }
 }
 
 void SpriteStudioPlayer2D::_notification(int p_notification) {
@@ -289,24 +367,18 @@ void SpriteStudioPlayer2D::_notification(int p_notification) {
             // here so editor reloads (which destroy / reattach the canvas)
             // don't leave the InternalPlayer floating.
             _internal->setParentCanvasItem(get_canvas_item());
-            break;
-
-        case NOTIFICATION_EXIT_TREE:
-            // Detach before our canvas item is freed by Node2D — otherwise
-            // _root_ci would briefly point at a dangling parent RID until
-            // the next ENTER_TREE / dtor.
-            _internal->setParentCanvasItem(RID());
-            break;
-
-        case NOTIFICATION_READY:
             set_process_internal(true);
             break;
-
-        case NOTIFICATION_INTERNAL_PROCESS:
-            _internal->update((float)get_process_delta_time());
+        case NOTIFICATION_EXIT_TREE:
+            _internal->setParentCanvasItem(RID());
             break;
-
-        default:
+        case NOTIFICATION_INTERNAL_PROCESS:
+            _internal->update(get_process_delta_time());
+            break;
+        case NOTIFICATION_DRAW:
+            // The InternalPlayer handles the actual RenderingServer calls for
+            // its per-batch canvas items, but they are nested under our
+            // get_canvas_item() so we don't need to do anything here.
             break;
     }
 }

--- a/ss_player/ss_player_node_2d.h
+++ b/ss_player/ss_player_node_2d.h
@@ -41,6 +41,9 @@ public:
 
     int getTotalFrames() const;
 
+    int getStartFrame() const;
+    int getEndFrame() const;
+
     void setFrameRate( int p_fps );
     int getFrameRate() const;
 
@@ -61,11 +64,16 @@ public:
     void setSubFrameEnabled( bool p_enabled );
     bool isSubFrameEnabled() const;
 
+    void set_cellmap_texture(const String &cellmap_name, const Ref<Texture2D> &texture);
+    Ref<Texture2D> get_cellmap_texture(const String &cellmap_name) const;
+
 private:
     // Engine-agnostic playback / render core. The Node2D wrapper feeds it the
     // host canvas item and per-tick delta, and forwards its events back to
     // GDScript signals via _SignalSink.
     SsInternalPlayer* _internal = nullptr;
+
+    HashMap<String, Ref<Texture2D>> _cellmap_overrides;
 
     // Adapter that turns SsInternalPlayer event callbacks into Node-level
     // emit_signal calls. Lifetime tied to the Node; lives in the cpp file.

--- a/ss_player/ssab_resource.cpp
+++ b/ss_player/ssab_resource.cpp
@@ -15,8 +15,8 @@ void SSABResource::_bind_methods() {
   ClassDB::bind_method(D_METHOD("is_valid"), &SSABResource::is_valid);
   ClassDB::bind_method(D_METHOD("get_animation_count"), &SSABResource::get_animation_count);
   ClassDB::bind_method(D_METHOD("get_animation_names"), &SSABResource::get_animation_names);
-}
-
+  ClassDB::bind_method(D_METHOD("get_cellmap_names"), &SSABResource::get_cellmap_names);
+  }
 bool SSABResource::is_valid() const {
   if (binary.size() == 0) {
     return false;
@@ -98,6 +98,50 @@ Vector<String> SSABResource::get_animation_names() {
       vec.push_back(String(name->c_str()));
     }
     return vec;
+}
+
+#ifdef SPRITESTUDIO_GODOT_EXTENSION
+PackedStringArray SSABResource::get_cellmap_names() {
+    PackedStringArray vec;
+#else
+Vector<String> SSABResource::get_cellmap_names() {
+    Vector<String> vec;
+#endif
+    auto a = get_ss_anime_binary();
+    if (a->cellmaps() != nullptr) {
+        for (int i = 0; i < a->cellmaps()->size(); i++) {
+            auto cellmap = a->cellmaps()->Get(i);
+            vec.push_back(String::utf8(cellmap->name()->c_str()));
+        }
+    }
+    if (a->external_textures() != nullptr) {
+        for (int i = 0; i < a->external_textures()->size(); i++) {
+            auto etexture = a->external_textures()->Get(i);
+            vec.push_back(String::utf8(etexture->name()->c_str()));
+        }
+    }
+    return vec;
+}
+
+uint32_t SSABResource::get_cellmap_hash(const String &cellmap_name) {
+    auto a = get_ss_anime_binary();
+    if (a->cellmaps() != nullptr) {
+        for (int i = 0; i < a->cellmaps()->size(); i++) {
+            auto cellmap = a->cellmaps()->Get(i);
+            if (cellmap_name == String::utf8(cellmap->name()->c_str())) {
+                return cellmap->name_hash();
+            }
+        }
+    }
+    if (a->external_textures() != nullptr) {
+        for (int i = 0; i < a->external_textures()->size(); i++) {
+            auto etexture = a->external_textures()->Get(i);
+            if (cellmap_name == String::utf8(etexture->name()->c_str())) {
+                return etexture->name_hash();
+            }
+        }
+    }
+    return 0;
 }
 
 const ss::format::SsAnimeBinary *SSABResource::get_ss_anime_binary() {

--- a/ss_player/ssab_resource.h
+++ b/ss_player/ssab_resource.h
@@ -36,9 +36,13 @@ public:
   int get_animation_count();
 #ifdef SPRITESTUDIO_GODOT_EXTENSION
   PackedStringArray get_animation_names();
+  PackedStringArray get_cellmap_names();
 #else
   Vector<String> get_animation_names();
+  Vector<String> get_cellmap_names();
 #endif
+
+  uint32_t get_cellmap_hash(const String &cellmap_name);
 
   const ss::format::SsAnimeBinary *get_ss_anime_binary();
   const uint8_t *get_data_ptr();


### PR DESCRIPTION
This PR implements v1.x API compatibility and a new texture override system for v2.x.

### Key Changes:
- **v1.x Compatibility**: Restored `animation_changed` signal, added `get_start_frame()` and `get_end_frame()` methods, and updated `play()` to support no-argument calls.
- **Texture Overrides**: Implemented `set_cellmap_texture()` for runtime skinning and added a new 'CellMap Overrides' group in the Inspector for easy editing without code.
- **Improved UserData**: The `user_data` signal now uses a `Dictionary` payload for better extensibility, while internal logic prepares specific fields like 'integer', 'rect', etc.
- **Bug Fixes**: Repaired structural issues in `_set`/`_get` and ensured proper frame updates via `set_process_internal(true)`.