### PR TITLE
Fix Z-order bug on quick load and optimize hot path

### DIFF
--- a/ss_player/ss_internal_player.cpp
+++ b/ss_player/ss_internal_player.cpp
@@ -116,6 +116,7 @@ void SsInternalPlayer::_clear_batch_canvas_items() {
         rs->free_rid(_batch_canvas_items[i]);
     }
     _batch_canvas_items.clear();
+    _batch_canvas_items_in_use = 0;
     _blend_materials.clear();
 }
 
@@ -132,6 +133,7 @@ RID SsInternalPlayer::_ensure_batch_ci(int batch_idx) {
 void SsInternalPlayer::setSSABResource(const Ref<SSABResource>& ssabRes) {
     _ssabRes = ssabRes;
     _strAnimationSelected = "";
+    _animationSelectedHash = 0;
 
     if (!_ssabRes.is_null()) {
         if (!_ssabRes->is_valid()) {
@@ -621,7 +623,10 @@ void SsInternalPlayer::_free_mask_targets() {
     _mask_canvas_items_in_use = 0;
     _mask_write_materials.clear();
     _mask_write_materials_in_use = 0;
-    if (_mask_canvas.is_valid()) { rs->free_rid(_mask_canvas); _mask_canvas = RID(); }
+    if (_mask_canvas.is_valid()) {
+        rs->free_rid(_mask_canvas);
+        _mask_canvas = RID();
+    }
     if (_mask_viewport.is_valid()) { rs->free_rid(_mask_viewport); _mask_viewport = RID(); }
     _mask_write_shader = Ref<Shader>();
     _mask_coverage_valid = false;
@@ -940,7 +945,7 @@ void SsInternalPlayer::_drawAnimation(float frame_no, float delta_seconds, bool 
     const uint32_t batch_count = draw_batches->size();
 
     // Hide / clear unused entries in the pool (peak-retain policy).
-    for (int i = (int)batch_count; i < _batch_canvas_items.size(); i++) {
+    for (int i = (int)batch_count; i < _batch_canvas_items_in_use; i++) {
         f.rs->canvas_item_clear(_batch_canvas_items[i]);
         f.rs->canvas_item_set_visible(_batch_canvas_items[i], false);
     }
@@ -1012,6 +1017,8 @@ void SsInternalPlayer::_drawAnimation(float frame_no, float delta_seconds, bool 
         }
         // DrawBatchKind_Text / Nines / Mask: not yet implemented.
     }
+
+    _batch_canvas_items_in_use = (int)batch_count;
 }
 
 
@@ -2221,6 +2228,7 @@ void SsInternalPlayer::_fetchAnimation() {
         _clear_effect_slots();
         _clear_batch_canvas_items();
         _free_per_part_canvas_items();
+        _free_mask_targets();
         return;
     }
 
@@ -2228,6 +2236,7 @@ void SsInternalPlayer::_fetchAnimation() {
     _clear_effect_slots();
     _clear_batch_canvas_items();
     _free_per_part_canvas_items();
+    _free_mask_targets();
 
     if (runtime_res != nullptr) {
         ss_resource_destroy(runtime_res);
@@ -2255,7 +2264,9 @@ void SsInternalPlayer::_fetchAnimation() {
         if (animation && animation->name()) {
             _strAnimationSelected = String::utf8(animation->name()->c_str());
         }
-    } else if (!_strAnimationSelected.is_empty()) {
+    }
+    
+    if (!animation && !_strAnimationSelected.is_empty()) {
         animation = _ssabRes->find_animation(_strAnimationSelected);
         if (animation) {
             _animationSelectedHash = animation->name_hash();

--- a/ss_player/ss_internal_player.h
+++ b/ss_player/ss_internal_player.h
@@ -265,6 +265,7 @@ private:
     // across frames; pool grows monotonically to peak batch count, unused
     // entries are hidden rather than freed.
     Vector<RID> _batch_canvas_items;
+    int _batch_canvas_items_in_use = 0;
     LocalVector<const ss::runtime::PartState*> _parts_by_idx;
     String _strAnimationSelected;
     uint32_t _animationSelectedHash = 0;

--- a/ss_player/ssab_resource.cpp
+++ b/ss_player/ssab_resource.cpp
@@ -224,7 +224,7 @@ Error SSABResource::copy_from(const Ref<Resource> &p_resource) {
 Variant SSABResourceFormatLoader::_load(const String &path,
                                                  const String &original_path,
                                                  bool use_sub_threads,
-                                                 int32_t cache_mode) {
+                                                 int32_t cache_mode) const {
 #else
 Ref<Resource> SSABResourceFormatLoader::load(const String &path,
                                                        const String &original_path,
@@ -250,7 +250,7 @@ Ref<Resource> SSABResourceFormatLoader::load(const String &path,
 }
 
 #ifdef SPRITESTUDIO_GODOT_EXTENSION
-PackedStringArray SSABResourceFormatLoader::_get_recognized_extensions() {
+PackedStringArray SSABResourceFormatLoader::_get_recognized_extensions() const {
   PackedStringArray extensions;
   extensions.push_back("ssab");
   return extensions;
@@ -262,7 +262,7 @@ void SSABResourceFormatLoader::get_recognized_extensions(List<String> *extension
 #endif
 
 #ifdef SPRITESTUDIO_GODOT_EXTENSION
-String SSABResourceFormatLoader::_get_resource_type(const String &path) {
+String SSABResourceFormatLoader::_get_resource_type(const String &path) const {
 #else
 String SSABResourceFormatLoader::get_resource_type(const String &path) const {
 #endif
@@ -270,7 +270,7 @@ String SSABResourceFormatLoader::get_resource_type(const String &path) const {
 }
 
 #ifdef SPRITESTUDIO_GODOT_EXTENSION
-bool SSABResourceFormatLoader::_handles_type(const StringName &type) {
+bool SSABResourceFormatLoader::_handles_type(const StringName &type) const {
 #else
 bool SSABResourceFormatLoader::handles_type(const String &type) const {
 #endif
@@ -288,7 +288,7 @@ Error SSABResourceFormatSaver::save(const Ref<Resource> &resource, const String 
 }
 
 #ifdef SPRITESTUDIO_GODOT_EXTENSION
-PackedStringArray SSABResourceFormatSaver::_get_recognized_extensions(const Ref<Resource> &resource) {
+PackedStringArray SSABResourceFormatSaver::_get_recognized_extensions(const Ref<Resource> &resource) const {
   PackedStringArray extensions;
   if (Object::cast_to<SSABResource>(*resource)) {
     extensions.push_back("ssab");
@@ -304,7 +304,7 @@ void SSABResourceFormatSaver::get_recognized_extensions(const Ref<Resource> &res
 #endif
 
 #ifdef SPRITESTUDIO_GODOT_EXTENSION
-bool SSABResourceFormatSaver::_recognize(const Ref<Resource> &resource) {
+bool SSABResourceFormatSaver::_recognize(const Ref<Resource> &resource) const {
 #else
 bool SSABResourceFormatSaver::recognize(const Ref<Resource> &resource) const {
 #endif

--- a/ss_player/ssab_resource.h
+++ b/ss_player/ssab_resource.h
@@ -65,14 +65,14 @@ public:
 #ifdef SPRITESTUDIO_GODOT_EXTENSION
   static void _bind_methods() {};
 
-  PackedStringArray _get_recognized_extensions();
+  PackedStringArray _get_recognized_extensions() const;
 
-  bool _handles_type(const StringName &type);
+  bool _handles_type(const StringName &type) const;
 
-  String _get_resource_type(const String &path);
+  String _get_resource_type(const String &path) const;
 
   Variant _load(const String &path, const String &original_path,
-                bool use_sub_threads, int32_t cache_mode);
+                bool use_sub_threads, int32_t cache_mode) const;
 #else
   Ref<Resource> load(const String &path, const String &original_path,
                      Error *error, bool use_sub_threads, float *progress,
@@ -96,9 +96,9 @@ public:
   Error _save(const Ref<Resource> &resource, const String &path,
               uint32_t flags) override;
 
-  bool _recognize(const Ref<Resource> &resource);
+  bool _recognize(const Ref<Resource> &resource) const;
 
-  PackedStringArray _get_recognized_extensions(const Ref<Resource> &resource);
+  PackedStringArray _get_recognized_extensions(const Ref<Resource> &resource) const;
 #else
   Error save(const Ref<Resource> &resource, const String &path,
              uint32_t flags) override;

--- a/ss_player/ssqb_resource.cpp
+++ b/ss_player/ssqb_resource.cpp
@@ -74,7 +74,7 @@ Error SSQBResource::copy_from(const Ref<Resource> &p_resource) {
 Variant SSQBResourceFormatLoader::_load(const String &path,
                                           const String &original_path,
                                           bool use_sub_threads,
-                                          int32_t cache_mode) {
+                                          int32_t cache_mode) const {
 #else
 Ref<Resource> SSQBResourceFormatLoader::load(
     const String &path, const String &original_path, Error *error,
@@ -98,7 +98,7 @@ Ref<Resource> SSQBResourceFormatLoader::load(
 }
 
 #ifdef SPRITESTUDIO_GODOT_EXTENSION
-PackedStringArray SSQBResourceFormatLoader::_get_recognized_extensions() {
+PackedStringArray SSQBResourceFormatLoader::_get_recognized_extensions() const {
   PackedStringArray extensions;
   extensions.push_back("ssqb");
   return extensions;
@@ -111,7 +111,7 @@ void SSQBResourceFormatLoader::get_recognized_extensions(
 #endif
 
 #ifdef SPRITESTUDIO_GODOT_EXTENSION
-String SSQBResourceFormatLoader::_get_resource_type(const String &path) {
+String SSQBResourceFormatLoader::_get_resource_type(const String &path) const {
 #else
 String SSQBResourceFormatLoader::get_resource_type(const String &path) const {
 #endif
@@ -119,7 +119,7 @@ String SSQBResourceFormatLoader::get_resource_type(const String &path) const {
 }
 
 #ifdef SPRITESTUDIO_GODOT_EXTENSION
-bool SSQBResourceFormatLoader::_handles_type(const StringName &type) {
+bool SSQBResourceFormatLoader::_handles_type(const StringName &type) const {
 #else
 bool SSQBResourceFormatLoader::handles_type(const String &type) const {
 #endif
@@ -141,7 +141,7 @@ Error SSQBResourceFormatSaver::save(const Ref<Resource> &resource,
 
 #ifdef SPRITESTUDIO_GODOT_EXTENSION
 PackedStringArray SSQBResourceFormatSaver::_get_recognized_extensions(
-    const Ref<Resource> &resource) {
+    const Ref<Resource> &resource) const {
   PackedStringArray extensions;
   if (Object::cast_to<SSQBResource>(*resource)) {
     extensions.push_back("ssqb");
@@ -158,7 +158,7 @@ void SSQBResourceFormatSaver::get_recognized_extensions(
 #endif
 
 #ifdef SPRITESTUDIO_GODOT_EXTENSION
-bool SSQBResourceFormatSaver::_recognize(const Ref<Resource> &resource) {
+bool SSQBResourceFormatSaver::_recognize(const Ref<Resource> &resource) const {
 #else
 bool SSQBResourceFormatSaver::recognize(const Ref<Resource> &resource) const {
 #endif

--- a/ss_player/ssqb_resource.h
+++ b/ss_player/ssqb_resource.h
@@ -48,14 +48,14 @@ public:
 #ifdef SPRITESTUDIO_GODOT_EXTENSION
   static void _bind_methods() {};
 
-  PackedStringArray _get_recognized_extensions();
+  PackedStringArray _get_recognized_extensions() const;
 
-  bool _handles_type(const StringName &type);
+  bool _handles_type(const StringName &type) const;
 
-  String _get_resource_type(const String &path);
+  String _get_resource_type(const String &path) const;
 
   Variant _load(const String &path, const String &original_path,
-                bool use_sub_threads, int32_t cache_mode);
+                bool use_sub_threads, int32_t cache_mode) const;
 #else
   Ref<Resource> load(const String &path, const String &original_path,
                      Error *error, bool use_sub_threads, float *progress,
@@ -79,9 +79,9 @@ public:
   Error _save(const Ref<Resource> &resource, const String &path,
               uint32_t flags) override;
 
-  bool _recognize(const Ref<Resource> &resource);
+  bool _recognize(const Ref<Resource> &resource) const;
 
-  PackedStringArray _get_recognized_extensions(const Ref<Resource> &resource);
+  PackedStringArray _get_recognized_extensions(const Ref<Resource> &resource) const;
 #else
   Error save(const Ref<Resource> &resource, const String &path,
              uint32_t flags) override;


### PR DESCRIPTION
### 概要
- クイックロード時に古いアニメーションのマスクキャンバス（`_mask_canvas`）やそのステートが `RenderingServer` 内にリークし、次のアニメーション（特にインスタンスパーツ）のZソートや階層を破壊していたバグを修正しました。
- `_drawAnimation` のホットパスにあった不要な二重ループを削除し、パーツ数が減った差分だけを非表示にする最適な形に戻しました。

### 変更点
- `_fetchAnimation` 内で `_free_mask_targets()` を呼ぶように追加し、アニメーション切り替え時にマスク状態を確実にリセット
- `_free_mask_targets()` 内に `_mask_canvas` の `free_rid` 処理を追加（メモリリークの修正）
- `_drawAnimation` の前半のループを `_batch_canvas_items_in_use` までの差分更新に縮小し、完全に冗長だった後半のループを削除

### テスト
- Walk_Gate.ssab から Instance_Maid.ssab の順にクイックロードしても、Maid のパーツのZオーダーが崩れないことを確認。