### PR TITLE
Fix UTF-8 string decoding for animations and runtime logs

### DIFF
--- a/ss_player/ss_internal_player.cpp
+++ b/ss_player/ss_internal_player.cpp
@@ -20,7 +20,7 @@ void ss_runtime_log_bridge(int level, const char *message) {
     if (!message) {
         return;
     }
-    WARN_PRINT(String("[ssruntime] ") + String(message));
+    WARN_PRINT(String("[ssruntime] ") + String::utf8(message));
 }
 
 // Shader source pieces. The vertex shader (default.vs) is meant to be reused

--- a/ss_player/ssab_resource.cpp
+++ b/ss_player/ssab_resource.cpp
@@ -101,7 +101,7 @@ Vector<String> SSABResource::get_animation_names() {
     for (int i=0; i < num; i++) {
       auto animation = ss_anime_binary->animations()->Get(i);
       auto name = animation->name();
-      vec.push_back(String(name->c_str()));
+      vec.push_back(String::utf8(name->c_str()));
     }
     return vec;
 }
@@ -180,7 +180,7 @@ ss::format::AnimationData *SSABResource::find_animation(const String &name) {
     for (int i=0; i < num; i++) {
         auto animation = ss_anime_binary->animations()->Get(i);
         auto anim_name = animation->name();
-        if (name == String(anim_name->c_str())) {
+        if (name == String::utf8(anim_name->c_str())) {
             return (ss::format::AnimationData *)animation;
         }
     }


### PR DESCRIPTION
Uses String::utf8() instead of String() when decoding strings from Flatbuffers and ssruntime logs. This ensures Japanese and other multi-byte characters are displayed and looked up correctly.