### PR TITLE
Fix: Propagate sub_frame_enabled to instance children

### DIFF
--- a/ss_player/ss_internal_player.cpp
+++ b/ss_player/ss_internal_player.cpp
@@ -295,6 +295,12 @@ bool SsInternalPlayer::isSkipFrames() const {
 
 void SsInternalPlayer::setSubFrameEnabled(bool p_enabled) {
     _sub_frame_enabled = p_enabled;
+    for (uint32_t i = 0; i < _instance_children.size(); i++) {
+        SsInternalPlayer* child = _instance_children[i].player;
+        if (child) {
+            child->setSubFrameEnabled(p_enabled);
+        }
+    }
     if (runtime_ctx) {
         _seek_and_redraw(ss_runtime_get_frame_no(runtime_ctx), 0.0f, false);
     }
@@ -1071,6 +1077,7 @@ void SsInternalPlayer::_setup_instance_children() {
 
         SsInternalPlayer* child = memnew(SsInternalPlayer);
         child->setParentDriven(true);
+        child->setSubFrameEnabled(_sub_frame_enabled);
         // Hand the child the SSAB that actually contains the referenced
         // animation — may be `_ssabRes` itself or an external sibling.
         child->setSSABResource(source);


### PR DESCRIPTION
## Description
Fixes an issue where the `sub_frame_enabled` setting was not being propagated to child instance players (nested animations).

## Changes
- Updated `_setup_instance_children` to pass the parent's `_sub_frame_enabled` to newly instantiated children before they initialize.
- Updated `setSubFrameEnabled` to propagate property changes recursively to existing `_instance_children`.