### PR TITLE
Fix HIDE not applying to Instance parts (independent=false, infinite-loop=true)

### DIFF
--- a/ss_player/ss_internal_player.cpp
+++ b/ss_player/ss_internal_player.cpp
@@ -821,11 +821,10 @@ void SsInternalPlayer::_drive_instance_slot(InstanceChildState& state,
         child->play();
     }
 
+    child->setRootVisible(false);
     if (!r.visible) {
-        child->setRootVisible(false);
         return;
     }
-    child->setRootVisible(true);
 
     _redraw_child_if_frame_changed(child, r.child_frame_no, delta_seconds, r.child_looped);
 }
@@ -854,6 +853,7 @@ void SsInternalPlayer::_emit_instance_slot(const DrawFrame& /*f*/, RID ci, int p
     // guaranteed to be the same RID across frames.
     child->setParentCanvasItem(ci);
     child->setRootTransform(matrix_to_transform2d(slot_matrix));
+    child->setRootVisible(true);
 }
 
 void SsInternalPlayer::_emit_effect_slot(const DrawFrame& f, RID ci, int p_idx, const float* slot_matrix) {


### PR DESCRIPTION
Switch the contract:
- `_drive_instance_slot` defaults the child to hidden every frame, then redraws to keep the child's frame_no in sync regardless.
- `_emit_instance_slot` flips the child back to visible when reached (i.e. when the part is in the current frame's draw_batches).

HIDE'd parts skip `_emit_instance_slot` and stay hidden; visible parts get re-shown. The fix applies uniformly to all independent/loop combinations, not just the reported synced+looping case.