### PR TITLE
docs: update ssqb status and SDK reference for Phase 3

### DIFF
--- a/docs/en/workflow/tips.md
+++ b/docs/en/workflow/tips.md
@@ -23,3 +23,4 @@ There are two types of animation binaries imported into Godot:
 - **SSQB (Sequence Binary)**
   - This is a "sequence" of multiple animations (e.g., `Walk` -> `Run` -> `Jump`) linked together on the timeline within SpriteStudio.
   - Use this when you want to reproduce the exact continuous playback designed in SpriteStudio directly in Godot, without writing complex state transition logic in your GDScript.
+  - **Note (current status):** Loading into `SSQBResource` is supported, but **sequence playback is not available yet** (planned — subsumed into the runtime state machine in roadmap Phase 3, or a Player-side prototype). For now, chain animations yourself in GDScript via the `animation_finished` signal.

--- a/docs/ja/workflow/tips.md
+++ b/docs/ja/workflow/tips.md
@@ -23,3 +23,4 @@ Godot へインポートされたアニメーションバイナリには、2つ�
 - **SSQB (Sequence Binary)**
   - 複数のアニメーション（例: `歩き` → `走り` → `ジャンプ`）を SpriteStudio 側で「シーケンス」としてタイムライン上に連結したものです。
   - プログラム（GDScript）側で複雑な状態遷移を書かずとも、デザイナーが SpriteStudio 上で設定した通りの連続再生を Godot 上でそのまま再現したい場合に使用します。
+  - **注意 (現状)**: `SSQBResource` への読み込みには対応していますが、**シーケンス再生は現時点では未提供**です（今後対応予定 — ロードマップ Phase 3 の state machine への内包、または Player 側 prototype）。当面の連続再生は `animation_finished` シグナルで GDScript 側から次アニメに切り替えて実現してください。


### PR DESCRIPTION
Included SDK documentation updates for Phase 3 state machine / ssqb design, and updated Player-side docs to clarify the current status.