### PR TITLE
Update GDExtension to target Godot 4.6

### DIFF
--- a/.github/workflows/extension.yml
+++ b/.github/workflows/extension.yml
@@ -5,7 +5,7 @@ on:
       godot_tag:
         required: true
         type: string
-        default: "4.4"
+        default: "master"
         description: "a branch or a tag of godot-cpp"
 
 env:

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -54,7 +54,10 @@ graph LR
 ## Supported Versions
 
 - **Godot Engine**: [4.6 branch](https://github.com/godotengine/godot/tree/4.6)
-- **godot-cpp**: [4.5 branch](https://github.com/godotengine/godot-cpp/tree/4.5)
+- **godot-cpp**: [master branch](https://github.com/godotengine/godot-cpp/tree/master)
+
+> [!NOTE]
+> GDExtension is officially supported starting from Godot 4.6.
 
 Build and execution have been verified on Windows / macOS.
 

--- a/docs/en/setup/build.md
+++ b/docs/en/setup/build.md
@@ -17,7 +17,7 @@ Clone this repository (with submodules) and clone Godot Engine / godot-cpp depen
 git clone --recursive https://github.com/SpriteStudio/SSPlayerForGodot.git
 cd SSPlayerForGodot
 git clone https://github.com/godotengine/godot.git -b 4.6
-git clone https://github.com/godotengine/godot-cpp.git -b 4.5
+git clone https://github.com/godotengine/godot-cpp.git -b master
 ```
 
 The `godot` directory is required when building a custom-module Godot Engine.
@@ -59,7 +59,7 @@ To build `libssruntime` from the SS7-SDK source yourself, see [For SS7-SDK Devel
 
 ## 2-A. Build the GDExtension
 
-Requires `godot-cpp` to be cloned at the `4.5` branch.
+Requires `godot-cpp` to be cloned at the `master` branch.
 
 **macOS / Linux**
 

--- a/docs/ja/index.md
+++ b/docs/ja/index.md
@@ -54,7 +54,10 @@ graph LR
 ## 対応バージョン
 
 - **Godot Engine**: [4.6 ブランチ](https://github.com/godotengine/godot/tree/4.6)
-- **godot-cpp**: [4.5 ブランチ](https://github.com/godotengine/godot-cpp/tree/4.5)
+- **godot-cpp**: [master ブランチ](https://github.com/godotengine/godot-cpp/tree/master)
+
+> [!NOTE]
+> GDExtension は Godot 4.6 以降から正式サポートされます。
 
 Windows / macOS でのビルドおよび実行を確認しています。
 

--- a/docs/ja/setup/build.md
+++ b/docs/ja/setup/build.md
@@ -17,7 +17,7 @@ GDExtension またはカスタムモジュール組み込み Godot Engine を自
 git clone --recursive https://github.com/SpriteStudio/SSPlayerForGodot.git
 cd SSPlayerForGodot
 git clone https://github.com/godotengine/godot.git -b 4.6
-git clone https://github.com/godotengine/godot-cpp.git -b 4.5
+git clone https://github.com/godotengine/godot-cpp.git -b master
 ```
 
 `godot` ディレクトリはカスタムモジュール組み込み Godot Engine をビルドする場合に必要です。
@@ -59,7 +59,7 @@ Homebrew で配布されている `molten-vk` はホストアーキ向けのバ�
 
 ## 2-A. GDExtension のビルド
 
-`godot-cpp` を `4.5` ブランチで clone 済みであることが前提です。
+`godot-cpp` を `master` ブランチで clone 済みであることが前提です。
 
 **macOS / Linux**
 

--- a/scripts/build-extension.ps1
+++ b/scripts/build-extension.ps1
@@ -10,19 +10,6 @@ if ($arch -match "AMD64") {
 }
 $cpus = (Get-Item Env:NUMBER_OF_PROCESSORS).Value
 
-pushd $rootDirectory/godot-cpp
-try {
-    $GODOT_BRANCH = (git branch --show-current).Trim()
-} catch {
-    $GODOT_BRANCH = ""
-}
-try {
-    $GODOT_TAG = (git describe --tags --abbrev=0).Trim()
-} catch {
-    $GODOT_TAG = ""
-}
-popd
-
 # Godot scons default options
 $scons_default_opts = @{
     arch = $HOST_ARCH
@@ -72,6 +59,7 @@ $opts
 echo ""
 
 # validate scons command options from winbuild options
+$scons_command_opts = ""
 foreach ($key in $opts.Keys) {
     if ($winbuild_default_opts.ContainsKey($key)) {
         # skip winbuild default options
@@ -79,8 +67,14 @@ foreach ($key in $opts.Keys) {
     }
     $scons_command_opts += " $key=$($opts[$key])"
 }
+
+# Map version to api_version for SCons
+if ($opts.version) {
+    $scons_command_opts += " api_version=$($opts.version)"
+}
+
 $j = $opts["cpus"]
-$scons_command_opts += "$scons_command_opts -j $j"
+$scons_command_opts += " -j $j"
 
 
 echo "scons command options: $scons_command_opts"

--- a/scripts/build-extension.sh
+++ b/scripts/build-extension.sh
@@ -19,10 +19,6 @@ else
 fi
 
 HOST_ARCH=$(uname -m)
-pushd $ROOTDIR/godot-cpp > /dev/null
-GODOT_BRANCH=$(git branch --show-current | sed -e "s/[\r\n]\+//g")
-GODOT_TAG=$(git describe --tags --abbrev=0 | sed -e "s/[\r\n]\+//g")
-popd > /dev/null
 
 # Godot scons default options
 declare -A scons_default_opts=(
@@ -82,13 +78,7 @@ done
 echo ""
 
 # get Godot Version
-if [[ -n $GODOT_BRANCH ]]; then
-    VERSION=${GODOT_BRANCH}
-elif [[ -n $GODOT_TAG ]]; then
-    VERSION=${GODOT_TAG}
-else
-    VERSION=${opts[version]}
-fi
+VERSION=${opts[version]}
 echo "Godot Version: ${VERSION}"
 
 # validate scons command options from macbuild.sh options
@@ -103,6 +93,12 @@ for key value in ${(kv)opts}; do
     fi
     scons_command_opts="$scons_command_opts $key=$value"
 done
+
+# Map version to api_version for SCons
+if [[ -n $VERSION ]]; then
+    scons_command_opts="$scons_command_opts api_version=$VERSION"
+fi
+
 scons_command_opts="$scons_command_opts -j $build_default_opts[cpus]"
 
 echo "scons command options: $scons_command_opts"


### PR DESCRIPTION
This PR updates the GDExtension build configuration and documentation to target Godot 4.6 and use the master branch of godot-cpp. It also simplifies the version mapping inside the build scripts.