### PR TITLE
docs: Update Ringo example description and order in README

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -88,12 +88,12 @@ graph LR
 
 [examples フォルダ](./examples/) に SDK のテストプロジェクトに基づいたサンプルプロジェクトがあります。
 
+- [Ringo](./examples/Ringo) — 「りんご」のテスト
 - [allAttributeV7](./examples/allAttributeV7) — 全属性の機能テスト
 - [allPartsV7](./examples/allPartsV7) — 全パーツ種の機能テスト
 - [overall](./examples/overall) — 総合的な機能テスト
 - [overall_gdextension](./examples/overall_gdextension) — GDExtension 版での総合テスト
 - [ParticleEffect](./examples/ParticleEffect) — エフェクト機能のテスト
-- [Ringo](./examples/Ringo) — Ringoのテスト
 
 ## 関連リポジトリ
 

--- a/README.md
+++ b/README.md
@@ -88,12 +88,12 @@ graph LR
 
 Sample projects based on SDK test projects are available under the [examples folder](./examples/).
 
+- [Ringo](./examples/Ringo) — Test for Ringo
 - [allAttributeV7](./examples/allAttributeV7) — Functional test for all attributes
 - [allPartsV7](./examples/allPartsV7) — Functional test for all part types
 - [overall](./examples/overall) — Comprehensive functional test
 - [overall_gdextension](./examples/overall_gdextension) — Comprehensive test for GDExtension
 - [ParticleEffect](./examples/ParticleEffect) — Test for effect features
-- [Ringo](./examples/Ringo) — Test for Ringo
 
 ## Related Repositories
 


### PR DESCRIPTION
Fix missing Ringo example update in README files. Moved Ringo to the top and changed description to 「りんご」のテスト.