### PR TITLE
feat: Add autoplay and editor_playing properties to SpriteStudioPlayer2D

### DIFF
--- a/docs/en/api/player.md
+++ b/docs/en/api/player.md
@@ -24,6 +24,8 @@ func _ready() -> void:
 
 * `set_ssab_resource(res: SSABResource)` / `get_ssab_resource() -> SSABResource`
 * `set_animation(name: String)` / `get_animation() -> String`
+* `set_autoplay(autoplay: bool)` / `is_autoplay() -> bool`: Determines if the selected animation plays automatically when the scene starts.
+* `editor_playing` (bool, Editor-only property): Checking this in the inspector plays the animation as a preview in the editor. This property is never saved in the scene.
 * `play(start_frame: float = -1.0)`: Starts playback. If `start_frame` is `-1.0`, it plays from the current frame or the start of the section.
 * `pause()`: Pauses playback while retaining the current frame.
 * `stop()`: Stops playback and typically resets the state.

--- a/docs/en/workflow/usage_basic.md
+++ b/docs/en/workflow/usage_basic.md
@@ -40,14 +40,14 @@ Once the node is selected, you can adjust various settings from Godot's Inspecto
    Open the dropdown for the `Animation` property in the Inspector. You will see a list of animations contained in the `.ssab`. Select the name of the animation you want to play.
 
 2. **In-Editor Preview**
-   Checking the **`Playing`** property in the Inspector allows the animation to **play directly in the editor without running the game**.
-   Changes to parameters like `Frame`, `Speed`, and `Loop` are reflected in the preview in real-time, enabling quick adjustments.
+   Checking the **`Editor Playing`** property in the Inspector allows the animation to **play directly in the editor without running the game** (this state is not saved to the scene).
+   Changes to parameters like `Frame`, `Speed`, and `Loop Count` are reflected in the preview in real-time, enabling quick adjustments.
 
 > [!TIP]
 > <video autoplay loop muted playsinline width="100%">
 >   <source src="../../assets/inspector_preview.webm" type="video/webm">
 > </video>
-> *(※ Video showing the animation playing in the editor after checking the Playing property will be placed here)*
+> *(※ Video showing the animation playing in the editor after checking the Editor Playing property will be placed here)*
 
 ---
 
@@ -57,11 +57,12 @@ Once the node is selected, you can adjust various settings from Godot's Inspecto
 | -------------------------- | -------- | ------------------------------------------------------------------- |
 | `SSAB Resource`            | Resource | The target `SSABResource` (`.ssab` file) to play                    |
 | `Animation`                | String   | The name of the currently selected animation                        |
+| `Autoplay`                 | bool     | Whether to play automatically when the game starts                  |
+| `Editor Playing`           | bool     | An editor-only flag to preview the animation in the editor          |
 | `Frame`                    | float    | The current frame position                                          |
 | `Speed`                    | float    | Playback speed multiplier (Default: 1.0)                            |
 | `Frame Rate`               | int      | FPS                                                                 |
-| `Loop`                     | int      | Number of loops (`-1` for infinite loop)                            |
-| `Playing`                  | bool     | Playback flag                                                       |
+| `Loop Count`               | int      | Number of loops (`-1` for infinite loop)                            |
 | `Animation Section Start`  | int      | Start frame for partial playback                                    |
 | `Animation Section End`    | int      | End frame for partial playback                                      |
 | `Playback Direction`       | int      | Playback direction                                                  |

--- a/docs/ja/api/player.md
+++ b/docs/ja/api/player.md
@@ -24,6 +24,8 @@ func _ready() -> void:
 
 * `set_ssab_resource(res: SSABResource)` / `get_ssab_resource() -> SSABResource`
 * `set_animation(name: String)` / `get_animation() -> String`
+* `set_autoplay(autoplay: bool)` / `is_autoplay() -> bool`: シーン開始時に自動再生するかどうか。
+* `editor_playing` (bool, エディタ専用プロパティ): インスペクタ上でチェックを入れるとエディタでのみプレビュー再生を行います（シーンには保存されません）。
 * `play(start_frame: float = -1.0)`: 再生を開始します。`-1.0` を指定した場合は、現在のフレームまたは区間の先頭から再生します。
 * `pause()`: 再生を一時停止します。
 * `stop()`: 再生を停止します。

--- a/docs/ja/workflow/usage_basic.md
+++ b/docs/ja/workflow/usage_basic.md
@@ -40,14 +40,14 @@ Godot エディタの強力な機能を活かし、最短の手順でアニメ�
    インスペクタの `Animation` プロパティのドロップダウンを開くと、`.ssab` に含まれるアニメーションのリストが表示されます。再生したいアニメーション名を選択してください。
 
 2. **エディタ上でのプレビュー**
-   インスペクタにある **`Playing`** プロパティにチェックを入れると、**ゲームを実行しなくてもエディタ上でアニメーションが再生されます**。
+   インスペクタにある **`Editor Playing`** プロパティにチェックを入れると、**ゲームを実行しなくてもエディタ上でアニメーションが再生されます**（この状態はシーンには保存されません）。
    `Frame` や `Speed`、`Loop` などのパラメータを変更するとリアルタイムにプレビューへ反映されるため、素早い調整が可能です。
 
 > [!TIP]
 > <video autoplay loop muted playsinline width="100%">
 >   <source src="../../assets/inspector_preview.webm" type="video/webm">
 > </video>
-> *(※上記に Playing にチェックを入れてエディタ上でプレビューが動く様子を示す動画が入ります)*
+> *(※上記に Editor Playing にチェックを入れてエディタ上でプレビューが動く様子を示す動画が入ります)*
 
 ---
 
@@ -57,11 +57,12 @@ Godot エディタの強力な機能を活かし、最短の手順でアニメ�
 | -------------------------- | ------ | ------------------------------------------------------------------- |
 | `SSAB Resource`           | Resource | 再生対象の `SSABResource` (`.ssab` ファイル)                     |
 | `Animation`                | String | 選択中のアニメーション名                                            |
+| `Autoplay`                 | bool   | ゲーム開始時に自動再生するかどうか                                  |
+| `Editor Playing`           | bool   | エディタ上でのみ再生するプレビュー用フラグ                          |
 | `Frame`                    | float  | 現在のフレーム位置                                                  |
 | `Speed`                    | float  | 再生速度倍率 (既定: 1.0)                                            |
 | `Frame Rate`               | int    | FPS                                                                 |
-| `Loop`                     | int    | ループ回数 (`-1` で無限ループ)                                      |
-| `Playing`                  | bool   | 再生フラグ                                                          |
+| `Loop Count`               | int    | ループ回数 (`-1` で無限ループ)                                      |
 | `Animation Section Start` | int    | 部分再生の開始フレーム                                              |
 | `Animation Section End`   | int    | 部分再生の終了フレーム                                              |
 | `Playback Direction`       | int    | 再生方向                                                            |

--- a/ss_player/ss_player_node_2d.cpp
+++ b/ss_player/ss_player_node_2d.cpp
@@ -1,5 +1,11 @@
 #include "ss_player_node_2d.h"
 
+#ifdef SPRITESTUDIO_GODOT_EXTENSION
+#include <godot_cpp/classes/engine.hpp>
+#else
+#include "core/config/engine.h"
+#endif
+
 class SpriteStudioPlayer2D::_SignalSink : public SsPlayerEventSink {
 public:
     explicit _SignalSink(SpriteStudioPlayer2D* p_owner) : _owner(p_owner) {}
@@ -119,6 +125,14 @@ String SpriteStudioPlayer2D::getAnimation() const {
     return _internal->getAnimation();
 }
 
+void SpriteStudioPlayer2D::setAutoplay(bool p_autoplay) {
+    _autoplay = p_autoplay;
+}
+
+bool SpriteStudioPlayer2D::isAutoplay() const {
+    return _autoplay;
+}
+
 bool SpriteStudioPlayer2D::isPlaying() const { return _internal->isPlaying(); }
 void SpriteStudioPlayer2D::play(float p_start_frame) { _internal->play(p_start_frame); }
 bool SpriteStudioPlayer2D::isPausing() const { return _internal->isPausing(); }
@@ -162,6 +176,9 @@ void SpriteStudioPlayer2D::_bind_methods() {
     ClassDB::bind_method( D_METHOD( "get_ssab_resource" ), &SpriteStudioPlayer2D::getSSABResource );
     ClassDB::bind_method( D_METHOD( "set_animation", "name" ), &SpriteStudioPlayer2D::setAnimation );
     ClassDB::bind_method( D_METHOD( "get_animation" ), &SpriteStudioPlayer2D::getAnimation );
+
+    ClassDB::bind_method( D_METHOD( "set_autoplay", "autoplay" ), &SpriteStudioPlayer2D::setAutoplay );
+    ClassDB::bind_method( D_METHOD( "is_autoplay" ), &SpriteStudioPlayer2D::isAutoplay );
 
     ClassDB::bind_method( D_METHOD( "is_playing" ), &SpriteStudioPlayer2D::isPlaying );
     ClassDB::bind_method( D_METHOD( "play", "start_frame" ), &SpriteStudioPlayer2D::play, DEFVAL(-1.0f) );
@@ -237,6 +254,9 @@ bool SpriteStudioPlayer2D::_set(const StringName& p_name, const Variant& p_prope
     if (name == "animation") {
         setAnimation(p_property);
         return true;
+    } else if (name == "autoplay") {
+        setAutoplay(p_property);
+        return true;
     } else if (name == "frame") {
         setFrame(p_property);
         return true;
@@ -252,7 +272,7 @@ bool SpriteStudioPlayer2D::_set(const StringName& p_name, const Variant& p_prope
     } else if (name == "sub_frame_enabled") {
         setSubFrameEnabled(p_property);
         return true;
-    } else if (name == "playing") {
+    } else if (name == "editor_playing") {
         if (p_property) {
             play();
         } else {
@@ -290,6 +310,9 @@ bool SpriteStudioPlayer2D::_get(const StringName& p_name, Variant& r_property) c
     if (name == "animation") {
         r_property = getAnimation();
         return true;
+    } else if (name == "autoplay") {
+        r_property = isAutoplay();
+        return true;
     } else if (name == "frame") {
         r_property = getFrame();
         return true;
@@ -305,7 +328,7 @@ bool SpriteStudioPlayer2D::_get(const StringName& p_name, Variant& r_property) c
     } else if (name == "sub_frame_enabled") {
         r_property = isSubFrameEnabled();
         return true;
-    } else if (name == "playing") {
+    } else if (name == "editor_playing") {
         r_property = isPlaying();
         return true;
     } else if (name == "playback_direction") {
@@ -345,7 +368,9 @@ void SpriteStudioPlayer2D::_get_property_list(List<PropertyInfo>* p_list) const 
         Vector<String> anim_names = res->get_animation_names();
 #endif
         p_list->push_back(PropertyInfo(Variant::STRING, "animation", PROPERTY_HINT_ENUM, String(",").join(anim_names)));
-        p_list->push_back(PropertyInfo(Variant::BOOL, "playing"));
+        p_list->push_back(PropertyInfo(Variant::BOOL, "autoplay"));
+
+        p_list->push_back(PropertyInfo(Variant::BOOL, "editor_playing", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR));
 
         int total = getTotalFrames();
         int max_frame = total > 0 ? total - 1 : 0;
@@ -385,6 +410,13 @@ void SpriteStudioPlayer2D::_get_property_list(List<PropertyInfo>* p_list) const 
 
 void SpriteStudioPlayer2D::_notification(int p_notification) {
     switch (p_notification) {
+        case NOTIFICATION_READY:
+            if (!Engine::get_singleton()->is_editor_hint()) {
+                if (_autoplay) {
+                    play();
+                }
+            }
+            break;
         case NOTIFICATION_ENTER_TREE:
             // Re-parent the InternalPlayer's root canvas item to ours so the
             // Node2D's transform / visibility / Z-order propagate. Also done

--- a/ss_player/ss_player_node_2d.h
+++ b/ss_player/ss_player_node_2d.h
@@ -27,6 +27,9 @@ public:
     void setAnimation( const String& strName );
     String getAnimation() const;
 
+    void setAutoplay( bool p_autoplay );
+    bool isAutoplay() const;
+
     bool isPlaying() const;
     void play( float p_start_frame = -1.0f );
     bool isPausing() const;
@@ -73,6 +76,7 @@ private:
     SsInternalPlayer* _internal = nullptr;
 
     HashMap<String, Ref<Texture2D>> _cellmap_overrides;
+    bool _autoplay = false;
 
     // Adapter that turns SsInternalPlayer event callbacks into Node-level
     // emit_signal calls. Lifetime tied to the Node; lives in the cpp file.


### PR DESCRIPTION
## Description
- Added the `autoplay` property to allow animations to play automatically when the scene starts (similar to Godot's built-in `AnimationPlayer`).
- Renamed the `preview_playing` flag to `editor_playing` for better clarity.
- Ensured `editor_playing` uses `PROPERTY_USAGE_EDITOR` so that the preview playback state is never saved to the scene file (`.tscn`), preventing unintended playback bugs in production.
- Updated the relevant documentation (API references and basic usage guides) in both English and Japanese.

## Changes
- Implemented `_autoplay` member, setter, and getter in `SpriteStudioPlayer2D`.
- Added a check in `NOTIFICATION_READY` to call `play()` if `autoplay` is true.
- Modified `_get_property_list` to rename the editor preview property and removed the unnecessary property group.
- Updated `docs/en` and `docs/ja`.
