### PR TITLE
Fix GDExtension build: include HashSet header in ss_internal_player.h

### DIFF
--- a/ss_player/ss_internal_player.h
+++ b/ss_player/ss_internal_player.h
@@ -8,6 +8,7 @@
 #include <godot_cpp/classes/shader_material.hpp>
 #include <godot_cpp/classes/texture2d.hpp>
 #include <godot_cpp/templates/hash_map.hpp>
+#include <godot_cpp/templates/hash_set.hpp>
 #include <godot_cpp/templates/local_vector.hpp>
 #include <godot_cpp/templates/vector.hpp>
 #include <godot_cpp/variant/dictionary.hpp>
@@ -22,6 +23,7 @@ using namespace godot;
 #include "core/object/ref_counted.h"
 #include "core/string/ustring.h"
 #include "core/templates/hash_map.h"
+#include "core/templates/hash_set.h"
 #include "core/templates/local_vector.h"
 #include "core/templates/vector.h"
 #include "core/variant/dictionary.h"


### PR DESCRIPTION
`_load_external_ssabs` uses `HashSet<String>` (added when the instance resolver was rewritten) but the header only included hash_map, not hash_set. The custom-module build compiled via a transitive include, but the GDExtension (godot-cpp) build fails with C2065 'HashSet' undefined. Add the hash_set include to both the GDExtension and module include blocks, mirroring the existing hash_map pattern (and ss_filesystem_menu.cpp).