### PR TITLE
UX: Improve error dialogs, logs, and import progress UI

### DIFF
--- a/ss_player/ss_editor_plugin.cpp
+++ b/ss_player/ss_editor_plugin.cpp
@@ -52,7 +52,7 @@ void SSEditorPlugin::_install_canvas_drop_overlay() {
 #endif
 
     if (viewport_control == nullptr) {
-        print_line("SSEditorPlugin: CanvasItemEditorViewport not found; .ssab drop-to-viewport disabled.");
+        WARN_PRINT("SSEditorPlugin: CanvasItemEditorViewport not found; .ssab drop-to-viewport disabled.");
         return;
     }
 

--- a/ss_player/ss_filesystem_menu.cpp
+++ b/ss_player/ss_filesystem_menu.cpp
@@ -73,7 +73,7 @@ void SSFileSystemContextMenu::get_options(const Vector<String> &p_paths) {
 
 void SSFileSystemContextMenu::_on_open_in_editor(const PackedStringArray &p_paths) {
     if (!importer) {
-        print_line("SSFileSystemContextMenu: importer not set.");
+        ERR_PRINT("SSFileSystemContextMenu: importer not set.");
         return;
     }
 
@@ -103,17 +103,17 @@ void SSFileSystemContextMenu::_on_open_in_editor(const PackedStringArray &p_path
     if (pending_count == 1) {
         _ask_user_for_sspj(pending_ssab_for_dialog, ACTION_OPEN_IN_EDITOR);
     } else if (pending_count > 1) {
-        print_line(vformat("SSFileSystemContextMenu: %d file(s) without source record skipped. Right-click each individually to set their sspj.", pending_count));
+        WARN_PRINT(vformat("SSFileSystemContextMenu: %d file(s) without source record skipped. Right-click each individually to set their sspj.", pending_count));
     }
 }
 
 void SSFileSystemContextMenu::_on_convert(const PackedStringArray &p_paths) {
     if (!importer) {
-        print_line("SSFileSystemContextMenu: importer not set.");
+        ERR_PRINT("SSFileSystemContextMenu: importer not set.");
         return;
     }
     if (importer->is_importing()) {
-        print_line("SSFileSystemContextMenu: Already importing. Please wait.");
+        WARN_PRINT("SSFileSystemContextMenu: Already importing. Please wait.");
         return;
     }
 
@@ -151,14 +151,14 @@ void SSFileSystemContextMenu::_on_convert(const PackedStringArray &p_paths) {
     if (pending_count == 1 && sspjs.is_empty()) {
         _ask_user_for_sspj(pending_ssab_for_dialog, ACTION_CONVERT);
     } else if (pending_count > 0) {
-        print_line(vformat("SSFileSystemContextMenu: %d file(s) without source record skipped. Right-click each individually to set their sspj.", pending_count));
+        WARN_PRINT(vformat("SSFileSystemContextMenu: %d file(s) without source record skipped. Right-click each individually to set their sspj.", pending_count));
     }
 }
 
 void SSFileSystemContextMenu::_do_open_in_editor(const String &p_sspj_path) {
     Error err = OS::get_singleton()->shell_open(p_sspj_path);
     if (err != OK) {
-        print_line(vformat("SSFileSystemContextMenu: failed to open sspj (%s) via OS shell. error=%d", p_sspj_path, (int)err));
+        ERR_PRINT(vformat("SSFileSystemContextMenu: failed to open sspj (%s) via OS shell. error=%d", p_sspj_path, (int)err));
     }
 }
 

--- a/ss_player/ss_import_dock.cpp
+++ b/ss_player/ss_import_dock.cpp
@@ -3,6 +3,7 @@
 #include "ss_macros.h"
 
 #ifdef SPRITESTUDIO_GODOT_EXTENSION
+#include <godot_cpp/classes/accept_dialog.hpp>
 #include <godot_cpp/classes/dir_access.hpp>
 #include <godot_cpp/classes/display_server.hpp>
 #include <godot_cpp/classes/editor_file_system.hpp>
@@ -19,6 +20,7 @@ using namespace godot;
 #include "core/os/os.h"
 #include "editor/editor_interface.h"
 #include "editor/settings/editor_settings.h"
+#include "scene/gui/dialogs.h"
 #include "scene/main/window.h"
 #if VERSION_MAJOR >= 4
     #if VERSION_MINOR >= 5
@@ -51,23 +53,6 @@ void SSImportControl::_bind_methods() {
 SSImportControl::SSImportControl() {
     set_h_size_flags(Control::SIZE_EXPAND_FILL);
     set_v_size_flags(Control::SIZE_EXPAND_FILL);
-
-    // 1. Header: converter version
-    {
-        HBoxContainer *hbox = memnew(HBoxContainer);
-        add_child(hbox);
-
-        Label *label = memnew(Label);
-        label->set_text(tr("converter:"));
-        hbox->add_child(label);
-
-        SSClickableLabel *clickable_label = memnew(SSClickableLabel);
-        const char *v = ss_converter_version();
-        clickable_label->set_text(String(v));
-        ss_converter_version_free((char *)v);
-        v = nullptr;
-        hbox->add_child(clickable_label);
-    }
 
     // 2. Output Dir row
     {
@@ -172,6 +157,23 @@ SSImportControl::SSImportControl() {
     recent_popup->connect("id_pressed", Callable(this, "_on_recent_menu_id_pressed"));
     add_child(recent_popup);
 
+    // 6. Footer: converter version (moved to bottom)
+    {
+        HBoxContainer *hbox = memnew(HBoxContainer);
+        add_child(hbox);
+
+        Label *label = memnew(Label);
+        label->set_text(tr("converter:"));
+        hbox->add_child(label);
+
+        SSClickableLabel *clickable_label = memnew(SSClickableLabel);
+        const char *v = ss_converter_version();
+        clickable_label->set_text(String(v));
+        ss_converter_version_free((char *)v);
+        v = nullptr;
+        hbox->add_child(clickable_label);
+    }
+
     _load_settings();
 }
 
@@ -266,7 +268,7 @@ void SSImportControl::_on_window_files_dropped(const Vector<String> &p_files) {
     if (get_global_rect().has_point(get_global_mouse_position())) {
 
         if (importer && importer->is_importing()) {
-            print_line("SSImportControl: Already importing. Please wait.");
+            WARN_PRINT("SSImportControl: Already importing. Please wait.");
             return;
         }
 
@@ -284,7 +286,14 @@ void SSImportControl::_on_window_files_dropped(const Vector<String> &p_files) {
             }
         }
         if (sspj_files.is_empty()) {
-            print_line("SSImportControl: sspj files not found.");
+            ERR_PRINT("SSImportControl: No .sspj files found.");
+            AcceptDialog *dialog = memnew(AcceptDialog);
+            dialog->set_title(tr("Import Error"));
+            dialog->set_text(tr("No .sspj files found.\nPlease drop SpriteStudio project (.sspj) files."));
+            EditorInterface::get_singleton()->get_base_control()->add_child(dialog);
+            dialog->connect("confirmed", Callable(dialog, "queue_free"));
+            dialog->connect("canceled", Callable(dialog, "queue_free"));
+            dialog->popup_centered();
             return;
         }
 
@@ -300,7 +309,7 @@ void SSImportControl::_start_import(const PackedStringArray &p_sspj_files) {
 void SSImportControl::_start_import(const Vector<String> &p_sspj_files) {
 #endif
     if (!importer) {
-        print_line("SSImportControl: importer is not set.");
+        ERR_PRINT("SSImportControl: importer is not set.");
         return;
     }
 
@@ -370,7 +379,7 @@ void SSImportControl::_on_open_dir_button_pressed() {
     String global_path = ProjectSettings::get_singleton()->globalize_path(path);
     Error err = OS::get_singleton()->shell_open(global_path);
     if (err != OK) {
-        print_line(vformat("SSImportControl: failed to open output directory %s. error=%d", global_path, (int)err));
+        ERR_PRINT(vformat("SSImportControl: failed to open output directory %s. error=%d", global_path, (int)err));
     }
 }
 
@@ -382,7 +391,7 @@ void SSImportControl::_on_dir_selected(const String &p_path) {
 
 void SSImportControl::_on_recent_file_pressed(const String &p_path) {
     if (importer && importer->is_importing()) {
-        print_line("SSImportControl: Already importing. Please wait.");
+        WARN_PRINT("SSImportControl: Already importing. Please wait.");
         return;
     }
     _reconvert_sspj(p_path);
@@ -466,18 +475,18 @@ void SSImportControl::_on_recent_menu_id_pressed(int p_id) {
         case RECENT_MENU_OPEN_IN_EDITOR: {
             Error err = OS::get_singleton()->shell_open(path);
             if (err != OK) {
-                print_line(vformat("SSImportControl: failed to open sspj %s. error=%d", path, (int)err));
+                ERR_PRINT(vformat("SSImportControl: failed to open sspj %s. error=%d", path, (int)err));
             }
         } break;
         case RECENT_MENU_REVEAL: {
             Error err = OS::get_singleton()->shell_show_in_file_manager(path, false);
             if (err != OK) {
-                print_line(vformat("SSImportControl: failed to reveal %s. error=%d", path, (int)err));
+                ERR_PRINT(vformat("SSImportControl: failed to reveal %s. error=%d", path, (int)err));
             }
         } break;
         case RECENT_MENU_RECONVERT: {
             if (importer && importer->is_importing()) {
-                print_line("SSImportControl: Already importing. Please wait.");
+                WARN_PRINT("SSImportControl: Already importing. Please wait.");
                 return;
             }
             _reconvert_sspj(path);

--- a/ss_player/ss_importer.cpp
+++ b/ss_player/ss_importer.cpp
@@ -6,6 +6,7 @@
 #include "ss_progress_dialog.h"
 
 #ifdef SPRITESTUDIO_GODOT_EXTENSION
+#include <godot_cpp/classes/accept_dialog.hpp>
 #include <godot_cpp/classes/dir_access.hpp>
 #include <godot_cpp/classes/editor_file_system.hpp>
 #include <godot_cpp/classes/editor_interface.hpp>
@@ -22,6 +23,7 @@ using namespace godot;
 #include "core/io/resource.h"
 #include "editor/editor_interface.h"
 #include "editor/settings/editor_settings.h"
+#include "scene/gui/dialogs.h"
 #if VERSION_MAJOR >= 4
     #if VERSION_MINOR >= 5
     #include "editor/file_system/editor_file_system.h"
@@ -71,7 +73,18 @@ void SSImporter::_notification(int p_what) {
             }
 
             if (finished_num != _import_prev_num) {
-                _import_dialog->step(vformat("%s %d/%d", _session_title, finished_num, _import_finished_contexts.size()), finished_num);
+                String running_file = "";
+                for (size_t i = 0; i < _import_finished_contexts.size(); ++i) {
+                    if (!_import_finished_contexts[i]) {
+                        running_file = _import_src_files[i].get_file();
+                        break;
+                    }
+                }
+                if (!running_file.is_empty()) {
+                    _import_dialog->step(vformat("%s %d/%d (%s)", _session_title, finished_num, _import_finished_contexts.size(), running_file), finished_num);
+                } else {
+                    _import_dialog->step(vformat("%s %d/%d", _session_title, finished_num, _import_finished_contexts.size()), finished_num);
+                }
                 _import_prev_num = finished_num;
             }
 
@@ -101,6 +114,9 @@ void SSImporter::_finalize_import() {
     Dictionary source_map = _load_source_map();
     bool any_success = false;
 
+    Vector<String> failed_files;
+    Vector<String> failed_reasons;
+
     for (size_t i = 0; i < _import_contexts.size(); ++i) {
         void *ctx = _import_contexts[i];
         CConverterError result = ss_converter_get_result((Context *)ctx);
@@ -113,8 +129,26 @@ void SSImporter::_finalize_import() {
             ss_converter_get_error((Context *)ctx, &err_msg, &err_len);
             String err_str = err_msg ? String::utf8(err_msg) : String("Unknown error");
             ERR_PRINT(vformat("SSImporter: convert failed for %s (error %d): %s", _import_src_files[i], (int)result, err_str));
+            failed_files.push_back(_import_src_files[i].get_file());
+            failed_reasons.push_back(err_str);
         }
         ss_converter_destroy((Context *)ctx);
+    }
+
+    if (!failed_files.is_empty()) {
+        String msg = tr("Some files failed to import.\n\n");
+        for (int i = 0; i < failed_files.size(); ++i) {
+            msg += vformat("- %s: %s\n", failed_files[i], failed_reasons[i]);
+        }
+        msg += tr("\nPlease check the Output tab for details.");
+
+        AcceptDialog *dialog = memnew(AcceptDialog);
+        dialog->set_title(tr("Import Error"));
+        dialog->set_text(msg);
+        EditorInterface::get_singleton()->get_base_control()->add_child(dialog);
+        dialog->connect("confirmed", Callable(dialog, "queue_free"));
+        dialog->connect("canceled", Callable(dialog, "queue_free"));
+        dialog->popup_centered();
     }
 
     if (any_success) {
@@ -269,7 +303,12 @@ void SSImporter::_start_session(const String &p_dialog_title) {
     _import_finished_contexts.resize(_import_contexts.size());
     _import_prev_num = 0;
     _is_importing = true;
-    _import_dialog->step(vformat("%s %d/%d", _session_title, 0, _import_finished_contexts.size()), 0);
+    String first_file = _import_src_files.is_empty() ? "" : _import_src_files[0].get_file();
+    if (!first_file.is_empty()) {
+        _import_dialog->step(vformat("%s %d/%d (%s)", _session_title, 0, _import_finished_contexts.size(), first_file), 0);
+    } else {
+        _import_dialog->step(vformat("%s %d/%d", _session_title, 0, _import_finished_contexts.size()), 0);
+    }
 
     set_process(true);
 
@@ -282,7 +321,7 @@ void SSImporter::queue_import(const PackedStringArray &p_sspj_files, const Strin
 void SSImporter::queue_import(const Vector<String> &p_sspj_files, const String &p_output_dir) {
 #endif
     if (_is_importing) {
-        print_line("SSImporter: Already importing. Please wait.");
+        WARN_PRINT("SSImporter: Already importing. Please wait.");
         return;
     }
     if (p_sspj_files.is_empty()) {
@@ -306,7 +345,7 @@ void SSImporter::queue_import(const Vector<String> &p_sspj_files, const String &
 
 void SSImporter::queue_reconvert(const PackedStringArray &p_sspj_files, const PackedStringArray &p_dst_dirs) {
     if (_is_importing) {
-        print_line("SSImporter: Already importing. Please wait.");
+        WARN_PRINT("SSImporter: Already importing. Please wait.");
         return;
     }
     if (p_sspj_files.is_empty() || p_sspj_files.size() != p_dst_dirs.size()) {

--- a/ss_player/ss_resource_inspector.cpp
+++ b/ss_player/ss_resource_inspector.cpp
@@ -126,7 +126,7 @@ void SSResourceInspectorPlugin::_on_reveal_pressed(const String &p_resource_path
     String global = ProjectSettings::get_singleton()->globalize_path(p_resource_path);
     Error err = OS::get_singleton()->shell_show_in_file_manager(global, false);
     if (err != OK) {
-        print_line(vformat("SSResourceInspectorPlugin: failed to reveal %s. error=%d", global, (int)err));
+        ERR_PRINT(vformat("SSResourceInspectorPlugin: failed to reveal %s. error=%d", global, (int)err));
     }
 }
 


### PR DESCRIPTION
This PR introduces several UX improvements for the editor:
- Replaced `print_line` with `ERR_PRINT` / `WARN_PRINT` for better visibility in Godot's output/debugger.
- Added a warning popup (`AcceptDialog`) when dropping non-`.sspj` files into the import dock.
- Added the current processing file name to the progress dialog when importing multiple files.
- Added an error summary popup (`AcceptDialog`) at the end of the import process if any files failed.
- Moved the Converter version text to the bottom of the import dock UI.