### PR TITLE
UX: Improve Import Dock and FileSystem navigation feedback

### DIFF
--- a/examples/dev_module/node_2d.tscn
+++ b/examples/dev_module/node_2d.tscn
@@ -1,15 +1,21 @@
 [gd_scene format=3 uid="uid://crm5d340adlbm"]
 
-[ext_resource type="SSABResource" uid="uid://bxou6b7daw1se" path="res://ssab_generated/Mask/True_Light.ssab" id="1_wtcfe"]
+[node name="Node2D" type="Node2D" unique_id=2106903659]
 
-[node name="Node2D" type="Node2D" unique_id=1299694310]
+[node name="00_spr_03_action_01_level3" type="SpriteStudioPlayer2D" parent="." unique_id=1405222810]
+position = Vector2(139, 381)
 
-[node name="00_spr_03_action_01_level3" type="SpriteStudioPlayer2D" parent="." unique_id=222078339]
-position = Vector2(564, 609)
-ssab = ExtResource("1_wtcfe")
-animation = "True_light"
-playing = false
-animation_section_start = 0
-animation_section_end = 120
-sub_frame_enabled = true
-cellmaps/Mask_parts = null
+[node name="00_spr_03_action_01_level3" type="SpriteStudioPlayer2D" parent="00_spr_03_action_01_level3" unique_id=1174840223]
+position = Vector2(174, -3)
+
+[node name="00_spr_03_action_01_level3" type="SpriteStudioPlayer2D" parent="00_spr_03_action_01_level3/00_spr_03_action_01_level3" unique_id=6772756]
+position = Vector2(176, 11)
+
+[node name="00_spr_03_action_01_level3" type="SpriteStudioPlayer2D" parent="00_spr_03_action_01_level3/00_spr_03_action_01_level3/00_spr_03_action_01_level3" unique_id=1915863492]
+position = Vector2(188, -5)
+
+[node name="00_spr_03_action_01_level3" type="SpriteStudioPlayer2D" parent="00_spr_03_action_01_level3/00_spr_03_action_01_level3/00_spr_03_action_01_level3/00_spr_03_action_01_level3" unique_id=2104474040]
+position = Vector2(170, -9)
+
+[node name="00_spr_03_action_01_level3" type="SpriteStudioPlayer2D" parent="00_spr_03_action_01_level3/00_spr_03_action_01_level3/00_spr_03_action_01_level3/00_spr_03_action_01_level3/00_spr_03_action_01_level3" unique_id=1999012952]
+position = Vector2(164, 9)

--- a/examples/dev_module/node_2d.tscn
+++ b/examples/dev_module/node_2d.tscn
@@ -1,21 +1,65 @@
 [gd_scene format=3 uid="uid://crm5d340adlbm"]
 
+[ext_resource type="SSABResource" uid="uid://eymruor4ksd5" path="res://ssab_generated/spr_00_00/00_spr_03_action_01_level3.ssab" id="1_wtcfe"]
+
 [node name="Node2D" type="Node2D" unique_id=2106903659]
 
 [node name="00_spr_03_action_01_level3" type="SpriteStudioPlayer2D" parent="." unique_id=1405222810]
 position = Vector2(139, 381)
+ssab = ExtResource("1_wtcfe")
+animation = "00_action_01_left"
+playing = false
+animation_section_start = 0
+animation_section_end = 373
+cellmaps/spr_00_00_1 = null
+cellmaps/spr_00_00_0 = null
 
 [node name="00_spr_03_action_01_level3" type="SpriteStudioPlayer2D" parent="00_spr_03_action_01_level3" unique_id=1174840223]
 position = Vector2(174, -3)
+ssab = ExtResource("1_wtcfe")
+animation = "00_action_01_left"
+playing = false
+animation_section_start = 0
+animation_section_end = 373
+cellmaps/spr_00_00_1 = null
+cellmaps/spr_00_00_0 = null
 
 [node name="00_spr_03_action_01_level3" type="SpriteStudioPlayer2D" parent="00_spr_03_action_01_level3/00_spr_03_action_01_level3" unique_id=6772756]
 position = Vector2(176, 11)
+ssab = ExtResource("1_wtcfe")
+animation = "00_action_01_left"
+playing = false
+animation_section_start = 0
+animation_section_end = 373
+cellmaps/spr_00_00_1 = null
+cellmaps/spr_00_00_0 = null
 
 [node name="00_spr_03_action_01_level3" type="SpriteStudioPlayer2D" parent="00_spr_03_action_01_level3/00_spr_03_action_01_level3/00_spr_03_action_01_level3" unique_id=1915863492]
 position = Vector2(188, -5)
+ssab = ExtResource("1_wtcfe")
+animation = "00_action_01_left"
+playing = false
+animation_section_start = 0
+animation_section_end = 373
+cellmaps/spr_00_00_1 = null
+cellmaps/spr_00_00_0 = null
 
 [node name="00_spr_03_action_01_level3" type="SpriteStudioPlayer2D" parent="00_spr_03_action_01_level3/00_spr_03_action_01_level3/00_spr_03_action_01_level3/00_spr_03_action_01_level3" unique_id=2104474040]
 position = Vector2(170, -9)
+ssab = ExtResource("1_wtcfe")
+animation = "00_action_01_left"
+playing = false
+animation_section_start = 0
+animation_section_end = 373
+cellmaps/spr_00_00_1 = null
+cellmaps/spr_00_00_0 = null
 
 [node name="00_spr_03_action_01_level3" type="SpriteStudioPlayer2D" parent="00_spr_03_action_01_level3/00_spr_03_action_01_level3/00_spr_03_action_01_level3/00_spr_03_action_01_level3/00_spr_03_action_01_level3" unique_id=1999012952]
 position = Vector2(164, 9)
+ssab = ExtResource("1_wtcfe")
+animation = "00_action_01_left"
+playing = true
+animation_section_start = 0
+animation_section_end = 373
+cellmaps/spr_00_00_1 = null
+cellmaps/spr_00_00_0 = null

--- a/examples/dev_module/node_2d.tscn
+++ b/examples/dev_module/node_2d.tscn
@@ -1,65 +1,15 @@
 [gd_scene format=3 uid="uid://crm5d340adlbm"]
 
-[ext_resource type="SSABResource" uid="uid://eymruor4ksd5" path="res://ssab_generated/spr_00_00/00_spr_03_action_01_level3.ssab" id="1_wtcfe"]
+[ext_resource type="SSABResource" uid="uid://bxou6b7daw1se" path="res://ssab_generated/Mask/True_Light.ssab" id="1_wtcfe"]
 
-[node name="Node2D" type="Node2D" unique_id=2106903659]
+[node name="Node2D" type="Node2D" unique_id=1299694310]
 
-[node name="00_spr_03_action_01_level3" type="SpriteStudioPlayer2D" parent="." unique_id=1405222810]
-position = Vector2(139, 381)
+[node name="00_spr_03_action_01_level3" type="SpriteStudioPlayer2D" parent="." unique_id=222078339]
+position = Vector2(564, 609)
 ssab = ExtResource("1_wtcfe")
-animation = "00_action_01_left"
+animation = "True_light"
 playing = false
 animation_section_start = 0
-animation_section_end = 373
-cellmaps/spr_00_00_1 = null
-cellmaps/spr_00_00_0 = null
-
-[node name="00_spr_03_action_01_level3" type="SpriteStudioPlayer2D" parent="00_spr_03_action_01_level3" unique_id=1174840223]
-position = Vector2(174, -3)
-ssab = ExtResource("1_wtcfe")
-animation = "00_action_01_left"
-playing = false
-animation_section_start = 0
-animation_section_end = 373
-cellmaps/spr_00_00_1 = null
-cellmaps/spr_00_00_0 = null
-
-[node name="00_spr_03_action_01_level3" type="SpriteStudioPlayer2D" parent="00_spr_03_action_01_level3/00_spr_03_action_01_level3" unique_id=6772756]
-position = Vector2(176, 11)
-ssab = ExtResource("1_wtcfe")
-animation = "00_action_01_left"
-playing = false
-animation_section_start = 0
-animation_section_end = 373
-cellmaps/spr_00_00_1 = null
-cellmaps/spr_00_00_0 = null
-
-[node name="00_spr_03_action_01_level3" type="SpriteStudioPlayer2D" parent="00_spr_03_action_01_level3/00_spr_03_action_01_level3/00_spr_03_action_01_level3" unique_id=1915863492]
-position = Vector2(188, -5)
-ssab = ExtResource("1_wtcfe")
-animation = "00_action_01_left"
-playing = false
-animation_section_start = 0
-animation_section_end = 373
-cellmaps/spr_00_00_1 = null
-cellmaps/spr_00_00_0 = null
-
-[node name="00_spr_03_action_01_level3" type="SpriteStudioPlayer2D" parent="00_spr_03_action_01_level3/00_spr_03_action_01_level3/00_spr_03_action_01_level3/00_spr_03_action_01_level3" unique_id=2104474040]
-position = Vector2(170, -9)
-ssab = ExtResource("1_wtcfe")
-animation = "00_action_01_left"
-playing = false
-animation_section_start = 0
-animation_section_end = 373
-cellmaps/spr_00_00_1 = null
-cellmaps/spr_00_00_0 = null
-
-[node name="00_spr_03_action_01_level3" type="SpriteStudioPlayer2D" parent="00_spr_03_action_01_level3/00_spr_03_action_01_level3/00_spr_03_action_01_level3/00_spr_03_action_01_level3/00_spr_03_action_01_level3" unique_id=1999012952]
-position = Vector2(164, 9)
-ssab = ExtResource("1_wtcfe")
-animation = "00_action_01_left"
-playing = true
-animation_section_start = 0
-animation_section_end = 373
-cellmaps/spr_00_00_1 = null
-cellmaps/spr_00_00_0 = null
+animation_section_end = 120
+sub_frame_enabled = true
+cellmaps/Mask_parts = null

--- a/ss_player/ss_import_dock.cpp
+++ b/ss_player/ss_import_dock.cpp
@@ -137,7 +137,6 @@ SSImportControl::SSImportControl() {
         recent_header->add_child(recent_label);
 
         clear_recent_button = memnew(Button);
-        clear_recent_button->set_text(tr("Clear"));
         clear_recent_button->set_tooltip_text(tr("Clear recent SSPJ files"));
         clear_recent_button->connect("pressed", Callable(this, "_on_clear_recent_pressed"));
         recent_header->add_child(clear_recent_button);
@@ -187,6 +186,7 @@ void SSImportControl::_notification(int p_what) {
             if (browse_button) browse_button->set_button_icon(get_theme_icon(SNAME("Load"), SNAME("EditorIcons")));
             if (reset_button) reset_button->set_button_icon(get_theme_icon(SNAME("Reload"), SNAME("EditorIcons")));
             if (open_dir_button) open_dir_button->set_button_icon(get_theme_icon(SNAME("Filesystem"), SNAME("EditorIcons")));
+            if (clear_recent_button) clear_recent_button->set_button_icon(get_theme_icon(SNAME("Clear"), SNAME("EditorIcons")));
         } break;
         case NOTIFICATION_ENTER_TREE: {
             start_intercepting();

--- a/ss_player/ss_importer.cpp
+++ b/ss_player/ss_importer.cpp
@@ -38,6 +38,7 @@ using namespace godot;
 void SSImporter::_bind_methods() {
     ADD_SIGNAL(MethodInfo("import_started"));
     ADD_SIGNAL(MethodInfo("import_finished"));
+    ClassDB::bind_method(D_METHOD("_on_filesystem_changed", "dir"), &SSImporter::_on_filesystem_changed);
 }
 
 SSImporter::SSImporter() {
@@ -177,6 +178,14 @@ void SSImporter::_finalize_import() {
         efs->scan_changes();
 #endif
     }
+
+    if (any_success && !_import_dst_dirs.is_empty()) {
+        String target_dir = _import_dst_dirs[_import_dst_dirs.size() - 1].get_base_dir();
+        if (!efs->is_connected("filesystem_changed", Callable(this, "_on_filesystem_changed"))) {
+            efs->connect("filesystem_changed", Callable(this, "_on_filesystem_changed").bind(target_dir), Object::CONNECT_ONE_SHOT);
+        }
+    }
+
     _import_dst_dirs.clear();
     _import_generated_files.clear();
     _needs_full_scan = false;
@@ -185,6 +194,13 @@ void SSImporter::_finalize_import() {
     set_process(false);
 
     emit_signal("import_finished");
+}
+
+void SSImporter::_on_filesystem_changed(const String &p_dir) {
+    Object *fs_dock = (Object *)EditorInterface::get_singleton()->get_file_system_dock();
+    if (fs_dock) {
+        fs_dock->call_deferred("navigate_to_path", p_dir);
+    }
 }
 
 Dictionary SSImporter::_load_source_map() const {

--- a/ss_player/ss_importer.h
+++ b/ss_player/ss_importer.h
@@ -77,6 +77,7 @@ private:
   void _enqueue_one(const String &p_sspj_path, const String &p_dst_dir);
   void _start_session(const String &p_dialog_title);
   void _finalize_import();
+  void _on_filesystem_changed(const String &p_dir);
 
   Dictionary _load_source_map() const;
   void _save_source_map(const Dictionary &p_map);

--- a/ss_player/ss_resource_inspector.cpp
+++ b/ss_player/ss_resource_inspector.cpp
@@ -11,6 +11,7 @@
 
 #ifdef SPRITESTUDIO_GODOT_EXTENSION
 #include <godot_cpp/classes/button.hpp>
+#include <godot_cpp/classes/editor_interface.hpp>
 #include <godot_cpp/classes/h_box_container.hpp>
 #include <godot_cpp/classes/os.hpp>
 #include <godot_cpp/classes/project_settings.hpp>
@@ -22,6 +23,7 @@ using namespace godot;
 #include "core/config/project_settings.h"
 #include "core/io/resource.h"
 #include "core/os/os.h"
+#include "editor/editor_interface.h"
 #include "scene/gui/box_container.h"
 #include "scene/gui/button.h"
 #endif
@@ -81,9 +83,12 @@ void SSResourceInspectorPlugin::_add_action_buttons(const String &p_path) {
 
     HBoxContainer *hbox = memnew(HBoxContainer);
 
+    Control *base = EditorInterface::get_singleton()->get_base_control();
+
     if (!_is_unsupported_for_editor()) {
         Button *open_btn = memnew(Button);
         open_btn->set_text(tr("Open SSPJ"));
+        if (base) open_btn->set_button_icon(base->get_theme_icon(SNAME("Load"), SNAME("EditorIcons")));
         open_btn->set_tooltip_text(sspj.is_empty() ? missing_tip : sspj);
         open_btn->connect("pressed", callable_mp(this, &SSResourceInspectorPlugin::_on_open_pressed).bind(p_path));
         hbox->add_child(open_btn);
@@ -91,12 +96,14 @@ void SSResourceInspectorPlugin::_add_action_buttons(const String &p_path) {
 
     Button *reconvert_btn = memnew(Button);
     reconvert_btn->set_text(tr("Reconvert"));
+    if (base) reconvert_btn->set_button_icon(base->get_theme_icon(SNAME("Reload"), SNAME("EditorIcons")));
     reconvert_btn->set_tooltip_text(sspj.is_empty() ? missing_tip : tr("Reconvert from") + " " + sspj);
     reconvert_btn->connect("pressed", callable_mp(this, &SSResourceInspectorPlugin::_on_reconvert_pressed).bind(p_path));
     hbox->add_child(reconvert_btn);
 
     Button *reveal_btn = memnew(Button);
     reveal_btn->set_text(tr("Reveal"));
+    if (base) reveal_btn->set_button_icon(base->get_theme_icon(SNAME("Filesystem"), SNAME("EditorIcons")));
     reveal_btn->set_tooltip_text(tr("Show this file in the OS file manager."));
     reveal_btn->connect("pressed", callable_mp(this, &SSResourceInspectorPlugin::_on_reveal_pressed).bind(p_path));
     hbox->add_child(reveal_btn);


### PR DESCRIPTION
This PR introduces several UX improvements to the SpriteStudio Importer and Inspector:

- Replaces generic terminal prints with `WARN_PRINT` and `ERR_PRINT` for proper error/warning reporting.
- Adds an `AcceptDialog` popup to clearly inform the user when an invalid file (non-.sspj) is dropped into the import dock.
- Updates the progress dialog format to be cleaner and more informative when converting multiple files.
- Automatically expands the FileSystem dock and focuses on the output directory (e.g., `ssab_generated`) after a successful import.
- Adds standard Godot Editor icons to the 'Open SSPJ', 'Reconvert', and 'Reveal' buttons in the inspector.
- Replaces the text on the 'Clear Recent' button with a standard editor icon.
- Moves the converter version label to the bottom of the import dock UI.