### PR TITLE
feat: Add AnimationLibrary generation for SSAB/SSQB

### DIFF
--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -15,6 +15,7 @@ Animation playback uses `libssruntime` provided by [SpriteStudio7-SDK](https://g
     - [Build Guide](setup/build.md)
 - **Workflow**
     - [Basic Usage](workflow/usage_basic.md)
+    - [Integration with AnimationPlayer](workflow/animation_player.md)
     - [Asset Import and Editor Integration](workflow/usage_asset_pipeline.md) (start here for the initial `.sspj` import)
     - [Scripting and Events](workflow/usage_scripting.md)
 - **Advanced Topics**

--- a/docs/en/workflow/animation_player.md
+++ b/docs/en/workflow/animation_player.md
@@ -1,0 +1,54 @@
+# Integration with AnimationPlayer (Cinematics and State Machines)
+
+By combining SSPlayer with Godot's standard `AnimationPlayer`, you can integrate SpriteStudio animation playback with Godot's powerful timeline and state machine features.
+
+This enables you to visually perform tasks such as **synchronizing attack hitboxes, triggering sound effects (SE), shaking the camera, and creating cutscenes** without writing complex code.
+
+---
+
+## 1. Generating an Animation Library
+
+To control SSPlayer with an `AnimationPlayer`, you must first convert all animations (e.g., walk, attack) contained in the target `.ssab` file into an `AnimationLibrary` (`_anims.res`) that Godot can read.
+
+1. In the Godot editor, select the `.ssab` (or `.ssqb`) file from the FileSystem dock.
+2. Click the **"Gen AnimLib"** button at the bottom of the Inspector.
+3. Upon success, a file named `[original_filename]_anims.res` will be generated in the same directory.
+
+> [!NOTE]
+> The generated `_anims.res` automatically contains "Value Tracks" with the exact same names as the original SpriteStudio animations. These tracks control the `animation` (animation name) and `frame` (current frame) properties of the target node.
+
+---
+
+## 2. Setting Up the AnimationPlayer
+
+Here is how to apply the generated library to your scene.
+
+1. **Prepare the Node**
+   Place a `SpriteStudioPlayer2D` node in your scene and assign the target `.ssab` file to its `SSAB Resource` property.
+2. **Add an AnimationPlayer**
+   Add an `AnimationPlayer` node to the scene.
+3. **Specify the Target (Important!)**
+   Select the added `AnimationPlayer` node and set its **`Root Node`** property in the Inspector to the **`SpriteStudioPlayer2D` node** from step 1.
+   *Note: Since the generated animations are configured to control the `animation` and `frame` properties of the target node itself, the Root Node must point directly to the SSPlayer node.*
+4. **Load the Library**
+   Open the "Animation" panel at the bottom of the editor, click the "Animation" menu > **"Manage Animations..."**.
+   Click the folder icon (Load Library) in the dialog that appears, and load the generated `_anims.res` file.
+
+You will now see a list of all animations created in SpriteStudio directly in the AnimationPlayer dropdown!
+
+---
+
+## 3. Advanced Use Cases
+
+Once integrated with `AnimationPlayer`, you unlock several advanced control methods:
+
+### A. Synchronizing with Events and Sound Effects (Call Method Track / Audio Track)
+Add a "Call Method Track" or "Audio Playback Track" on the AnimationPlayer timeline.
+You can visually and perfectly sync the exact frame a character swings a sword with playing a sound effect or calling a GDScript function like `enable_hitbox()`.
+
+### B. Using State Machines (AnimationTree)
+Add an `AnimationTree` node to the scene and assign the aforementioned AnimationPlayer to its `Anim Player` property.
+By setting the `Tree Root` to `AnimationNodeStateMachine`, you can visually construct state transitions (e.g., Idle -> Walk -> Attack) using a node-based interface instead of writing complex logic in code.
+
+### C. Cutscenes and Cinematics
+By adding tracks that move the camera (`Camera2D`), change background colors, or trigger other visual effects, you can create fully synchronized event scenes (cutscenes) all within a single timeline.

--- a/docs/ja/index.md
+++ b/docs/ja/index.md
@@ -15,6 +15,7 @@
     - [ビルドガイド](setup/build.md)
 - **ワークフロー**
     - [基本的な使い方](workflow/usage_basic.md)
+    - [AnimationPlayer との連携](workflow/animation_player.md)
     - [アセットのインポートとエディタ連携](workflow/usage_asset_pipeline.md)（初回の `.sspj` インポートはこちら）
     - [スクリプト制御とイベント](workflow/usage_scripting.md)
 - **応用**

--- a/docs/ja/workflow/animation_player.md
+++ b/docs/ja/workflow/animation_player.md
@@ -1,0 +1,54 @@
+# AnimationPlayer との連携 (シネマティクスとステートマシン)
+
+Godot 標準の `AnimationPlayer` と組み合わせることで、SSPlayer のアニメーション再生を Godot の強力なタイムライン機能やステートマシン機能と連携させることができます。
+
+これにより、**攻撃判定（Hitbox）の同期、効果音（SE）の再生タイミング、カメラの揺らし、カットシーンの作成**などが、ノーコードで視覚的に行えるようになります。
+
+---
+
+## 1. アニメーションライブラリの生成
+
+SSPlayer を `AnimationPlayer` で制御するためには、まず対象の `.ssab` に含まれるすべてのアニメーション（walk, attack など）を Godot が読み込める `AnimationLibrary`（`_anims.res`）に変換する必要があります。
+
+1. Godot エディタ上で、ファイルシステムから `.ssab`（または `.ssqb`）ファイルを選択します。
+2. インスペクタの下部にある **「Gen AnimLib (AnimationPlayer用ライブラリを生成)」** ボタンをクリックします。
+3. 成功すると、同じフォルダに `[元のファイル名]_anims.res` というファイルが生成されます。
+
+> [!NOTE]
+> 生成された `_anims.res` の中には、元の SpriteStudio アニメーションと同じ名前の「Value Track（値トラック）」が自動生成されています。このトラックは対象ノードの `animation`（アニメーション名）と `frame`（現在のフレーム）を制御します。
+
+---
+
+## 2. AnimationPlayer のセットアップ
+
+生成されたライブラリを実際にシーンへ適用する手順です。
+
+1. **ノードの準備**
+   シーン上に `SpriteStudioPlayer2D` ノードを配置し、対象の `.ssab` を `SSAB Resource` にセットしておきます。
+2. **AnimationPlayer の追加**
+   シーン内に `AnimationPlayer` ノードを追加します。
+3. **ターゲットの指定（重要！）**
+   追加した `AnimationPlayer` ノードを選択し、インスペクタ内の **`Root Node`** を、手順1の **`SpriteStudioPlayer2D` ノード** に設定します。
+   *※自動生成されたアニメーションは「対象ノード自身の `animation` と `frame` を制御する」ようになっているため、Root Node を対象ノードに向ける必要があります。*
+4. **ライブラリの読み込み**
+   エディタ下部の「アニメーション (Animation)」パネルを開き、「アニメーション」メニュー ＞ **「アニメーションを管理... (Manage Animations)」** をクリックします。
+   出てきたウィンドウのフォルダアイコン（ライブラリをロード）を押し、生成された `_anims.res` を読み込みます。
+
+これで AnimationPlayer のドロップダウンに、SpriteStudio で作成したアニメーション一覧が表示されるようになります！
+
+---
+
+## 3. 応用例
+
+AnimationPlayer と連携できるようになると、以下のような高度な制御が可能になります。
+
+### A. イベントや効果音との同期（Call Method Track / Audio Track）
+AnimationPlayer のタイムライン上で「トラックを追加」し、`Call Method Track` や `Audio Playback Track` を追加します。
+「剣を振り下ろしたフレーム」に合わせて効果音を鳴らしたり、GDScript の `enable_hitbox()` 関数を呼び出したりするタイミングを、目で見ながら完璧に合わせることができます。
+
+### B. ステートマシン（AnimationTree）の利用
+シーンに `AnimationTree` ノードを追加し、`Anim Player` に上記の AnimationPlayer を割り当てます。
+`Tree Root` に `AnimationNodeStateMachine` を設定することで、Idle（待機）→ Walk（歩き）→ Attack（攻撃）といった状態遷移を、コードではなくノード同士を矢印で繋ぐUI（ステートマシン）で構築できるようになります。
+
+### C. カットシーン・シネマティクス
+カメラ (`Camera2D`) の位置を動かすトラックや、背景の色を変えるトラックなどを追加することで、キャラクターの動きと完全に連動したイベントシーン（カットシーン）をひとつのタイムライン上で作成できます。

--- a/ss_player/ss_resource_inspector.cpp
+++ b/ss_player/ss_resource_inspector.cpp
@@ -18,6 +18,10 @@
 #include <godot_cpp/classes/resource.hpp>
 #include <godot_cpp/core/class_db.hpp>
 #include <godot_cpp/variant/utility_functions.hpp>
+#include <godot_cpp/classes/animation.hpp>
+#include <godot_cpp/classes/animation_library.hpp>
+#include <godot_cpp/classes/resource_saver.hpp>
+#include <godot_cpp/classes/editor_file_system.hpp>
 using namespace godot;
 #else
 #include "core/config/project_settings.h"
@@ -26,12 +30,24 @@ using namespace godot;
 #include "editor/editor_interface.h"
 #include "scene/gui/box_container.h"
 #include "scene/gui/button.h"
+#include "scene/resources/animation.h"
+#include "scene/resources/animation_library.h"
+#include "core/io/resource_saver.h"
+#if VERSION_MAJOR >= 4
+    #if VERSION_MINOR >= 5
+    #include "editor/file_system/editor_file_system.h"
+    #else
+    #include "editor/editor_file_system.h"
+    #endif
+#else
+    #include "editor/editor_file_system.h"
+#endif
 #endif
 
 void SSResourceInspectorPlugin::_bind_methods() {
     ClassDB::bind_method(D_METHOD("_on_open_pressed", "path"), &SSResourceInspectorPlugin::_on_open_pressed);
     ClassDB::bind_method(D_METHOD("_on_reconvert_pressed", "path"), &SSResourceInspectorPlugin::_on_reconvert_pressed);
-    ClassDB::bind_method(D_METHOD("_on_reveal_pressed", "path"), &SSResourceInspectorPlugin::_on_reveal_pressed);
+    ClassDB::bind_method(D_METHOD("_on_generate_animation_library_pressed", "path"), &SSResourceInspectorPlugin::_on_generate_animation_library_pressed);
 }
 
 SSResourceInspectorPlugin::SSResourceInspectorPlugin() {
@@ -101,12 +117,12 @@ void SSResourceInspectorPlugin::_add_action_buttons(const String &p_path) {
     reconvert_btn->connect("pressed", callable_mp(this, &SSResourceInspectorPlugin::_on_reconvert_pressed).bind(p_path));
     hbox->add_child(reconvert_btn);
 
-    Button *reveal_btn = memnew(Button);
-    reveal_btn->set_text(tr("Reveal"));
-    if (base) reveal_btn->set_button_icon(base->get_theme_icon(SNAME("Filesystem"), SNAME("EditorIcons")));
-    reveal_btn->set_tooltip_text(tr("Show this file in the OS file manager."));
-    reveal_btn->connect("pressed", callable_mp(this, &SSResourceInspectorPlugin::_on_reveal_pressed).bind(p_path));
-    hbox->add_child(reveal_btn);
+    Button *anim_btn = memnew(Button);
+    anim_btn->set_text(tr("Gen AnimLib"));
+    if (base) anim_btn->set_button_icon(base->get_theme_icon(SNAME("AnimationLibrary"), SNAME("EditorIcons")));
+    anim_btn->set_tooltip_text(tr("Generate an AnimationLibrary resource from this SSAB for use with AnimationPlayer."));
+    anim_btn->connect("pressed", callable_mp(this, &SSResourceInspectorPlugin::_on_generate_animation_library_pressed).bind(p_path));
+    hbox->add_child(anim_btn);
 
     add_custom_control(hbox);
 }
@@ -129,11 +145,72 @@ void SSResourceInspectorPlugin::_on_reconvert_pressed(const String &p_resource_p
     context_menu->_on_convert(paths);
 }
 
-void SSResourceInspectorPlugin::_on_reveal_pressed(const String &p_resource_path) {
-    String global = ProjectSettings::get_singleton()->globalize_path(p_resource_path);
-    Error err = OS::get_singleton()->shell_show_in_file_manager(global, false);
-    if (err != OK) {
-        ERR_PRINT(vformat("SSResourceInspectorPlugin: failed to reveal %s. error=%d", global, (int)err));
+void SSResourceInspectorPlugin::_on_generate_animation_library_pressed(const String &p_resource_path) {
+    Ref<SSABResource> ssab;
+    ssab.instantiate();
+    if (ssab->load_from_file(p_resource_path) != OK) {
+        ERR_PRINT("Failed to load SSAB for AnimationLibrary generation: " + p_resource_path);
+        return;
+    }
+
+    Ref<AnimationLibrary> library;
+    library.instantiate();
+
+#ifdef SPRITESTUDIO_GODOT_EXTENSION
+    PackedStringArray anim_names = ssab->get_animation_names();
+#else
+    Vector<String> anim_names = ssab->get_animation_names();
+#endif
+
+    for (int i = 0; i < anim_names.size(); i++) {
+        String anim_name = anim_names[i];
+        ss::format::AnimationData *data = ssab->find_animation(anim_name);
+        if (!data) continue;
+
+        float fps = (float)data->fps();
+        if (fps <= 0.0f) fps = 60.0f;
+        int total_frames = data->total_frame();
+        float length = (float)total_frames / fps;
+
+        Ref<Animation> anim;
+        anim.instantiate();
+        anim->set_length(length);
+        anim->set_step(1.0f / fps);
+
+        // Track 0: animation
+        int track_anim = anim->add_track(Animation::TYPE_VALUE);
+        anim->track_set_path(track_anim, NodePath(".:animation"));
+        anim->track_insert_key(track_anim, 0.0, anim_name);
+        anim->value_track_set_update_mode(track_anim, Animation::UPDATE_DISCRETE);
+
+        // Track 1: frame
+        int track_frame = anim->add_track(Animation::TYPE_VALUE);
+        anim->track_set_path(track_frame, NodePath(".:frame"));
+        anim->track_insert_key(track_frame, 0.0, 0.0f);
+        anim->track_insert_key(track_frame, length, (float)total_frames);
+        
+        anim->value_track_set_update_mode(track_frame, Animation::UPDATE_CONTINUOUS);
+        anim->track_set_interpolation_type(track_frame, Animation::INTERPOLATION_LINEAR);
+
+        library->add_animation(anim_name, anim);
+    }
+
+    String out_path = p_resource_path.get_basename() + "_anims.res";
+#ifdef SPRITESTUDIO_GODOT_EXTENSION
+    Error err = ResourceSaver::get_singleton()->save(library, out_path);
+#else
+    Error err = ResourceSaver::save(library, out_path);
+#endif
+
+    if (err == OK) {
+        EditorInterface::get_singleton()->get_resource_filesystem()->scan();
+#ifdef SPRITESTUDIO_GODOT_EXTENSION
+        UtilityFunctions::print("Generated AnimationLibrary: " + out_path);
+#else
+        print_line("Generated AnimationLibrary: " + out_path);
+#endif
+    } else {
+        ERR_PRINT("Failed to save AnimationLibrary to " + out_path);
     }
 }
 

--- a/ss_player/ss_resource_inspector.h
+++ b/ss_player/ss_resource_inspector.h
@@ -40,7 +40,7 @@ public:
 
   void _on_open_pressed(const String &p_resource_path);
   void _on_reconvert_pressed(const String &p_resource_path);
-  void _on_reveal_pressed(const String &p_resource_path);
+  void _on_generate_animation_library_pressed(const String &p_resource_path);
 
 private:
   SSImporter *importer = nullptr;


### PR DESCRIPTION
## Description

This PR implements the highly requested feature to integrate SpriteStudio animations with Godot's standard `AnimationPlayer`.

### Changes
- Added a `Gen AnimLib` button to the Inspector when selecting `.ssab` or `.ssqb` resources.
- Automatically generates an `AnimationLibrary` (`_anims.res`) from the SpriteStudio file.
- Generates standard Godot Value Tracks for `animation` (discrete) and `frame` (continuous linear) properties.
- Ensures compatibility across both **GDExtension** and **Custom Module** build configurations (resolving minor API differences between `ResourceSaver` and `EditorInterface`).
- Removed the redundant 'Reveal' button from the Inspector to declutter the UI.
- Added comprehensive documentation on how to set up and use the integration (`docs/ja/workflow/animation_player.md` and `docs/en/workflow/animation_player.md`).

This allows users to easily synchronize Audio Tracks, Call Method Tracks, Hitbox monitoring, and seamlessly integrate SpriteStudio animations into Godot's visual `AnimationTree` state machines.