### PR TITLE
fix: add null check for FlatBuffers parts_color retrieval

### DIFF
--- a/ss_player/ss_internal_player.cpp
+++ b/ss_player/ss_internal_player.cpp
@@ -1354,7 +1354,7 @@ int SsInternalPlayer::_build_normal(const DrawFrame& f, int p_idx,
     int blend_idx = 0;
 
     const auto partColorIndex = part->part_color();
-    if ((flags & ss::runtime::UpdateAttributeFlags_AttributePartColor) && partColorIndex >= 0) {
+    if ((flags & ss::runtime::UpdateAttributeFlags_AttributePartColor) && partColorIndex >= 0 && f.frameData->parts_color() != nullptr) {
         auto pc = f.frameData->parts_color()->Get(partColorIndex);
         // SDK converter has applied SS6-style mediation; ssab fields now carry
         // a consistent semantic regardless of the source (blend_type, target):
@@ -1654,7 +1654,7 @@ bool SsInternalPlayer::_build_shape_geometry(const DrawFrame& f, int p_idx,
     int blend_idx = 0;
 
     const auto partColorIndex = part->part_color();
-    if ((flags & ss::runtime::UpdateAttributeFlags_AttributePartColor) && partColorIndex >= 0) {
+    if ((flags & ss::runtime::UpdateAttributeFlags_AttributePartColor) && partColorIndex >= 0 && f.frameData->parts_color() != nullptr) {
         auto pc = f.frameData->parts_color()->Get(partColorIndex);
         // SDK-mediated semantic — see _build_normal for the field meanings.
         // Shape paths additionally get the (blend_type == Mix → rgba.a = 255)
@@ -2105,7 +2105,7 @@ bool SsInternalPlayer::_build_mesh_geometry(const DrawFrame& f, int p_idx,
     int blend_idx = 0;
     const uint64_t flags = part->update_flag();
     const auto partColorIndex = part->part_color();
-    if ((flags & ss::runtime::UpdateAttributeFlags_AttributePartColor) && partColorIndex >= 0) {
+    if ((flags & ss::runtime::UpdateAttributeFlags_AttributePartColor) && partColorIndex >= 0 && f.frameData->parts_color() != nullptr) {
         auto pc = f.frameData->parts_color()->Get(partColorIndex);
         auto to_color = [part_alpha](const ss::runtime::SsAttributePartColorKeyValueColor& c) {
             return Color(c.rgba().r()/255.0f, c.rgba().g()/255.0f, c.rgba().b()/255.0f,


### PR DESCRIPTION
## 概要

FlatBuffers から `parts_color()` を取得する際に、データが存在しない（`nullptr` が返る）ケースでの未定義動作・クラッシュを防ぐためのセーフティチェックを追加しました。

## 背景

SDK側で `RenderMode::Direct` 等の最適化が適用された際、バッチ描画に乗らないアンバッチパーツ（マスクやカスタムシェーダー適用パーツ）を `_build_normal` で描画しようとすると、FlatBuffers 上に `parts_color` 配列が存在しない場合があります。
これまでは無条件で `parts_color()->Get(index)` を呼び出していたため、存在しない場合に不正なメモリアクセスが発生し、画面のちらつきや予期せぬ挙動を引き起こす原因となっていました。

本修正により、`f.frameData->parts_color() != nullptr` を事前に確認することで安全にフォールバック（デフォルトカラーでの描画）できるようになります。

ref
https://github.com/SpriteStudio/SpriteStudio7-SDK/pull/224