### PR TITLE
Fix CanvasDropOverlay intercepting 2D scene object picking

### DIFF
--- a/ss_player/ss_canvas_drop_overlay.cpp
+++ b/ss_player/ss_canvas_drop_overlay.cpp
@@ -156,8 +156,19 @@ SpriteStudioPlayer2D *_add_children_with_undo(
 } // namespace
 
 SSCanvasDropOverlay::SSCanvasDropOverlay() {
-    set_mouse_filter(MOUSE_FILTER_PASS);
+    set_mouse_filter(MOUSE_FILTER_IGNORE);
     set_anchors_and_offsets_preset(PRESET_FULL_RECT);
+}
+
+void SSCanvasDropOverlay::_notification(int p_what) {
+    switch (p_what) {
+        case NOTIFICATION_DRAG_BEGIN: {
+            set_mouse_filter(MOUSE_FILTER_PASS);
+        } break;
+        case NOTIFICATION_DRAG_END: {
+            set_mouse_filter(MOUSE_FILTER_IGNORE);
+        } break;
+    }
 }
 
 PackedStringArray SSCanvasDropOverlay::_extract_ssab_paths(const Variant &p_data) const {

--- a/ss_player/ss_canvas_drop_overlay.h
+++ b/ss_player/ss_canvas_drop_overlay.h
@@ -13,6 +13,11 @@ using namespace godot;
 // Transparent Control installed as a child of CanvasItemEditorViewport that
 // claims drops of .ssab files and turns them into SpriteStudioPlayer2D nodes.
 //
+// To prevent intercepting standard mouse input (which breaks 2D scene picking
+// and sibling controls), this overlay uses MOUSE_FILTER_IGNORE by default.
+// It listens to NOTIFICATION_DRAG_BEGIN/END to temporarily switch to
+// MOUSE_FILTER_PASS while a drag is active.
+//
 // Non-.ssab drops are explicitly rejected so that Godot's drop walk continues
 // up to the host viewport (which still handles PNG/PackedScene/AudioStream).
 // This relies on Viewport::_gui_drop walking parent CanvasItems when a child
@@ -33,6 +38,9 @@ public:
     bool can_drop_data(const Point2 &p_point, const Variant &p_data) const override;
     void drop_data(const Point2 &p_point, const Variant &p_data) override;
 #endif
+
+protected:
+    void _notification(int p_what);
 
 private:
     PackedStringArray _extract_ssab_paths(const Variant &p_data) const;


### PR DESCRIPTION
## Description

Fixes an issue where `SSCanvasDropOverlay` intercepted standard mouse clicks on the 2D canvas, preventing object picking for 2D scene nodes. 

Previously, it used `MOUSE_FILTER_PASS` which inherently prevents unhandled input from being dispatched to the underlying viewport in Godot 4. Now, it defaults to `MOUSE_FILTER_IGNORE` to be entirely transparent to clicks, and dynamically switches to `MOUSE_FILTER_PASS` only when a drag operation begins via `NOTIFICATION_DRAG_BEGIN` / `NOTIFICATION_DRAG_END`.