### PR TITLE
Fix effect particle ghosting; bump SpriteStudio7-SDK

### DIFF
--- a/ss_player/ss_internal_player.cpp
+++ b/ss_player/ss_internal_player.cpp
@@ -490,6 +490,20 @@ void SsInternalPlayer::_drawAnimation(float frame_no, float delta_seconds, bool 
         f.rs->canvas_item_set_visible(_batch_canvas_items[i], false);
     }
 
+    // Effect emitter canvas items are owned by EffectSlotState (persistent
+    // across frames) and hang off whatever batch CI they were last parented
+    // to. When an effect part stops producing an Effect batch (HIDE'd) or its
+    // slot reports not_visible, `_emit_effect_slot` is skipped or early-returns
+    // without touching `emitter_cis` — leaving stale particle geometry on a
+    // pool slot that gets recycled by another (visible) batch. Hide every
+    // emitter CI up-front; `_emit_effect_slot`'s visible branch re-shows only
+    // the ones it actually draws this frame.
+    for (const EffectSlotState& slot : _effect_slots) {
+        for (const RID& e_ci : slot.emitter_cis) {
+            f.rs->canvas_item_set_visible(e_ci, false);
+        }
+    }
+
     for (uint32_t bi = 0; bi < batch_count; bi++) {
         const auto* batch = draw_batches->Get(bi);
         RID ci = _ensure_batch_ci((int)bi);


### PR DESCRIPTION
- player: hide every effect emitter canvas item up-front in _drawAnimation. EffectSlotState::emitter_cis are persistent and hang off recycled batch CIs, so a slot going not_visible (effect past lifetime) or HIDE'd (no Effect draw batch emitted) left stale particle quads attached to a pool slot a later batch reused — bleeding old flash particles onto unrelated frames. The visible branch re-shows the active ones.
- SpriteStudio7-SDK: implicit frame-0 playback key handling for effect / instance parts — converter no longer materializes the key, runtime supplies it via synthetic_default and ignores it on the parent's loop edge for independent slots.