### PR TITLE
build(wasm): update SDK to fix Emscripten allocator collision and script names

### DIFF
--- a/scripts/build-runtime.ps1
+++ b/scripts/build-runtime.ps1
@@ -75,7 +75,7 @@ if ($IS_HOST_BUILD) {
     } elseif ($PLATFORM -eq "ios" -and $IOS_SIMULATOR -eq "yes") {
         & sh ./scripts/release-ios-sim.sh $BUILD_MODE
     } elseif ($PLATFORM -eq "web") {
-        & sh ./scripts/release-wasm.sh $BUILD_MODE
+        & sh ./scripts/release-emscripten.sh $BUILD_MODE
     } else {
         & sh "./scripts/release-$PLATFORM.sh" $BUILD_MODE
     }

--- a/scripts/build-runtime.sh
+++ b/scripts/build-runtime.sh
@@ -112,7 +112,7 @@ else
             SRC_DIR="target/$BUILD_MODE"
             ;;
         web)
-            ./scripts/release-wasm.sh $BUILD_MODE
+            ./scripts/release-emscripten.sh $BUILD_MODE
             SRC_DIR="target/wasm32-unknown-unknown/$BUILD_MODE"
             ;;
         windows)


### PR DESCRIPTION
## Description
- Bumps `SpriteStudio7-SDK` submodule to include the `emscripten_allocator` fix (https://github.com/SpriteStudio/SpriteStudio7-SDK/pull/225).
- Updates `build-runtime` scripts (`.sh` and `.ps1`) to use the renamed `release-emscripten.sh` script.
- Prevents `memory access out of bounds` in WebGL exports by delegating WASM memory allocations directly to Emscripten's host malloc.