### PR TITLE
feat(godot): handle and display detailed converter errors

### DIFF
--- a/ss_player/ss_importer.cpp
+++ b/ss_player/ss_importer.cpp
@@ -108,7 +108,11 @@ void SSImporter::_finalize_import() {
             _record_ssabs_in_dir(source_map, _import_dst_dirs[i], _import_src_files[i]);
             any_success = true;
         } else {
-            print_line(vformat("SSImporter: convert failed for %s (error %d)", _import_src_files[i], (int)result));
+            const char *err_msg = nullptr;
+            uintptr_t err_len = 0;
+            ss_converter_get_error((Context *)ctx, &err_msg, &err_len);
+            String err_str = err_msg ? String::utf8(err_msg) : String("Unknown error");
+            ERR_PRINT(vformat("SSImporter: convert failed for %s (error %d): %s", _import_src_files[i], (int)result, err_str));
         }
         ss_converter_destroy((Context *)ctx);
     }


### PR DESCRIPTION
- Use ss_converter_get_error to extract the specific error message from the FFI boundary when a conversion fails.
- Display the detailed error via ERR_PRINT to aid in diagnosing issues like OneDrive path failures or missing files.
- Update SpriteStudio7-SDK submodule to include the FFI crash fix.

ref
https://github.com/SpriteStudio/SpriteStudio7-SDK/pull/197