### PR TITLE
Fix: Restore _resolve_ssab_by_hash for proper Instance part resolution

### DIFF
--- a/ss_player/format/ssab.h
+++ b/ss_player/format/ssab.h
@@ -8089,27 +8089,32 @@ inline ::flatbuffers::Offset<ExternalTexture> CreateExternalTextureDirect(
 struct ExternalInstance FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
   typedef ExternalInstanceBuilder Builder;
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
-    VT_ANIME_PACK_NAME_HASH = 4,
-    VT_ANIME_PACK_NAME = 6
+    VT_ANIME_PACK_NAME = 4,
+    VT_ANIME_PACK_NAME_HASH = 6,
+    VT_ANIME_NAME = 8,
+    VT_ANIME_NAME_HASH = 10
   };
+  const ::flatbuffers::String *anime_pack_name() const {
+    return GetPointer<const ::flatbuffers::String *>(VT_ANIME_PACK_NAME);
+  }
   uint32_t anime_pack_name_hash() const {
     return GetField<uint32_t>(VT_ANIME_PACK_NAME_HASH, 0);
   }
-  bool KeyCompareLessThan(const ExternalInstance * const o) const {
-    return anime_pack_name_hash() < o->anime_pack_name_hash();
+  const ::flatbuffers::String *anime_name() const {
+    return GetPointer<const ::flatbuffers::String *>(VT_ANIME_NAME);
   }
-  int KeyCompareWithValue(uint32_t _anime_pack_name_hash) const {
-    return static_cast<int>(anime_pack_name_hash() > _anime_pack_name_hash) - static_cast<int>(anime_pack_name_hash() < _anime_pack_name_hash);
-  }
-  const ::flatbuffers::String *anime_pack_name() const {
-    return GetPointer<const ::flatbuffers::String *>(VT_ANIME_PACK_NAME);
+  uint32_t anime_name_hash() const {
+    return GetField<uint32_t>(VT_ANIME_NAME_HASH, 0);
   }
   template <bool B = false>
   bool Verify(::flatbuffers::VerifierTemplate<B> &verifier) const {
     return VerifyTableStart(verifier) &&
-           VerifyField<uint32_t>(verifier, VT_ANIME_PACK_NAME_HASH, 4) &&
            VerifyOffset(verifier, VT_ANIME_PACK_NAME) &&
            verifier.VerifyString(anime_pack_name()) &&
+           VerifyField<uint32_t>(verifier, VT_ANIME_PACK_NAME_HASH, 4) &&
+           VerifyOffset(verifier, VT_ANIME_NAME) &&
+           verifier.VerifyString(anime_name()) &&
+           VerifyField<uint32_t>(verifier, VT_ANIME_NAME_HASH, 4) &&
            verifier.EndTable();
   }
 };
@@ -8118,11 +8123,17 @@ struct ExternalInstanceBuilder {
   typedef ExternalInstance Table;
   ::flatbuffers::FlatBufferBuilder &fbb_;
   ::flatbuffers::uoffset_t start_;
+  void add_anime_pack_name(::flatbuffers::Offset<::flatbuffers::String> anime_pack_name) {
+    fbb_.AddOffset(ExternalInstance::VT_ANIME_PACK_NAME, anime_pack_name);
+  }
   void add_anime_pack_name_hash(uint32_t anime_pack_name_hash) {
     fbb_.AddElement<uint32_t>(ExternalInstance::VT_ANIME_PACK_NAME_HASH, anime_pack_name_hash, 0);
   }
-  void add_anime_pack_name(::flatbuffers::Offset<::flatbuffers::String> anime_pack_name) {
-    fbb_.AddOffset(ExternalInstance::VT_ANIME_PACK_NAME, anime_pack_name);
+  void add_anime_name(::flatbuffers::Offset<::flatbuffers::String> anime_name) {
+    fbb_.AddOffset(ExternalInstance::VT_ANIME_NAME, anime_name);
+  }
+  void add_anime_name_hash(uint32_t anime_name_hash) {
+    fbb_.AddElement<uint32_t>(ExternalInstance::VT_ANIME_NAME_HASH, anime_name_hash, 0);
   }
   explicit ExternalInstanceBuilder(::flatbuffers::FlatBufferBuilder &_fbb)
         : fbb_(_fbb) {
@@ -8137,23 +8148,32 @@ struct ExternalInstanceBuilder {
 
 inline ::flatbuffers::Offset<ExternalInstance> CreateExternalInstance(
     ::flatbuffers::FlatBufferBuilder &_fbb,
+    ::flatbuffers::Offset<::flatbuffers::String> anime_pack_name = 0,
     uint32_t anime_pack_name_hash = 0,
-    ::flatbuffers::Offset<::flatbuffers::String> anime_pack_name = 0) {
+    ::flatbuffers::Offset<::flatbuffers::String> anime_name = 0,
+    uint32_t anime_name_hash = 0) {
   ExternalInstanceBuilder builder_(_fbb);
-  builder_.add_anime_pack_name(anime_pack_name);
+  builder_.add_anime_name_hash(anime_name_hash);
+  builder_.add_anime_name(anime_name);
   builder_.add_anime_pack_name_hash(anime_pack_name_hash);
+  builder_.add_anime_pack_name(anime_pack_name);
   return builder_.Finish();
 }
 
 inline ::flatbuffers::Offset<ExternalInstance> CreateExternalInstanceDirect(
     ::flatbuffers::FlatBufferBuilder &_fbb,
+    const char *anime_pack_name = nullptr,
     uint32_t anime_pack_name_hash = 0,
-    const char *anime_pack_name = nullptr) {
+    const char *anime_name = nullptr,
+    uint32_t anime_name_hash = 0) {
   auto anime_pack_name__ = anime_pack_name ? _fbb.CreateString(anime_pack_name) : 0;
+  auto anime_name__ = anime_name ? _fbb.CreateString(anime_name) : 0;
   return ss::format::CreateExternalInstance(
       _fbb,
+      anime_pack_name__,
       anime_pack_name_hash,
-      anime_pack_name__);
+      anime_name__,
+      anime_name_hash);
 }
 
 struct EmbeddedAsset FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
@@ -8423,7 +8443,7 @@ inline ::flatbuffers::Offset<SsAnimeBinary> CreateSsAnimeBinaryDirect(
     std::vector<::flatbuffers::Offset<ss::format::SoundList>> *sound_lists = nullptr,
     std::vector<::flatbuffers::Offset<ss::format::FontBitmap>> *font_bitmaps = nullptr,
     std::vector<::flatbuffers::Offset<ss::format::ExternalTexture>> *external_textures = nullptr,
-    std::vector<::flatbuffers::Offset<ss::format::ExternalInstance>> *external_instances = nullptr,
+    const std::vector<::flatbuffers::Offset<ss::format::ExternalInstance>> *external_instances = nullptr,
     std::vector<::flatbuffers::Offset<ss::format::EmbeddedAsset>> *embedded_assets = nullptr) {
   auto name__ = name ? _fbb.CreateString(name) : 0;
   auto parts__ = parts ? _fbb.CreateVector<::flatbuffers::Offset<ss::format::PartData>>(*parts) : 0;
@@ -8433,7 +8453,7 @@ inline ::flatbuffers::Offset<SsAnimeBinary> CreateSsAnimeBinaryDirect(
   auto sound_lists__ = sound_lists ? _fbb.CreateVectorOfSortedTables<ss::format::SoundList>(sound_lists) : 0;
   auto font_bitmaps__ = font_bitmaps ? _fbb.CreateVectorOfSortedTables<ss::format::FontBitmap>(font_bitmaps) : 0;
   auto external_textures__ = external_textures ? _fbb.CreateVectorOfSortedTables<ss::format::ExternalTexture>(external_textures) : 0;
-  auto external_instances__ = external_instances ? _fbb.CreateVectorOfSortedTables<ss::format::ExternalInstance>(external_instances) : 0;
+  auto external_instances__ = external_instances ? _fbb.CreateVector<::flatbuffers::Offset<ss::format::ExternalInstance>>(*external_instances) : 0;
   auto embedded_assets__ = embedded_assets ? _fbb.CreateVectorOfSortedTables<ss::format::EmbeddedAsset>(embedded_assets) : 0;
   return ss::format::CreateSsAnimeBinary(
       _fbb,

--- a/ss_player/ss_internal_player.cpp
+++ b/ss_player/ss_internal_player.cpp
@@ -1099,6 +1099,23 @@ void SsInternalPlayer::_load_external_ssabs() {
     }
 }
 
+Ref<SSABResource> SsInternalPlayer::_resolve_ssab_by_hash(uint32_t pack_hash, uint32_t name_hash) const {
+    if (pack_hash != 0) {
+        if (auto* ext_ptr = _external_ssabs_by_pack_hash.getptr(pack_hash)) {
+            auto anim = (*ext_ptr)->find_animation_by_hash(name_hash);
+            if (anim) {
+                return *ext_ptr;
+            }
+        }
+    }
+    // Not external or not found; check current binary.
+    if (!_ssabRes.is_null()) {
+        auto anim = _ssabRes->find_animation_by_hash(name_hash);
+        if (anim) return _ssabRes;
+    }
+    return Ref<SSABResource>();
+}
+
 void SsInternalPlayer::_clear_instance_children() {
     for (uint32_t i = 0; i < _instance_children.size(); i++) {
         InstanceChildState& st = _instance_children[i];
@@ -1137,20 +1154,7 @@ void SsInternalPlayer::_setup_instance_children() {
         uint32_t pack_name_hash = pt->ref_anime_pack_hash();
         uint32_t anim_name_hash = pt->ref_anime_name_hash();
 
-        Ref<SSABResource> source;
-        if (!_ssabRes.is_null() && _ssabRes->get_ss_anime_binary() && _ssabRes->get_ss_anime_binary()->name_hash() == pack_name_hash) {
-            // パック名ハッシュが自分自身と一致する場合は、内部のSSABから検索
-            if (_ssabRes->find_animation_by_hash(anim_name_hash)) {
-                source = _ssabRes;
-            }
-        } else {
-            // それ以外の場合は外部のSSAB（external）から検索
-            if (auto* ext_ptr = _external_ssabs_by_pack_hash.getptr(pack_name_hash)) {
-                if ((*ext_ptr)->find_animation_by_hash(anim_name_hash)) {
-                    source = *ext_ptr;
-                }
-            }
-        }
+        Ref<SSABResource> source = _resolve_ssab_by_hash(pack_name_hash, anim_name_hash);
 
         if (source.is_null()) {
             ERR_PRINT(vformat("[SS] instance part %d: animation '%s' (pack '%s') not found in current or external SSABs", i, anim_name, pack_name));

--- a/ss_player/ss_internal_player.h
+++ b/ss_player/ss_internal_player.h
@@ -615,6 +615,7 @@ private:
     void _seek_and_redraw(float frame_no, float delta_seconds, bool parent_looped);
 
     void _load_external_ssabs();
+    Ref<SSABResource> _resolve_ssab_by_hash(uint32_t pack_hash, uint32_t name_hash) const;
 
     void _apply_blend_material(RenderingServer* rs, RID ci, ss::format::BlendType blend_type);
     // ShaderMaterial variant for Normal and Mesh batches. PartColor is handled


### PR DESCRIPTION
## Description
The previous PR 154/155 inlined the resolution logic for instance parts but missed the fallback to internal SSAB. This caused a runtime error where Instance parts could not find their animations if the external SSAB wasn't found or if it was an internal reference (`pack_name_hash == 0`).

This PR restores the encapsulated `_resolve_ssab_by_hash` method which correctly checks the external dictionary and gracefully falls back to the internal SSAB.

Additionally, this PR updates the `SpriteStudio7-SDK` submodule and regenerates the `ssab.h` and `ssqb.h` headers to include the schema updates (re-adding the animation name hashes for correct resolution).