### PR TITLE
docs: Add migration guide from v1.x

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -5,7 +5,7 @@
 本developブランチは現在開発中のバージョンです。  
 安定版は [mainブランチ](https://github.com/SpriteStudio/SSPlayerForGodot/tree/main) または、[Releases](https://github.com/SpriteStudio/SSPlayerForGodot/releases)から取得してください。  
 
-> **注意:** 本書で扱う API・ワークフローは現在開発中のため、予告なく変更される可能性があります。また、本ブランチに関していかなる保証もサポートも提供せず、リクエストやバグ報告への返信もできません。v1.x からの移行手順は別途マイグレーションドキュメントを用意予定です。
+> **注意:** 本書で扱う API・ワークフローは現在開発中のため、予告なく変更される可能性があります。また、本ブランチに関していかなる保証もサポートも提供せず、リクエストやバグ報告への返信もできません。
 
 [OPTPiX SpriteStudio 7](https://www.webtech.co.jp/spritestudio/) で作成したアニメーションを [Godot Engine](https://godotengine.org/) 上で再生するためのハイパフォーマンスなプラグインです。
 このプラグインを使用することで、ラスターベースの2Dアニメーションを Godot プロジェクトへ簡単に実装・再生することができます。
@@ -25,6 +25,7 @@
 - [CLI コンバートと自動化](./docs/ja/workflow/import.md)
 - [パフォーマンスと高度な設定](./docs/ja/workflow/tips.md)
 - [ビルドガイド](./docs/ja/setup/build.md)
+- [v1.x からのマイグレーション](./docs/ja/migration_from_v1.md)
 
 ## GDExtension を用いたクイックスタート
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 This `develop` branch is a work-in-progress version.  
 The stable version can be obtained from the [main branch](https://github.com/SpriteStudio/SSPlayerForGodot/tree/main) or from [Releases](https://github.com/SpriteStudio/SSPlayerForGodot/releases).  
 
-> **Note:** The APIs and workflows described here are still under active development and may change without notice. No warranty or support is provided for this branch, and we cannot respond to feature requests or bug reports. A migration guide for v1.x users will be provided as a separate document.
+> **Note:** The APIs and workflows described here are still under active development and may change without notice. No warranty or support is provided for this branch, and we cannot respond to feature requests or bug reports.
 
 A high-performance plugin for playing back animations created with [OPTPiX SpriteStudio 7](https://www.webtech.co.jp/spritestudio/) inside [Godot Engine](https://godotengine.org/).
 This plugin allows you to easily implement and play back raster-based 2D animations within your Godot projects.
@@ -25,6 +25,7 @@ Comprehensive documentation is available in the `docs/` folder:
 - [CLI Conversion and Automation](./docs/en/workflow/import.md)
 - [Performance and Advanced Settings](./docs/en/workflow/tips.md)
 - [Build Guide](./docs/en/setup/build.md)
+- [Migration from v1.x](./docs/en/migration_from_v1.md)
 
 ## Quick Start with GDExtension
 

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -3,7 +3,7 @@
 This `develop` branch is a work-in-progress version.  
 The stable version can be obtained from the [main branch](https://github.com/SpriteStudio/SSPlayerForGodot/tree/main) or from [Releases](https://github.com/SpriteStudio/SSPlayerForGodot/releases).  
 No warranty or support is provided for this branch, and we cannot respond to feature requests or bug reports.  
-Interfaces may change without notice. A migration guide for v1.x users will be provided as a separate document.  
+Interfaces may change without notice.  
 
 A plugin for playing back animations created with [OPTPiX SpriteStudio](https://www.webtech.co.jp/spritestudio/) inside [Godot Engine](https://godotengine.org/).
 Animation playback uses `libssruntime` provided by [SpriteStudio7-SDK](https://github.com/SpriteStudio/SpriteStudio7-SDK).
@@ -76,6 +76,12 @@ Sample projects based on SDK test projects are available under the `examples/` f
 
 - [SpriteStudio7-SDK](https://github.com/SpriteStudio/SpriteStudio7-SDK) — The SDK itself, providing `libssruntime` / `libssconverter`
 
+## Migration
+
+For instructions on migrating from versions prior to v1.x, please refer to the [Migration Guide](migration_from_v1.md).
+
 ## License
 
 See [LICENSE.txt](../../LICENSE.txt).
+
+

--- a/docs/en/migration_from_v1.md
+++ b/docs/en/migration_from_v1.md
@@ -1,0 +1,27 @@
+# Migration from v1.x
+
+When migrating from v1.x to this version, please note the following major changes:
+
+## 1. Asset Format and Import Pipeline
+- **v1.x**: SpriteStudio files like `.sspj`, `.ssae`, and `.ssce` were placed directly in the project and used as-is from Godot's FileSystem dock.
+- **Current Version**: Utilizes a customized optimized binary format (`.ssab`). Please remove the `.sspj` and other source files that were placed in your Godot project during v1 (move them outside the project). Then, use the **SS Import Dock** to convert them into `.ssab` files.
+  - For detailed conversion steps, please refer to [Editor Integration and Asset Iteration](workflow/usage_asset_pipeline.md).
+
+## 2. Node and GDScript API Changes
+- **Node Change**: The node to use has changed. Please use the new `SpriteStudioPlayer2D` node instead of the old `GdNodeSsPlayer`.
+- **Resource Assignment**:
+  - Previously, you had to assign multiple files via `res_player.res_project = load("...sspj")` and `set_anime_pack("...ssae")`. In the current version, a `.ssab` file is generated per `.ssae` (Anime Pack).
+  - Therefore, you simply need to set the `.ssab` containing the animation you want to play using `set_ssab_resource(load("...ssab"))`.
+- **Loop Playback**: The previous `set_loop(bool)` method has been replaced with `set_loop_count(int)` (`-1` for infinite loop, `0` for play once / no loop).
+- **Method Renames and Removals**:
+  - `set_player_resource()` → `set_ssab_resource()`
+  - `get_fps()` → `get_frame_rate()`
+  - `set_anime_pack()` → Removed (Anime packs are now bundled within each `.ssab` file)
+  - `set_play()` / `get_play()` → Removed (Use `play()`, `stop()`, and `is_playing()` instead)
+  - `pause(bool)` → `pause()` (No longer takes arguments)
+  - `set_texture_interpolate()` → Removed (Use Godot 4's native `Texture Filter` property on the CanvasItem instead)
+- **Signal Names**: Signal names have been updated to follow Godot's standard conventions (e.g., removing the `on_` prefix).
+  - `on_animation_finished` → `animation_finished`
+  - `on_animation_changed` → `animation_changed`
+  - `on_user_data` → `user_data`
+  - For full details, see the [API Reference](api/player.md).

--- a/docs/ja/index.md
+++ b/docs/ja/index.md
@@ -3,7 +3,7 @@
 本developブランチは現在開発中のバージョンです。  
 安定版は [mainブランチ](https://github.com/SpriteStudio/SSPlayerForGodot/tree/main) または、[Releases](https://github.com/SpriteStudio/SSPlayerForGodot/releases)から取得してください。  
 本developブランチに関してはいかなる保証もサポートも提供しません。リクエストやバグ報告への返信もできません。  
-インターフェースは予告なく変更される可能性があります。v1.x からの移行手順は別途マイグレーションドキュメントを用意予定です。
+インターフェースは予告なく変更される可能性があります。
 
 [OPTPiX SpriteStudio](https://www.webtech.co.jp/spritestudio/) で作成したアニメーションを [Godot Engine](https://godotengine.org/) 上で再生するためのプラグインです。
 再生処理は [SpriteStudio7-SDK](https://github.com/SpriteStudio/SpriteStudio7-SDK) が提供する `libssruntime` を介して行います。
@@ -76,6 +76,12 @@ Windows / macOS でのビルドおよび実行を確認しています。
 
 - [SpriteStudio7-SDK](https://github.com/SpriteStudio/SpriteStudio7-SDK) — `libssruntime` / `libssconverter` を提供する SDK 本体
 
+## マイグレーション
+
+v1.x 以前のバージョンからの移行手順については、[マイグレーションガイド](migration_from_v1.md) を参照してください。
+
 ## ライセンス
 
 [LICENSE.txt](../../LICENSE.txt) を参照してください。
+
+

--- a/docs/ja/migration_from_v1.md
+++ b/docs/ja/migration_from_v1.md
@@ -1,0 +1,27 @@
+# v1.x からのマイグレーション
+
+v1.x から本バージョンへ移行する場合は、以下の大きな変更点にご注意ください。
+
+## 1. アセットフォーマットとインポート仕様の変更
+- **v1.x**: `.sspj` や `.ssae`, `.ssce` などの SpriteStudio のファイル群を直接プロジェクトに配置し、Godot のファイルシステム (FileSystem) ドックからそのまま読み込んで使用していました。
+- **本バージョン**: 独自の最適化されたバイナリ形式 `.ssab` を利用します。v1 の時に Godot プロジェクト内に配置していた `.sspj` などのファイル群は、一度プロジェクト外に退避してください。その後、**SS Import Dock** を利用して `.ssab` にコンバートして利用します。
+  - コンバートの詳細な手順については [エディタ連携とアセットイテレーション](workflow/usage_asset_pipeline.md) を参照してください。
+
+## 2. 利用するノードと GDScript API の変更
+- **ノードの変更**: 利用するノードが変わります。旧バージョンの `GdNodeSsPlayer` ではなく、新しい `SpriteStudioPlayer2D` ノードを利用してください。
+- **リソースの割り当て**:
+  - 以前は `res_player.res_project = load("...sspj")` や `set_anime_pack("...ssae")` のように複数ファイルを設定していましたが、本バージョンでは `.ssab` が `.ssae` (アニメパック) 単位で生成されます。
+  - そのため、利用する（再生したい）アニメーションが含まれている `.ssab` を `set_ssab_resource(load("...ssab"))` のようにセットしてください。
+- **ループ再生の設定**: 以前の `set_loop(bool)` は廃止され、ループ回数を指定する `set_loop_count(int)` に変更されました（`-1` で無限ループ、`0` で1回再生（ループなし））。
+- **メソッドの変更と廃止**:
+  - `set_player_resource()` → `set_ssab_resource()`
+  - `get_fps()` → `get_frame_rate()`
+  - `set_anime_pack()` → 廃止（アニメパックは `.ssab` ごとに含まれるため不要）
+  - `set_play()` / `get_play()` → 廃止（代わりに `play()`, `stop()`, `is_playing()` 等を利用してください）
+  - `pause(bool)` → `pause()`（引数なしに変更）
+  - `set_texture_interpolate()` → 廃止（Godot 4 標準の `Texture Filter` (CanvasItem プロパティ) を利用してください）
+- **シグナル名の変更**: イベント名の先頭の `on_` が外れるなど、Godot の標準的な命名規則に統一されました。
+  - `on_animation_finished` → `animation_finished`
+  - `on_animation_changed` → `animation_changed`
+  - `on_user_data` → `user_data`
+  - 詳細は [API リファレンス](api/player.md) をご確認ください。

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -50,3 +50,4 @@ nav:
   - API Reference:
       - SpriteStudioPlayer2D: api/player.md
       - Resource Classes: api/resource.md
+  - Migration Guide: migration_from_v1.md


### PR DESCRIPTION
Separated the v1 migration instructions into a dedicated file (migration_from_v1.md), cleaned up the top-level warnings, and documented the GDScript API changes.