### PR TITLE
Update SSAB Schema: Remove redundant combined hashes and restore ExternalInstance.anime_name

### DIFF
--- a/examples/dev_module/node_2d.tscn
+++ b/examples/dev_module/node_2d.tscn
@@ -1,0 +1,15 @@
+[gd_scene format=3 uid="uid://crm5d340adlbm"]
+
+[ext_resource type="SSABResource" uid="uid://bxou6b7daw1se" path="res://ssab_generated/Mask/True_Light.ssab" id="1_wtcfe"]
+
+[node name="Node2D" type="Node2D" unique_id=1299694310]
+
+[node name="00_spr_03_action_01_level3" type="SpriteStudioPlayer2D" parent="." unique_id=222078339]
+position = Vector2(564, 609)
+ssab = ExtResource("1_wtcfe")
+animation = "True_light"
+playing = false
+animation_section_start = 0
+animation_section_end = 120
+sub_frame_enabled = true
+cellmaps/Mask_parts = null

--- a/ss_player/format/ssab.h
+++ b/ss_player/format/ssab.h
@@ -5840,15 +5840,37 @@ inline ::flatbuffers::Offset<PartTypeNines> CreatePartTypeNines(
 struct PartTypeInstance FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
   typedef PartTypeInstanceBuilder Builder;
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
-    VT_REF_ANIME_HASH = 4
+    VT_REF_ANIME_PACK_AND_NAME_HASH = 4,
+    VT_REF_ANIME_PACK = 6,
+    VT_REF_ANIME_PACK_HASH = 8,
+    VT_REF_ANIME_NAME = 10,
+    VT_REF_ANIME_NAME_HASH = 12
   };
-  uint32_t ref_anime_hash() const {
-    return GetField<uint32_t>(VT_REF_ANIME_HASH, 0);
+  uint32_t ref_anime_pack_and_name_hash() const {
+    return GetField<uint32_t>(VT_REF_ANIME_PACK_AND_NAME_HASH, 0);
+  }
+  const ::flatbuffers::String *ref_anime_pack() const {
+    return GetPointer<const ::flatbuffers::String *>(VT_REF_ANIME_PACK);
+  }
+  uint32_t ref_anime_pack_hash() const {
+    return GetField<uint32_t>(VT_REF_ANIME_PACK_HASH, 0);
+  }
+  const ::flatbuffers::String *ref_anime_name() const {
+    return GetPointer<const ::flatbuffers::String *>(VT_REF_ANIME_NAME);
+  }
+  uint32_t ref_anime_name_hash() const {
+    return GetField<uint32_t>(VT_REF_ANIME_NAME_HASH, 0);
   }
   template <bool B = false>
   bool Verify(::flatbuffers::VerifierTemplate<B> &verifier) const {
     return VerifyTableStart(verifier) &&
-           VerifyField<uint32_t>(verifier, VT_REF_ANIME_HASH, 4) &&
+           VerifyField<uint32_t>(verifier, VT_REF_ANIME_PACK_AND_NAME_HASH, 4) &&
+           VerifyOffset(verifier, VT_REF_ANIME_PACK) &&
+           verifier.VerifyString(ref_anime_pack()) &&
+           VerifyField<uint32_t>(verifier, VT_REF_ANIME_PACK_HASH, 4) &&
+           VerifyOffset(verifier, VT_REF_ANIME_NAME) &&
+           verifier.VerifyString(ref_anime_name()) &&
+           VerifyField<uint32_t>(verifier, VT_REF_ANIME_NAME_HASH, 4) &&
            verifier.EndTable();
   }
 };
@@ -5857,8 +5879,20 @@ struct PartTypeInstanceBuilder {
   typedef PartTypeInstance Table;
   ::flatbuffers::FlatBufferBuilder &fbb_;
   ::flatbuffers::uoffset_t start_;
-  void add_ref_anime_hash(uint32_t ref_anime_hash) {
-    fbb_.AddElement<uint32_t>(PartTypeInstance::VT_REF_ANIME_HASH, ref_anime_hash, 0);
+  void add_ref_anime_pack_and_name_hash(uint32_t ref_anime_pack_and_name_hash) {
+    fbb_.AddElement<uint32_t>(PartTypeInstance::VT_REF_ANIME_PACK_AND_NAME_HASH, ref_anime_pack_and_name_hash, 0);
+  }
+  void add_ref_anime_pack(::flatbuffers::Offset<::flatbuffers::String> ref_anime_pack) {
+    fbb_.AddOffset(PartTypeInstance::VT_REF_ANIME_PACK, ref_anime_pack);
+  }
+  void add_ref_anime_pack_hash(uint32_t ref_anime_pack_hash) {
+    fbb_.AddElement<uint32_t>(PartTypeInstance::VT_REF_ANIME_PACK_HASH, ref_anime_pack_hash, 0);
+  }
+  void add_ref_anime_name(::flatbuffers::Offset<::flatbuffers::String> ref_anime_name) {
+    fbb_.AddOffset(PartTypeInstance::VT_REF_ANIME_NAME, ref_anime_name);
+  }
+  void add_ref_anime_name_hash(uint32_t ref_anime_name_hash) {
+    fbb_.AddElement<uint32_t>(PartTypeInstance::VT_REF_ANIME_NAME_HASH, ref_anime_name_hash, 0);
   }
   explicit PartTypeInstanceBuilder(::flatbuffers::FlatBufferBuilder &_fbb)
         : fbb_(_fbb) {
@@ -5873,10 +5907,36 @@ struct PartTypeInstanceBuilder {
 
 inline ::flatbuffers::Offset<PartTypeInstance> CreatePartTypeInstance(
     ::flatbuffers::FlatBufferBuilder &_fbb,
-    uint32_t ref_anime_hash = 0) {
+    uint32_t ref_anime_pack_and_name_hash = 0,
+    ::flatbuffers::Offset<::flatbuffers::String> ref_anime_pack = 0,
+    uint32_t ref_anime_pack_hash = 0,
+    ::flatbuffers::Offset<::flatbuffers::String> ref_anime_name = 0,
+    uint32_t ref_anime_name_hash = 0) {
   PartTypeInstanceBuilder builder_(_fbb);
-  builder_.add_ref_anime_hash(ref_anime_hash);
+  builder_.add_ref_anime_name_hash(ref_anime_name_hash);
+  builder_.add_ref_anime_name(ref_anime_name);
+  builder_.add_ref_anime_pack_hash(ref_anime_pack_hash);
+  builder_.add_ref_anime_pack(ref_anime_pack);
+  builder_.add_ref_anime_pack_and_name_hash(ref_anime_pack_and_name_hash);
   return builder_.Finish();
+}
+
+inline ::flatbuffers::Offset<PartTypeInstance> CreatePartTypeInstanceDirect(
+    ::flatbuffers::FlatBufferBuilder &_fbb,
+    uint32_t ref_anime_pack_and_name_hash = 0,
+    const char *ref_anime_pack = nullptr,
+    uint32_t ref_anime_pack_hash = 0,
+    const char *ref_anime_name = nullptr,
+    uint32_t ref_anime_name_hash = 0) {
+  auto ref_anime_pack__ = ref_anime_pack ? _fbb.CreateString(ref_anime_pack) : 0;
+  auto ref_anime_name__ = ref_anime_name ? _fbb.CreateString(ref_anime_name) : 0;
+  return ss::format::CreatePartTypeInstance(
+      _fbb,
+      ref_anime_pack_and_name_hash,
+      ref_anime_pack__,
+      ref_anime_pack_hash,
+      ref_anime_name__,
+      ref_anime_name_hash);
 }
 
 struct PartTypeEffect FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
@@ -8041,22 +8101,18 @@ inline ::flatbuffers::Offset<ExternalTexture> CreateExternalTextureDirect(
 struct ExternalInstance FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
   typedef ExternalInstanceBuilder Builder;
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
-    VT_ANIME_NAME_HASH = 4,
-    VT_ANIME_PACK_NAME_HASH = 6,
-    VT_ANIME_PACK_NAME = 8,
-    VT_ANIME_NAME = 10
+    VT_ANIME_PACK_AND_NAME_HASH = 4,
+    VT_ANIME_PACK_NAME = 6,
+    VT_ANIME_NAME = 8
   };
-  uint32_t anime_name_hash() const {
-    return GetField<uint32_t>(VT_ANIME_NAME_HASH, 0);
+  uint32_t anime_pack_and_name_hash() const {
+    return GetField<uint32_t>(VT_ANIME_PACK_AND_NAME_HASH, 0);
   }
   bool KeyCompareLessThan(const ExternalInstance * const o) const {
-    return anime_name_hash() < o->anime_name_hash();
+    return anime_pack_and_name_hash() < o->anime_pack_and_name_hash();
   }
-  int KeyCompareWithValue(uint32_t _anime_name_hash) const {
-    return static_cast<int>(anime_name_hash() > _anime_name_hash) - static_cast<int>(anime_name_hash() < _anime_name_hash);
-  }
-  uint32_t anime_pack_name_hash() const {
-    return GetField<uint32_t>(VT_ANIME_PACK_NAME_HASH, 0);
+  int KeyCompareWithValue(uint32_t _anime_pack_and_name_hash) const {
+    return static_cast<int>(anime_pack_and_name_hash() > _anime_pack_and_name_hash) - static_cast<int>(anime_pack_and_name_hash() < _anime_pack_and_name_hash);
   }
   const ::flatbuffers::String *anime_pack_name() const {
     return GetPointer<const ::flatbuffers::String *>(VT_ANIME_PACK_NAME);
@@ -8067,8 +8123,7 @@ struct ExternalInstance FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
   template <bool B = false>
   bool Verify(::flatbuffers::VerifierTemplate<B> &verifier) const {
     return VerifyTableStart(verifier) &&
-           VerifyField<uint32_t>(verifier, VT_ANIME_NAME_HASH, 4) &&
-           VerifyField<uint32_t>(verifier, VT_ANIME_PACK_NAME_HASH, 4) &&
+           VerifyField<uint32_t>(verifier, VT_ANIME_PACK_AND_NAME_HASH, 4) &&
            VerifyOffset(verifier, VT_ANIME_PACK_NAME) &&
            verifier.VerifyString(anime_pack_name()) &&
            VerifyOffset(verifier, VT_ANIME_NAME) &&
@@ -8081,11 +8136,8 @@ struct ExternalInstanceBuilder {
   typedef ExternalInstance Table;
   ::flatbuffers::FlatBufferBuilder &fbb_;
   ::flatbuffers::uoffset_t start_;
-  void add_anime_name_hash(uint32_t anime_name_hash) {
-    fbb_.AddElement<uint32_t>(ExternalInstance::VT_ANIME_NAME_HASH, anime_name_hash, 0);
-  }
-  void add_anime_pack_name_hash(uint32_t anime_pack_name_hash) {
-    fbb_.AddElement<uint32_t>(ExternalInstance::VT_ANIME_PACK_NAME_HASH, anime_pack_name_hash, 0);
+  void add_anime_pack_and_name_hash(uint32_t anime_pack_and_name_hash) {
+    fbb_.AddElement<uint32_t>(ExternalInstance::VT_ANIME_PACK_AND_NAME_HASH, anime_pack_and_name_hash, 0);
   }
   void add_anime_pack_name(::flatbuffers::Offset<::flatbuffers::String> anime_pack_name) {
     fbb_.AddOffset(ExternalInstance::VT_ANIME_PACK_NAME, anime_pack_name);
@@ -8106,30 +8158,26 @@ struct ExternalInstanceBuilder {
 
 inline ::flatbuffers::Offset<ExternalInstance> CreateExternalInstance(
     ::flatbuffers::FlatBufferBuilder &_fbb,
-    uint32_t anime_name_hash = 0,
-    uint32_t anime_pack_name_hash = 0,
+    uint32_t anime_pack_and_name_hash = 0,
     ::flatbuffers::Offset<::flatbuffers::String> anime_pack_name = 0,
     ::flatbuffers::Offset<::flatbuffers::String> anime_name = 0) {
   ExternalInstanceBuilder builder_(_fbb);
   builder_.add_anime_name(anime_name);
   builder_.add_anime_pack_name(anime_pack_name);
-  builder_.add_anime_pack_name_hash(anime_pack_name_hash);
-  builder_.add_anime_name_hash(anime_name_hash);
+  builder_.add_anime_pack_and_name_hash(anime_pack_and_name_hash);
   return builder_.Finish();
 }
 
 inline ::flatbuffers::Offset<ExternalInstance> CreateExternalInstanceDirect(
     ::flatbuffers::FlatBufferBuilder &_fbb,
-    uint32_t anime_name_hash = 0,
-    uint32_t anime_pack_name_hash = 0,
+    uint32_t anime_pack_and_name_hash = 0,
     const char *anime_pack_name = nullptr,
     const char *anime_name = nullptr) {
   auto anime_pack_name__ = anime_pack_name ? _fbb.CreateString(anime_pack_name) : 0;
   auto anime_name__ = anime_name ? _fbb.CreateString(anime_name) : 0;
   return ss::format::CreateExternalInstance(
       _fbb,
-      anime_name_hash,
-      anime_pack_name_hash,
+      anime_pack_and_name_hash,
       anime_pack_name__,
       anime_name__);
 }

--- a/ss_player/format/ssab.h
+++ b/ss_player/format/ssab.h
@@ -5840,15 +5840,11 @@ inline ::flatbuffers::Offset<PartTypeNines> CreatePartTypeNines(
 struct PartTypeInstance FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
   typedef PartTypeInstanceBuilder Builder;
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
-    VT_REF_ANIME_PACK_AND_NAME_HASH = 4,
-    VT_REF_ANIME_PACK = 6,
-    VT_REF_ANIME_PACK_HASH = 8,
-    VT_REF_ANIME_NAME = 10,
-    VT_REF_ANIME_NAME_HASH = 12
+    VT_REF_ANIME_PACK = 4,
+    VT_REF_ANIME_PACK_HASH = 6,
+    VT_REF_ANIME_NAME = 8,
+    VT_REF_ANIME_NAME_HASH = 10
   };
-  uint32_t ref_anime_pack_and_name_hash() const {
-    return GetField<uint32_t>(VT_REF_ANIME_PACK_AND_NAME_HASH, 0);
-  }
   const ::flatbuffers::String *ref_anime_pack() const {
     return GetPointer<const ::flatbuffers::String *>(VT_REF_ANIME_PACK);
   }
@@ -5864,7 +5860,6 @@ struct PartTypeInstance FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
   template <bool B = false>
   bool Verify(::flatbuffers::VerifierTemplate<B> &verifier) const {
     return VerifyTableStart(verifier) &&
-           VerifyField<uint32_t>(verifier, VT_REF_ANIME_PACK_AND_NAME_HASH, 4) &&
            VerifyOffset(verifier, VT_REF_ANIME_PACK) &&
            verifier.VerifyString(ref_anime_pack()) &&
            VerifyField<uint32_t>(verifier, VT_REF_ANIME_PACK_HASH, 4) &&
@@ -5879,9 +5874,6 @@ struct PartTypeInstanceBuilder {
   typedef PartTypeInstance Table;
   ::flatbuffers::FlatBufferBuilder &fbb_;
   ::flatbuffers::uoffset_t start_;
-  void add_ref_anime_pack_and_name_hash(uint32_t ref_anime_pack_and_name_hash) {
-    fbb_.AddElement<uint32_t>(PartTypeInstance::VT_REF_ANIME_PACK_AND_NAME_HASH, ref_anime_pack_and_name_hash, 0);
-  }
   void add_ref_anime_pack(::flatbuffers::Offset<::flatbuffers::String> ref_anime_pack) {
     fbb_.AddOffset(PartTypeInstance::VT_REF_ANIME_PACK, ref_anime_pack);
   }
@@ -5907,7 +5899,6 @@ struct PartTypeInstanceBuilder {
 
 inline ::flatbuffers::Offset<PartTypeInstance> CreatePartTypeInstance(
     ::flatbuffers::FlatBufferBuilder &_fbb,
-    uint32_t ref_anime_pack_and_name_hash = 0,
     ::flatbuffers::Offset<::flatbuffers::String> ref_anime_pack = 0,
     uint32_t ref_anime_pack_hash = 0,
     ::flatbuffers::Offset<::flatbuffers::String> ref_anime_name = 0,
@@ -5917,13 +5908,11 @@ inline ::flatbuffers::Offset<PartTypeInstance> CreatePartTypeInstance(
   builder_.add_ref_anime_name(ref_anime_name);
   builder_.add_ref_anime_pack_hash(ref_anime_pack_hash);
   builder_.add_ref_anime_pack(ref_anime_pack);
-  builder_.add_ref_anime_pack_and_name_hash(ref_anime_pack_and_name_hash);
   return builder_.Finish();
 }
 
 inline ::flatbuffers::Offset<PartTypeInstance> CreatePartTypeInstanceDirect(
     ::flatbuffers::FlatBufferBuilder &_fbb,
-    uint32_t ref_anime_pack_and_name_hash = 0,
     const char *ref_anime_pack = nullptr,
     uint32_t ref_anime_pack_hash = 0,
     const char *ref_anime_name = nullptr,
@@ -5932,7 +5921,6 @@ inline ::flatbuffers::Offset<PartTypeInstance> CreatePartTypeInstanceDirect(
   auto ref_anime_name__ = ref_anime_name ? _fbb.CreateString(ref_anime_name) : 0;
   return ss::format::CreatePartTypeInstance(
       _fbb,
-      ref_anime_pack_and_name_hash,
       ref_anime_pack__,
       ref_anime_pack_hash,
       ref_anime_name__,
@@ -8101,33 +8089,27 @@ inline ::flatbuffers::Offset<ExternalTexture> CreateExternalTextureDirect(
 struct ExternalInstance FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
   typedef ExternalInstanceBuilder Builder;
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
-    VT_ANIME_PACK_AND_NAME_HASH = 4,
-    VT_ANIME_PACK_NAME = 6,
-    VT_ANIME_NAME = 8
+    VT_ANIME_PACK_NAME_HASH = 4,
+    VT_ANIME_PACK_NAME = 6
   };
-  uint32_t anime_pack_and_name_hash() const {
-    return GetField<uint32_t>(VT_ANIME_PACK_AND_NAME_HASH, 0);
+  uint32_t anime_pack_name_hash() const {
+    return GetField<uint32_t>(VT_ANIME_PACK_NAME_HASH, 0);
   }
   bool KeyCompareLessThan(const ExternalInstance * const o) const {
-    return anime_pack_and_name_hash() < o->anime_pack_and_name_hash();
+    return anime_pack_name_hash() < o->anime_pack_name_hash();
   }
-  int KeyCompareWithValue(uint32_t _anime_pack_and_name_hash) const {
-    return static_cast<int>(anime_pack_and_name_hash() > _anime_pack_and_name_hash) - static_cast<int>(anime_pack_and_name_hash() < _anime_pack_and_name_hash);
+  int KeyCompareWithValue(uint32_t _anime_pack_name_hash) const {
+    return static_cast<int>(anime_pack_name_hash() > _anime_pack_name_hash) - static_cast<int>(anime_pack_name_hash() < _anime_pack_name_hash);
   }
   const ::flatbuffers::String *anime_pack_name() const {
     return GetPointer<const ::flatbuffers::String *>(VT_ANIME_PACK_NAME);
   }
-  const ::flatbuffers::String *anime_name() const {
-    return GetPointer<const ::flatbuffers::String *>(VT_ANIME_NAME);
-  }
   template <bool B = false>
   bool Verify(::flatbuffers::VerifierTemplate<B> &verifier) const {
     return VerifyTableStart(verifier) &&
-           VerifyField<uint32_t>(verifier, VT_ANIME_PACK_AND_NAME_HASH, 4) &&
+           VerifyField<uint32_t>(verifier, VT_ANIME_PACK_NAME_HASH, 4) &&
            VerifyOffset(verifier, VT_ANIME_PACK_NAME) &&
            verifier.VerifyString(anime_pack_name()) &&
-           VerifyOffset(verifier, VT_ANIME_NAME) &&
-           verifier.VerifyString(anime_name()) &&
            verifier.EndTable();
   }
 };
@@ -8136,14 +8118,11 @@ struct ExternalInstanceBuilder {
   typedef ExternalInstance Table;
   ::flatbuffers::FlatBufferBuilder &fbb_;
   ::flatbuffers::uoffset_t start_;
-  void add_anime_pack_and_name_hash(uint32_t anime_pack_and_name_hash) {
-    fbb_.AddElement<uint32_t>(ExternalInstance::VT_ANIME_PACK_AND_NAME_HASH, anime_pack_and_name_hash, 0);
+  void add_anime_pack_name_hash(uint32_t anime_pack_name_hash) {
+    fbb_.AddElement<uint32_t>(ExternalInstance::VT_ANIME_PACK_NAME_HASH, anime_pack_name_hash, 0);
   }
   void add_anime_pack_name(::flatbuffers::Offset<::flatbuffers::String> anime_pack_name) {
     fbb_.AddOffset(ExternalInstance::VT_ANIME_PACK_NAME, anime_pack_name);
-  }
-  void add_anime_name(::flatbuffers::Offset<::flatbuffers::String> anime_name) {
-    fbb_.AddOffset(ExternalInstance::VT_ANIME_NAME, anime_name);
   }
   explicit ExternalInstanceBuilder(::flatbuffers::FlatBufferBuilder &_fbb)
         : fbb_(_fbb) {
@@ -8158,28 +8137,23 @@ struct ExternalInstanceBuilder {
 
 inline ::flatbuffers::Offset<ExternalInstance> CreateExternalInstance(
     ::flatbuffers::FlatBufferBuilder &_fbb,
-    uint32_t anime_pack_and_name_hash = 0,
-    ::flatbuffers::Offset<::flatbuffers::String> anime_pack_name = 0,
-    ::flatbuffers::Offset<::flatbuffers::String> anime_name = 0) {
+    uint32_t anime_pack_name_hash = 0,
+    ::flatbuffers::Offset<::flatbuffers::String> anime_pack_name = 0) {
   ExternalInstanceBuilder builder_(_fbb);
-  builder_.add_anime_name(anime_name);
   builder_.add_anime_pack_name(anime_pack_name);
-  builder_.add_anime_pack_and_name_hash(anime_pack_and_name_hash);
+  builder_.add_anime_pack_name_hash(anime_pack_name_hash);
   return builder_.Finish();
 }
 
 inline ::flatbuffers::Offset<ExternalInstance> CreateExternalInstanceDirect(
     ::flatbuffers::FlatBufferBuilder &_fbb,
-    uint32_t anime_pack_and_name_hash = 0,
-    const char *anime_pack_name = nullptr,
-    const char *anime_name = nullptr) {
+    uint32_t anime_pack_name_hash = 0,
+    const char *anime_pack_name = nullptr) {
   auto anime_pack_name__ = anime_pack_name ? _fbb.CreateString(anime_pack_name) : 0;
-  auto anime_name__ = anime_name ? _fbb.CreateString(anime_name) : 0;
   return ss::format::CreateExternalInstance(
       _fbb,
-      anime_pack_and_name_hash,
-      anime_pack_name__,
-      anime_name__);
+      anime_pack_name_hash,
+      anime_pack_name__);
 }
 
 struct EmbeddedAsset FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {

--- a/ss_player/format/ssqb.h
+++ b/ss_player/format/ssqb.h
@@ -61,16 +61,12 @@ inline const char *EnumNameSequenceType(SequenceType e) {
 struct SequenceItem FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
   typedef SequenceItemBuilder Builder;
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
-    VT_REF_ANIME_PACK_AND_NAME_HASH = 4,
-    VT_REF_ANIME_PACK = 6,
-    VT_REF_ANIME_PACK_HASH = 8,
-    VT_REF_ANIME_NAME = 10,
-    VT_REF_ANIME_NAME_HASH = 12,
-    VT_REPEAT_COUNT = 14
+    VT_REF_ANIME_PACK = 4,
+    VT_REF_ANIME_PACK_HASH = 6,
+    VT_REF_ANIME_NAME = 8,
+    VT_REF_ANIME_NAME_HASH = 10,
+    VT_REPEAT_COUNT = 12
   };
-  uint32_t ref_anime_pack_and_name_hash() const {
-    return GetField<uint32_t>(VT_REF_ANIME_PACK_AND_NAME_HASH, 0);
-  }
   const ::flatbuffers::String *ref_anime_pack() const {
     return GetPointer<const ::flatbuffers::String *>(VT_REF_ANIME_PACK);
   }
@@ -89,7 +85,6 @@ struct SequenceItem FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
   template <bool B = false>
   bool Verify(::flatbuffers::VerifierTemplate<B> &verifier) const {
     return VerifyTableStart(verifier) &&
-           VerifyField<uint32_t>(verifier, VT_REF_ANIME_PACK_AND_NAME_HASH, 4) &&
            VerifyOffset(verifier, VT_REF_ANIME_PACK) &&
            verifier.VerifyString(ref_anime_pack()) &&
            VerifyField<uint32_t>(verifier, VT_REF_ANIME_PACK_HASH, 4) &&
@@ -105,9 +100,6 @@ struct SequenceItemBuilder {
   typedef SequenceItem Table;
   ::flatbuffers::FlatBufferBuilder &fbb_;
   ::flatbuffers::uoffset_t start_;
-  void add_ref_anime_pack_and_name_hash(uint32_t ref_anime_pack_and_name_hash) {
-    fbb_.AddElement<uint32_t>(SequenceItem::VT_REF_ANIME_PACK_AND_NAME_HASH, ref_anime_pack_and_name_hash, 0);
-  }
   void add_ref_anime_pack(::flatbuffers::Offset<::flatbuffers::String> ref_anime_pack) {
     fbb_.AddOffset(SequenceItem::VT_REF_ANIME_PACK, ref_anime_pack);
   }
@@ -136,7 +128,6 @@ struct SequenceItemBuilder {
 
 inline ::flatbuffers::Offset<SequenceItem> CreateSequenceItem(
     ::flatbuffers::FlatBufferBuilder &_fbb,
-    uint32_t ref_anime_pack_and_name_hash = 0,
     ::flatbuffers::Offset<::flatbuffers::String> ref_anime_pack = 0,
     uint32_t ref_anime_pack_hash = 0,
     ::flatbuffers::Offset<::flatbuffers::String> ref_anime_name = 0,
@@ -148,13 +139,11 @@ inline ::flatbuffers::Offset<SequenceItem> CreateSequenceItem(
   builder_.add_ref_anime_name(ref_anime_name);
   builder_.add_ref_anime_pack_hash(ref_anime_pack_hash);
   builder_.add_ref_anime_pack(ref_anime_pack);
-  builder_.add_ref_anime_pack_and_name_hash(ref_anime_pack_and_name_hash);
   return builder_.Finish();
 }
 
 inline ::flatbuffers::Offset<SequenceItem> CreateSequenceItemDirect(
     ::flatbuffers::FlatBufferBuilder &_fbb,
-    uint32_t ref_anime_pack_and_name_hash = 0,
     const char *ref_anime_pack = nullptr,
     uint32_t ref_anime_pack_hash = 0,
     const char *ref_anime_name = nullptr,
@@ -164,7 +153,6 @@ inline ::flatbuffers::Offset<SequenceItem> CreateSequenceItemDirect(
   auto ref_anime_name__ = ref_anime_name ? _fbb.CreateString(ref_anime_name) : 0;
   return ss::format::CreateSequenceItem(
       _fbb,
-      ref_anime_pack_and_name_hash,
       ref_anime_pack__,
       ref_anime_pack_hash,
       ref_anime_name__,

--- a/ss_player/format/ssqb.h
+++ b/ss_player/format/ssqb.h
@@ -61,23 +61,27 @@ inline const char *EnumNameSequenceType(SequenceType e) {
 struct SequenceItem FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
   typedef SequenceItemBuilder Builder;
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
-    VT_REF_ANIME_PACK = 4,
-    VT_REF_ANIME_PACK_HASH = 6,
-    VT_REF_ANIME = 8,
-    VT_REF_ANIME_HASH = 10,
-    VT_REPEAT_COUNT = 12
+    VT_REF_ANIME_PACK_AND_NAME_HASH = 4,
+    VT_REF_ANIME_PACK = 6,
+    VT_REF_ANIME_PACK_HASH = 8,
+    VT_REF_ANIME_NAME = 10,
+    VT_REF_ANIME_NAME_HASH = 12,
+    VT_REPEAT_COUNT = 14
   };
+  uint32_t ref_anime_pack_and_name_hash() const {
+    return GetField<uint32_t>(VT_REF_ANIME_PACK_AND_NAME_HASH, 0);
+  }
   const ::flatbuffers::String *ref_anime_pack() const {
     return GetPointer<const ::flatbuffers::String *>(VT_REF_ANIME_PACK);
   }
   uint32_t ref_anime_pack_hash() const {
     return GetField<uint32_t>(VT_REF_ANIME_PACK_HASH, 0);
   }
-  const ::flatbuffers::String *ref_anime() const {
-    return GetPointer<const ::flatbuffers::String *>(VT_REF_ANIME);
+  const ::flatbuffers::String *ref_anime_name() const {
+    return GetPointer<const ::flatbuffers::String *>(VT_REF_ANIME_NAME);
   }
-  uint32_t ref_anime_hash() const {
-    return GetField<uint32_t>(VT_REF_ANIME_HASH, 0);
+  uint32_t ref_anime_name_hash() const {
+    return GetField<uint32_t>(VT_REF_ANIME_NAME_HASH, 0);
   }
   int32_t repeat_count() const {
     return GetField<int32_t>(VT_REPEAT_COUNT, 0);
@@ -85,12 +89,13 @@ struct SequenceItem FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
   template <bool B = false>
   bool Verify(::flatbuffers::VerifierTemplate<B> &verifier) const {
     return VerifyTableStart(verifier) &&
+           VerifyField<uint32_t>(verifier, VT_REF_ANIME_PACK_AND_NAME_HASH, 4) &&
            VerifyOffset(verifier, VT_REF_ANIME_PACK) &&
            verifier.VerifyString(ref_anime_pack()) &&
            VerifyField<uint32_t>(verifier, VT_REF_ANIME_PACK_HASH, 4) &&
-           VerifyOffset(verifier, VT_REF_ANIME) &&
-           verifier.VerifyString(ref_anime()) &&
-           VerifyField<uint32_t>(verifier, VT_REF_ANIME_HASH, 4) &&
+           VerifyOffset(verifier, VT_REF_ANIME_NAME) &&
+           verifier.VerifyString(ref_anime_name()) &&
+           VerifyField<uint32_t>(verifier, VT_REF_ANIME_NAME_HASH, 4) &&
            VerifyField<int32_t>(verifier, VT_REPEAT_COUNT, 4) &&
            verifier.EndTable();
   }
@@ -100,17 +105,20 @@ struct SequenceItemBuilder {
   typedef SequenceItem Table;
   ::flatbuffers::FlatBufferBuilder &fbb_;
   ::flatbuffers::uoffset_t start_;
+  void add_ref_anime_pack_and_name_hash(uint32_t ref_anime_pack_and_name_hash) {
+    fbb_.AddElement<uint32_t>(SequenceItem::VT_REF_ANIME_PACK_AND_NAME_HASH, ref_anime_pack_and_name_hash, 0);
+  }
   void add_ref_anime_pack(::flatbuffers::Offset<::flatbuffers::String> ref_anime_pack) {
     fbb_.AddOffset(SequenceItem::VT_REF_ANIME_PACK, ref_anime_pack);
   }
   void add_ref_anime_pack_hash(uint32_t ref_anime_pack_hash) {
     fbb_.AddElement<uint32_t>(SequenceItem::VT_REF_ANIME_PACK_HASH, ref_anime_pack_hash, 0);
   }
-  void add_ref_anime(::flatbuffers::Offset<::flatbuffers::String> ref_anime) {
-    fbb_.AddOffset(SequenceItem::VT_REF_ANIME, ref_anime);
+  void add_ref_anime_name(::flatbuffers::Offset<::flatbuffers::String> ref_anime_name) {
+    fbb_.AddOffset(SequenceItem::VT_REF_ANIME_NAME, ref_anime_name);
   }
-  void add_ref_anime_hash(uint32_t ref_anime_hash) {
-    fbb_.AddElement<uint32_t>(SequenceItem::VT_REF_ANIME_HASH, ref_anime_hash, 0);
+  void add_ref_anime_name_hash(uint32_t ref_anime_name_hash) {
+    fbb_.AddElement<uint32_t>(SequenceItem::VT_REF_ANIME_NAME_HASH, ref_anime_name_hash, 0);
   }
   void add_repeat_count(int32_t repeat_count) {
     fbb_.AddElement<int32_t>(SequenceItem::VT_REPEAT_COUNT, repeat_count, 0);
@@ -128,35 +136,39 @@ struct SequenceItemBuilder {
 
 inline ::flatbuffers::Offset<SequenceItem> CreateSequenceItem(
     ::flatbuffers::FlatBufferBuilder &_fbb,
+    uint32_t ref_anime_pack_and_name_hash = 0,
     ::flatbuffers::Offset<::flatbuffers::String> ref_anime_pack = 0,
     uint32_t ref_anime_pack_hash = 0,
-    ::flatbuffers::Offset<::flatbuffers::String> ref_anime = 0,
-    uint32_t ref_anime_hash = 0,
+    ::flatbuffers::Offset<::flatbuffers::String> ref_anime_name = 0,
+    uint32_t ref_anime_name_hash = 0,
     int32_t repeat_count = 0) {
   SequenceItemBuilder builder_(_fbb);
   builder_.add_repeat_count(repeat_count);
-  builder_.add_ref_anime_hash(ref_anime_hash);
-  builder_.add_ref_anime(ref_anime);
+  builder_.add_ref_anime_name_hash(ref_anime_name_hash);
+  builder_.add_ref_anime_name(ref_anime_name);
   builder_.add_ref_anime_pack_hash(ref_anime_pack_hash);
   builder_.add_ref_anime_pack(ref_anime_pack);
+  builder_.add_ref_anime_pack_and_name_hash(ref_anime_pack_and_name_hash);
   return builder_.Finish();
 }
 
 inline ::flatbuffers::Offset<SequenceItem> CreateSequenceItemDirect(
     ::flatbuffers::FlatBufferBuilder &_fbb,
+    uint32_t ref_anime_pack_and_name_hash = 0,
     const char *ref_anime_pack = nullptr,
     uint32_t ref_anime_pack_hash = 0,
-    const char *ref_anime = nullptr,
-    uint32_t ref_anime_hash = 0,
+    const char *ref_anime_name = nullptr,
+    uint32_t ref_anime_name_hash = 0,
     int32_t repeat_count = 0) {
   auto ref_anime_pack__ = ref_anime_pack ? _fbb.CreateString(ref_anime_pack) : 0;
-  auto ref_anime__ = ref_anime ? _fbb.CreateString(ref_anime) : 0;
+  auto ref_anime_name__ = ref_anime_name ? _fbb.CreateString(ref_anime_name) : 0;
   return ss::format::CreateSequenceItem(
       _fbb,
+      ref_anime_pack_and_name_hash,
       ref_anime_pack__,
       ref_anime_pack_hash,
-      ref_anime__,
-      ref_anime_hash,
+      ref_anime_name__,
+      ref_anime_name_hash,
       repeat_count);
 }
 

--- a/ss_player/ss_internal_player.cpp
+++ b/ss_player/ss_internal_player.cpp
@@ -1057,38 +1057,11 @@ void SsInternalPlayer::_drawAnimation(float frame_no, float delta_seconds, bool 
 
 
 
-Ref<SSABResource> SsInternalPlayer::_resolve_ssab_by_hash(uint32_t name_hash) const {
-    if (!_ssabRes.is_null()) {
-        auto binary = _ssabRes->get_ss_anime_binary();
-        if (binary && binary->external_instances()) {
-            const auto* entry = binary->external_instances()->LookupByKey(name_hash);
-            if (entry) {
-                const uint32_t pack_hash = entry->anime_pack_name_hash();
-                if (auto* ext_ptr = _external_ssabs_by_pack_hash.getptr(pack_hash)) {
-                    auto anim = (*ext_ptr)->find_animation_by_hash(name_hash);
-                    if (anim) {
-                        return *ext_ptr;
-                    }
-                }
-            }
-        }
-    }
 
-    if (!_ssabRes.is_null() && _ssabRes->find_animation_by_hash(name_hash)) {
-        return _ssabRes;
-    }
-    for (int i = 0; i < _external_ssabs.size(); i++) {
-        const Ref<SSABResource>& ext = _external_ssabs[i];
-        if (!ext.is_null() && ext->find_animation_by_hash(name_hash)) {
-            return ext;
-        }
-    }
-    return Ref<SSABResource>();
-}
 
 void SsInternalPlayer::_load_external_ssabs() {
     _external_ssabs.clear();
-    _external_ssabs_by_pack_hash.clear();
+    _external_ssabs_by_pack_name.clear();
     if (_ssabRes.is_null()) return;
     auto binary = _ssabRes->get_ss_anime_binary();
     if (!binary) return;
@@ -1099,11 +1072,9 @@ void SsInternalPlayer::_load_external_ssabs() {
     for (uint32_t i = 0; i < exts->size(); i++) {
         auto entry = exts->Get(i);
         if (!entry || !entry->anime_pack_name()) continue;
-        const uint32_t pack_hash = entry->anime_pack_name_hash();
-        if (_external_ssabs_by_pack_hash.has(pack_hash)) continue;
-
         String pack = String::utf8(entry->anime_pack_name()->c_str());
         if (pack.is_empty()) continue;
+        if (_external_ssabs_by_pack_name.has(pack)) continue;
         String path = parent_dir.path_join(pack + ".ssab");
         Ref<Resource> res =
         #ifdef SPRITESTUDIO_GODOT_EXTENSION
@@ -1121,7 +1092,7 @@ void SsInternalPlayer::_load_external_ssabs() {
             continue;
         }
         _external_ssabs.push_back(ssab);
-        _external_ssabs_by_pack_hash[pack_hash] = ssab;
+        _external_ssabs_by_pack_name[pack] = ssab;
     }
 }
 
@@ -1158,10 +1129,28 @@ void SsInternalPlayer::_setup_instance_children() {
         auto pt = p->part_type_as_PartTypeInstance();
         if (!pt) continue;
 
-        uint32_t ref_hash = pt->ref_anime_hash();
-        Ref<SSABResource> source = _resolve_ssab_by_hash(ref_hash);
+        String pack_name = pt->ref_anime_pack() ? String::utf8(pt->ref_anime_pack()->c_str()) : String();
+        String anim_name = pt->ref_anime_name() ? String::utf8(pt->ref_anime_name()->c_str()) : String();
+        uint32_t pack_name_hash = pt->ref_anime_pack_hash();
+        uint32_t anim_name_hash = pt->ref_anime_name_hash();
+
+        Ref<SSABResource> source;
+        if (!_ssabRes.is_null() && _ssabRes->get_ss_anime_binary() && _ssabRes->get_ss_anime_binary()->name_hash() == pack_name_hash) {
+            // パック名ハッシュが自分自身と一致する場合は、内部のSSABから検索
+            if (_ssabRes->find_animation_by_hash(anim_name_hash)) {
+                source = _ssabRes;
+            }
+        } else {
+            // それ以外の場合は外部のSSAB（external）から検索
+            if (auto* ext_ptr = _external_ssabs_by_pack_name.getptr(pack_name)) {
+                if ((*ext_ptr)->find_animation_by_hash(anim_name_hash)) {
+                    source = *ext_ptr;
+                }
+            }
+        }
+
         if (source.is_null()) {
-            ERR_PRINT(vformat("[SS] instance part %d: ref_anime_hash=0x%x not found in current or external SSABs", i, ref_hash));
+            ERR_PRINT(vformat("[SS] instance part %d: animation '%s' (pack '%s') not found in current or external SSABs", i, anim_name, pack_name));
             continue;
         }
 
@@ -1171,7 +1160,7 @@ void SsInternalPlayer::_setup_instance_children() {
         // Hand the child the SSAB that actually contains the referenced
         // animation — may be `_ssabRes` itself or an external sibling.
         child->setSSABResource(source);
-        child->setAnimationByHash(ref_hash);
+        child->setAnimationByHash(anim_name_hash);
         child->stop();
         // Keep the child hidden by default; _update_instance_children flips
         // it visible only once an EventInstance becomes active for the slot.

--- a/ss_player/ss_internal_player.cpp
+++ b/ss_player/ss_internal_player.cpp
@@ -1061,7 +1061,7 @@ void SsInternalPlayer::_drawAnimation(float frame_no, float delta_seconds, bool 
 
 void SsInternalPlayer::_load_external_ssabs() {
     _external_ssabs.clear();
-    _external_ssabs_by_pack_name.clear();
+    _external_ssabs_by_pack_hash.clear();
     if (_ssabRes.is_null()) return;
     auto binary = _ssabRes->get_ss_anime_binary();
     if (!binary) return;
@@ -1069,12 +1069,13 @@ void SsInternalPlayer::_load_external_ssabs() {
 
     auto exts = binary->external_instances();
     String parent_dir = _ssabRes->get_parent_dir();
+    HashSet<String> loaded_packs;
     for (uint32_t i = 0; i < exts->size(); i++) {
         auto entry = exts->Get(i);
         if (!entry || !entry->anime_pack_name()) continue;
         String pack = String::utf8(entry->anime_pack_name()->c_str());
-        if (pack.is_empty()) continue;
-        if (_external_ssabs_by_pack_name.has(pack)) continue;
+        if (pack.is_empty() || loaded_packs.has(pack)) continue;
+        loaded_packs.insert(pack);
         String path = parent_dir.path_join(pack + ".ssab");
         Ref<Resource> res =
         #ifdef SPRITESTUDIO_GODOT_EXTENSION
@@ -1092,7 +1093,9 @@ void SsInternalPlayer::_load_external_ssabs() {
             continue;
         }
         _external_ssabs.push_back(ssab);
-        _external_ssabs_by_pack_name[pack] = ssab;
+        if (ssab->get_ss_anime_binary()) {
+            _external_ssabs_by_pack_hash[ssab->get_ss_anime_binary()->name_hash()] = ssab;
+        }
     }
 }
 
@@ -1142,7 +1145,7 @@ void SsInternalPlayer::_setup_instance_children() {
             }
         } else {
             // それ以外の場合は外部のSSAB（external）から検索
-            if (auto* ext_ptr = _external_ssabs_by_pack_name.getptr(pack_name)) {
+            if (auto* ext_ptr = _external_ssabs_by_pack_hash.getptr(pack_name_hash)) {
                 if ((*ext_ptr)->find_animation_by_hash(anim_name_hash)) {
                     source = *ext_ptr;
                 }

--- a/ss_player/ss_internal_player.h
+++ b/ss_player/ss_internal_player.h
@@ -308,9 +308,9 @@ private:
     // External SSAB resources auto-loaded from the parent's directory based
     // on `external_instances`. Cleared and rebuilt on every setSSABResource.
     Vector<Ref<SSABResource>> _external_ssabs;
-    // Same set as `_external_ssabs`, keyed by SsAnimeBinary.name_hash so
-    // hash-based pack resolution is O(1). Built by `_load_external_ssabs`.
-    HashMap<uint32_t, Ref<SSABResource>> _external_ssabs_by_pack_hash;
+    // Same set as `_external_ssabs`, keyed by pack name so
+    // pack resolution is O(1). Built by `_load_external_ssabs`.
+    HashMap<String, Ref<SSABResource>> _external_ssabs_by_pack_name;
 
     // Per-frame draw context: SoA pointers and frame-shared bindings fetched
     // once at the top of `drawAnimation`.
@@ -615,7 +615,7 @@ private:
     void _seek_and_redraw(float frame_no, float delta_seconds, bool parent_looped);
 
     void _load_external_ssabs();
-    Ref<SSABResource> _resolve_ssab_by_hash(uint32_t name_hash) const;
+
     void _apply_blend_material(RenderingServer* rs, RID ci, ss::format::BlendType blend_type);
     // ShaderMaterial variant for Normal and Mesh batches. PartColor is handled
     // in the shader (per-vertex CUSTOM0 carries rate / blend_idx / pma flag).

--- a/ss_player/ss_internal_player.h
+++ b/ss_player/ss_internal_player.h
@@ -308,9 +308,7 @@ private:
     // External SSAB resources auto-loaded from the parent's directory based
     // on `external_instances`. Cleared and rebuilt on every setSSABResource.
     Vector<Ref<SSABResource>> _external_ssabs;
-    // Same set as `_external_ssabs`, keyed by pack name so
-    // pack resolution is O(1). Built by `_load_external_ssabs`.
-    HashMap<String, Ref<SSABResource>> _external_ssabs_by_pack_name;
+    HashMap<uint32_t, Ref<SSABResource>> _external_ssabs_by_pack_hash;
 
     // Per-frame draw context: SoA pointers and frame-shared bindings fetched
     // once at the top of `drawAnimation`.


### PR DESCRIPTION
This PR updates the C++ flatbuffers headers to match the latest SDK schema changes. It removes `anime_pack_and_name_hash` while keeping the individual pack/name hashes.