### PR TITLE
fix: Remove duplicated hierarchy alpha in PartColor paths

### DIFF
--- a/ss_player/ss_internal_player.cpp
+++ b/ss_player/ss_internal_player.cpp
@@ -1474,9 +1474,9 @@ int SsInternalPlayer::_build_normal(const DrawFrame& f, int p_idx,
         // a consistent semantic regardless of the source (blend_type, target):
         //   pc->lt/rt/lb/rb->rgba.a  = rateAlpha (final-alpha source, u8)
         //   pc->lt/rt/lb/rb->rate    = colorA    (blend weight, float)
-        auto to_color = [part_alpha](const ss::runtime::SsAttributePartColorKeyValueColor& c) {
+        auto to_color = [](const ss::runtime::SsAttributePartColorKeyValueColor& c) {
             return Color(c.rgba().r()/255.0f, c.rgba().g()/255.0f, c.rgba().b()/255.0f,
-                         (c.rgba().a()/255.0f) * part_alpha);
+                         c.rgba().a()/255.0f);
         };
         corner_colors[0] = to_color(pc->lt());
         corner_colors[1] = to_color(pc->rt());
@@ -1772,12 +1772,10 @@ bool SsInternalPlayer::_build_shape_geometry(const DrawFrame& f, int p_idx,
         auto pc = f.frameData->parts_color()->Get(partColorIndex);
         // SDK-mediated semantic — see _build_normal for the field meanings.
         // Shape paths additionally get the (blend_type == Mix → rgba.a = 255)
-        // override applied at convert time, so multiplying by part_alpha here
-        // gives `vertex.a = part_alpha` for Mix shapes and `vertex.a = dataA ×
-        // part_alpha` for non-Mix shapes — both matching the SS shape spec.
-        auto to_color = [part_alpha](const ss::runtime::SsAttributePartColorKeyValueColor& c) {
+        // override applied at convert time.
+        auto to_color = [](const ss::runtime::SsAttributePartColorKeyValueColor& c) {
             return Color(c.rgba().r()/255.0f, c.rgba().g()/255.0f, c.rgba().b()/255.0f,
-                         (c.rgba().a()/255.0f) * part_alpha);
+                         c.rgba().a()/255.0f);
         };
         corner_colors[0] = to_color(pc->lt());
         corner_colors[1] = to_color(pc->rt());
@@ -2221,9 +2219,9 @@ bool SsInternalPlayer::_build_mesh_geometry(const DrawFrame& f, int p_idx,
     const auto partColorIndex = part->part_color();
     if ((flags & ss::runtime::UpdateAttributeFlags_AttributePartColor) && partColorIndex >= 0 && f.frameData->parts_color() != nullptr) {
         auto pc = f.frameData->parts_color()->Get(partColorIndex);
-        auto to_color = [part_alpha](const ss::runtime::SsAttributePartColorKeyValueColor& c) {
+        auto to_color = [](const ss::runtime::SsAttributePartColorKeyValueColor& c) {
             return Color(c.rgba().r()/255.0f, c.rgba().g()/255.0f, c.rgba().b()/255.0f,
-                         (c.rgba().a()/255.0f) * part_alpha);
+                         c.rgba().a()/255.0f);
         };
         mesh_color = to_color(pc->lt());
         mesh_rate = pc->lt().rate();


### PR DESCRIPTION
The runtime (framedata.rs) already pre-multiplies the effective (hierarchy-composited) alpha into parts_color rgba.a. The player's to_color lambdas multiplied by part_alpha again, applying the hierarchy alpha twice for normal, shape, and mesh parts that carry a PartColor attribute. Drop the extra `* part_alpha` from the three PartColor to_color lambdas.