### PR TITLE
feat(player): add SpriteStudioPartAttachment2D for part following

### DIFF
--- a/ss_player/register_types.cpp
+++ b/ss_player/register_types.cpp
@@ -33,6 +33,7 @@ static void editor_init_callback() {
 
 #include "ssab_resource.h"
 #include "ss_player_node_2d.h"
+#include "ss_part_attachment_2d.h"
 #include "ssqb_resource.h"
 
 static SSABResourceFormatLoader *ssab_loader = nullptr;
@@ -78,6 +79,7 @@ void register_ss_player_types() {
 #endif
 
   GDREGISTER_CLASS(SpriteStudioPlayer2D);
+  GDREGISTER_CLASS(SpriteStudioPartAttachment2D);
 }
 
 void unregister_ss_player_types() {

--- a/ss_player/ss_internal_player.cpp
+++ b/ss_player/ss_internal_player.cpp
@@ -275,6 +275,67 @@ void SsInternalPlayer::setSSABResource(const Ref<SSABResource>& ssabRes) {
     _load_external_ssabs();
 
     _fetchAnimation();
+
+    // Build the part name -> index map for the query API. Done after the
+    // resource is validated; parts() is animation-independent (it lives on the
+    // binary), so one rebuild per resource covers every animation.
+    _rebuild_part_index_map();
+}
+
+void SsInternalPlayer::_rebuild_part_index_map() {
+    _part_name_to_index.clear();
+    _part_names.clear();
+    if (_ssabRes.is_null()) return;
+    const ss::format::SsAnimeBinary* binary = _ssabRes->get_ss_anime_binary();
+    if (!binary || !binary->parts()) return;
+    auto parts = binary->parts();
+    const uint32_t n = parts->size();
+    _part_names.resize(n);
+    for (uint32_t i = 0; i < n; i++) {
+        const auto* pd = parts->Get(i);
+        String nm = (pd && pd->name()) ? String::utf8(pd->name()->c_str()) : String();
+        _part_names[i] = nm;
+        // First occurrence wins; duplicate part names are not expected within a
+        // single binary, but guard against clobbering a lower index just in case.
+        if (!nm.is_empty() && !_part_name_to_index.has(nm)) {
+            _part_name_to_index[nm] = (int)i;
+        }
+    }
+}
+
+int SsInternalPlayer::resolve_part_index(const String& p_name) const {
+    const int* idx = _part_name_to_index.getptr(p_name);
+    return idx ? *idx : -1;
+}
+
+bool SsInternalPlayer::try_get_part_local_transform(int p_part_index, Transform2D& r_xf) const {
+    if (p_part_index < 0 || runtime_ctx == nullptr) return false;
+    const float* wm = nullptr;
+    uintptr_t len = 0;
+    ss_runtime_get_world_matrices(runtime_ctx, &wm, &len);
+    if (!wm) return false;
+    constexpr int FLOATS_PER_MATRIX = 16;
+    if ((uintptr_t)p_part_index * FLOATS_PER_MATRIX + FLOATS_PER_MATRIX > len) return false;
+    const float* m = wm + (p_part_index * FLOATS_PER_MATRIX);
+    // Same column-major layout the draw path consumes (see matrix_to_transform2d).
+    r_xf = Transform2D(m[0], m[1], m[4], m[5], m[12], m[13]);
+    return true;
+}
+
+bool SsInternalPlayer::try_get_part_hidden(int p_part_index, bool& r_hidden) const {
+    r_hidden = false;
+    if (p_part_index < 0 || (uint32_t)p_part_index >= _part_hidden.size()) return false;
+    r_hidden = _part_hidden[p_part_index] != 0;
+    return true;
+}
+
+int SsInternalPlayer::get_part_count() const {
+    return (int)_part_names.size();
+}
+
+String SsInternalPlayer::get_part_name(int p_part_index) const {
+    if (p_part_index < 0 || (uint32_t)p_part_index >= _part_names.size()) return String();
+    return _part_names[p_part_index];
 }
 
 void SsInternalPlayer::onSSABReloaded() {
@@ -1080,13 +1141,20 @@ void SsInternalPlayer::_drawAnimation(float frame_no, float delta_seconds, bool 
     {
         const int total = f.binary->parts() ? (int)f.binary->parts()->size() : 0;
         if ((int)_parts_by_idx.size() != total) _parts_by_idx.resize(total);
+        if ((int)_part_hidden.size() != total) _part_hidden.resize(total);
         if (total > 0) {
             memset(_parts_by_idx.ptr(), 0, total * sizeof(void*));
+            // Default to visible; parts absent from this frame's PartState list
+            // (not active) read as not-hidden via the query API.
+            memset(_part_hidden.ptr(), 0, total * sizeof(uint8_t));
         }
         for (uint32_t i = 0; i < parts->size(); i++) {
             auto p = parts->Get(i);
             int idx = p->part_index();
-            if (idx >= 0 && idx < total) _parts_by_idx[idx] = p;
+            if (idx >= 0 && idx < total) {
+                _parts_by_idx[idx] = p;
+                _part_hidden[idx] = p->hide() ? 1 : 0;
+            }
         }
     }
 

--- a/ss_player/ss_internal_player.h
+++ b/ss_player/ss_internal_player.h
@@ -184,6 +184,25 @@ public:
     // (mirrors the previous Resource::changed signal handler).
     void onSSABReloaded();
 
+    // ---- Part query API (for follow / attachment nodes) -------------------
+    // Read-only access to the current frame's part poses. The player never
+    // owns or drives external nodes; these just expose what it already
+    // computes so a SpriteStudioPartAttachment2D can mirror a part.
+    //
+    // Resolve a part name to its index in the current binary; -1 if unknown.
+    int resolve_part_index(const String& p_name) const;
+    // Player-local Transform2D of the part for the current frame (the same
+    // matrix the part draws with, via matrix_to_transform2d of its world
+    // matrix). False if the index is out of range or no frame data exists.
+    bool try_get_part_local_transform(int p_part_index, Transform2D& r_xf) const;
+    // Per-part hide flag for the current frame. False (with r_hidden=false)
+    // when the index is out of range.
+    bool try_get_part_hidden(int p_part_index, bool& r_hidden) const;
+    // Number of parts in the current binary, and the name of part i ("" if out
+    // of range). Used to populate the editor part-name dropdown.
+    int get_part_count() const;
+    String get_part_name(int p_part_index) const;
+
 private:
 #ifdef SPRITESTUDIO_GODOT_EXTENSION
     using SsVec2Array = PackedVector2Array;
@@ -281,6 +300,16 @@ private:
     Vector<RID> _batch_canvas_items;
     int _batch_canvas_items_in_use = 0;
     LocalVector<const ss::runtime::PartState*> _parts_by_idx;
+    // Part name -> index map + ordered names, rebuilt from the binary's
+    // PartData by `_rebuild_part_index_map` on setSSABResource. Backs the part
+    // query API (follow / attachment nodes). Indices match the part_index
+    // space the world matrices and `_parts_by_idx` use.
+    HashMap<String, int> _part_name_to_index;
+    LocalVector<String> _part_names;
+    // Per-part hide flag for the current frame, indexed by part_index. Rebuilt
+    // each _drawAnimation; 0 (visible) for parts absent from the frame.
+    LocalVector<uint8_t> _part_hidden;
+    void _rebuild_part_index_map();
     String _strAnimationSelected;
     uint32_t _animationSelectedHash = 0;
     const ss::format::AnimationData* _currentAnimationData = nullptr;

--- a/ss_player/ss_part_attachment_2d.cpp
+++ b/ss_player/ss_part_attachment_2d.cpp
@@ -1,0 +1,223 @@
+#include "ss_part_attachment_2d.h"
+
+#include "ss_player_node_2d.h"
+
+void SpriteStudioPartAttachment2D::_bind_methods() {
+    ClassDB::bind_method(D_METHOD("set_part_name", "part_name"), &SpriteStudioPartAttachment2D::set_part_name);
+    ClassDB::bind_method(D_METHOD("get_part_name"), &SpriteStudioPartAttachment2D::get_part_name);
+
+    ClassDB::bind_method(D_METHOD("set_player_path", "path"), &SpriteStudioPartAttachment2D::set_player_path);
+    ClassDB::bind_method(D_METHOD("get_player_path"), &SpriteStudioPartAttachment2D::get_player_path);
+
+    ClassDB::bind_method(D_METHOD("set_remote_path", "path"), &SpriteStudioPartAttachment2D::set_remote_path);
+    ClassDB::bind_method(D_METHOD("get_remote_path"), &SpriteStudioPartAttachment2D::get_remote_path);
+
+    ClassDB::bind_method(D_METHOD("set_use_global_coordinates", "enabled"), &SpriteStudioPartAttachment2D::set_use_global_coordinates);
+    ClassDB::bind_method(D_METHOD("get_use_global_coordinates"), &SpriteStudioPartAttachment2D::get_use_global_coordinates);
+
+    ClassDB::bind_method(D_METHOD("set_update_position", "enabled"), &SpriteStudioPartAttachment2D::set_update_position);
+    ClassDB::bind_method(D_METHOD("get_update_position"), &SpriteStudioPartAttachment2D::get_update_position);
+    ClassDB::bind_method(D_METHOD("set_update_rotation", "enabled"), &SpriteStudioPartAttachment2D::set_update_rotation);
+    ClassDB::bind_method(D_METHOD("get_update_rotation"), &SpriteStudioPartAttachment2D::get_update_rotation);
+    ClassDB::bind_method(D_METHOD("set_update_scale", "enabled"), &SpriteStudioPartAttachment2D::set_update_scale);
+    ClassDB::bind_method(D_METHOD("get_update_scale"), &SpriteStudioPartAttachment2D::get_update_scale);
+
+    ClassDB::bind_method(D_METHOD("set_on_part_hidden", "mode"), &SpriteStudioPartAttachment2D::set_on_part_hidden);
+    ClassDB::bind_method(D_METHOD("get_on_part_hidden"), &SpriteStudioPartAttachment2D::get_on_part_hidden);
+
+    ADD_PROPERTY(PropertyInfo(Variant::STRING, "part_name"), "set_part_name", "get_part_name");
+    ADD_PROPERTY(PropertyInfo(Variant::NODE_PATH, "player_path", PROPERTY_HINT_NODE_PATH_VALID_TYPES, "SpriteStudioPlayer2D"), "set_player_path", "get_player_path");
+    ADD_PROPERTY(PropertyInfo(Variant::NODE_PATH, "remote_path", PROPERTY_HINT_NODE_PATH_VALID_TYPES, "Node2D"), "set_remote_path", "get_remote_path");
+    ADD_PROPERTY(PropertyInfo(Variant::BOOL, "use_global_coordinates"), "set_use_global_coordinates", "get_use_global_coordinates");
+
+    ADD_GROUP("Update", "update_");
+    ADD_PROPERTY(PropertyInfo(Variant::BOOL, "update_position"), "set_update_position", "get_update_position");
+    ADD_PROPERTY(PropertyInfo(Variant::BOOL, "update_rotation"), "set_update_rotation", "get_update_rotation");
+    ADD_PROPERTY(PropertyInfo(Variant::BOOL, "update_scale"), "set_update_scale", "get_update_scale");
+
+    ADD_GROUP("", "");
+    ADD_PROPERTY(PropertyInfo(Variant::INT, "on_part_hidden", PROPERTY_HINT_ENUM, "Follow Always,Hide Target"), "set_on_part_hidden", "get_on_part_hidden");
+
+    BIND_ENUM_CONSTANT(FOLLOW_ALWAYS);
+    BIND_ENUM_CONSTANT(HIDE_TARGET);
+}
+
+SpriteStudioPlayer2D* SpriteStudioPartAttachment2D::_resolve_player() const {
+    if (!_player_path.is_empty()) {
+        Node* n = get_node_or_null(_player_path);
+        return Object::cast_to<SpriteStudioPlayer2D>(n);
+    }
+    // No explicit path: walk up to the nearest ancestor player.
+    Node* p = get_parent();
+    while (p) {
+        SpriteStudioPlayer2D* player = Object::cast_to<SpriteStudioPlayer2D>(p);
+        if (player) return player;
+        p = p->get_parent();
+    }
+    return nullptr;
+}
+
+Node2D* SpriteStudioPartAttachment2D::_resolve_target() {
+    if (!_remote_path.is_empty()) {
+        Node* n = get_node_or_null(_remote_path);
+        return Object::cast_to<Node2D>(n);
+    }
+    return this;
+}
+
+void SpriteStudioPartAttachment2D::_connect_player() {
+    SpriteStudioPlayer2D* player = _resolve_player();
+    if (!player) return;
+    Callable cb = callable_mp(this, &SpriteStudioPartAttachment2D::_on_player_frame_updated);
+    if (!player->is_connected("frame_updated", cb)) {
+        player->connect("frame_updated", cb);
+    }
+}
+
+void SpriteStudioPartAttachment2D::_disconnect_player() {
+    // Resolve via the current member state — callers update _player_path only
+    // after disconnecting, so this finds the player we actually connected to.
+    // A freed player auto-disconnects, so a null result here is safe to ignore.
+    SpriteStudioPlayer2D* player = _resolve_player();
+    if (!player) return;
+    Callable cb = callable_mp(this, &SpriteStudioPartAttachment2D::_on_player_frame_updated);
+    if (player->is_connected("frame_updated", cb)) {
+        player->disconnect("frame_updated", cb);
+    }
+}
+
+void SpriteStudioPartAttachment2D::_on_player_frame_updated(float frame_no) {
+    if (_part_name.is_empty()) return;
+    SpriteStudioPlayer2D* player = _resolve_player();
+    if (!player) return;
+    Node2D* target = _resolve_target();
+    if (!target) return;
+
+    int idx = player->get_part_index(_part_name);
+    if (idx < 0) {
+        // Part absent from this animation: nothing to follow, so hide the target.
+        if (target->is_visible()) target->set_visible(false);
+        return;
+    }
+
+    if (_on_part_hidden == HIDE_TARGET && player->is_part_hidden(_part_name)) {
+        if (target->is_visible()) target->set_visible(false);
+        return;
+    }
+
+    // Re-show if a previous frame auto-hid it (absent / hidden).
+    if (!target->is_visible()) target->set_visible(true);
+
+    const Transform2D part_local = player->get_part_transform(_part_name);
+    const Transform2D desired = _use_global_coordinates
+        ? (player->get_global_transform() * part_local)
+        : part_local;
+    _apply_transform(target, desired);
+}
+
+void SpriteStudioPartAttachment2D::_apply_transform(Node2D* p_target, const Transform2D& p_desired) {
+    const bool global = _use_global_coordinates;
+
+    // Full copy: assign the whole affine so skew / negative scale survive
+    // (the reason a Godot Transform2D can mirror the part exactly).
+    if (_update_position && _update_rotation && _update_scale) {
+        if (global) {
+            p_target->set_global_transform(p_desired);
+        } else {
+            p_target->set_transform(p_desired);
+        }
+        return;
+    }
+
+    // Partial copy: only the enabled components (skew is not preserved here,
+    // matching RemoteTransform2D's component-wise behaviour).
+    if (global) {
+        if (_update_position) p_target->set_global_position(p_desired.get_origin());
+        if (_update_rotation) p_target->set_global_rotation(p_desired.get_rotation());
+        if (_update_scale) p_target->set_global_scale(p_desired.get_scale());
+    } else {
+        if (_update_position) p_target->set_position(p_desired.get_origin());
+        if (_update_rotation) p_target->set_rotation(p_desired.get_rotation());
+        if (_update_scale) p_target->set_scale(p_desired.get_scale());
+    }
+}
+
+void SpriteStudioPartAttachment2D::set_part_name(const String& p_name) {
+    _part_name = p_name;
+    update_configuration_warnings();
+}
+String SpriteStudioPartAttachment2D::get_part_name() const { return _part_name; }
+
+void SpriteStudioPartAttachment2D::set_player_path(const NodePath& p_path) {
+    if (is_inside_tree()) _disconnect_player();
+    _player_path = p_path;
+    if (is_inside_tree()) _connect_player();
+    update_configuration_warnings();
+}
+NodePath SpriteStudioPartAttachment2D::get_player_path() const { return _player_path; }
+
+void SpriteStudioPartAttachment2D::set_remote_path(const NodePath& p_path) {
+    _remote_path = p_path;
+    update_configuration_warnings();
+}
+NodePath SpriteStudioPartAttachment2D::get_remote_path() const { return _remote_path; }
+
+void SpriteStudioPartAttachment2D::set_use_global_coordinates(bool p_enabled) { _use_global_coordinates = p_enabled; }
+bool SpriteStudioPartAttachment2D::get_use_global_coordinates() const { return _use_global_coordinates; }
+
+void SpriteStudioPartAttachment2D::set_update_position(bool p_enabled) { _update_position = p_enabled; }
+bool SpriteStudioPartAttachment2D::get_update_position() const { return _update_position; }
+void SpriteStudioPartAttachment2D::set_update_rotation(bool p_enabled) { _update_rotation = p_enabled; }
+bool SpriteStudioPartAttachment2D::get_update_rotation() const { return _update_rotation; }
+void SpriteStudioPartAttachment2D::set_update_scale(bool p_enabled) { _update_scale = p_enabled; }
+bool SpriteStudioPartAttachment2D::get_update_scale() const { return _update_scale; }
+
+void SpriteStudioPartAttachment2D::set_on_part_hidden(HiddenBehavior p_mode) { _on_part_hidden = p_mode; }
+SpriteStudioPartAttachment2D::HiddenBehavior SpriteStudioPartAttachment2D::get_on_part_hidden() const { return _on_part_hidden; }
+
+void SpriteStudioPartAttachment2D::_validate_property(PropertyInfo &p_property) const {
+    if (p_property.name == StringName("part_name")) {
+        const SpriteStudioPlayer2D* player = _resolve_player();
+        if (player) {
+            PackedStringArray names = player->get_part_names();
+            // ENUM_SUGGESTION (not ENUM) so the field stays editable when the
+            // player isn't resolvable at edit time — never lock out a name.
+            p_property.hint = PROPERTY_HINT_ENUM_SUGGESTION;
+            p_property.hint_string = String(",").join(names);
+        }
+    }
+}
+
+void SpriteStudioPartAttachment2D::_notification(int p_what) {
+    switch (p_what) {
+        case NOTIFICATION_ENTER_TREE:
+            // Covers the common case (player is an ancestor, already in tree)
+            // and re-parenting.
+            _connect_player();
+            break;
+        case NOTIFICATION_READY:
+            // Retry once the whole tree exists, for a player_path that points
+            // to a node outside this subtree (not yet present at ENTER_TREE).
+            // Idempotent: _connect_player guards on is_connected.
+            _connect_player();
+            break;
+        case NOTIFICATION_EXIT_TREE:
+            _disconnect_player();
+            break;
+    }
+}
+
+#ifdef SPRITESTUDIO_GODOT_EXTENSION
+PackedStringArray SpriteStudioPartAttachment2D::_get_configuration_warnings() const {
+    PackedStringArray warnings;
+#else
+PackedStringArray SpriteStudioPartAttachment2D::get_configuration_warnings() const {
+    PackedStringArray warnings = Node2D::get_configuration_warnings();
+#endif
+    if (_resolve_player() == nullptr) {
+        warnings.push_back(tr("No SpriteStudioPlayer2D found. Set \"player_path\" or place this node under a SpriteStudioPlayer2D."));
+    } else if (_part_name.is_empty()) {
+        warnings.push_back(tr("Set \"part_name\" to the SpriteStudio part this node should follow."));
+    }
+    return warnings;
+}

--- a/ss_player/ss_part_attachment_2d.cpp
+++ b/ss_player/ss_part_attachment_2d.cpp
@@ -6,8 +6,8 @@ void SpriteStudioPartAttachment2D::_bind_methods() {
     ClassDB::bind_method(D_METHOD("set_part_name", "part_name"), &SpriteStudioPartAttachment2D::set_part_name);
     ClassDB::bind_method(D_METHOD("get_part_name"), &SpriteStudioPartAttachment2D::get_part_name);
 
-    ClassDB::bind_method(D_METHOD("set_player_path", "path"), &SpriteStudioPartAttachment2D::set_player_path);
-    ClassDB::bind_method(D_METHOD("get_player_path"), &SpriteStudioPartAttachment2D::get_player_path);
+    ClassDB::bind_method(D_METHOD("set_follow_path", "path"), &SpriteStudioPartAttachment2D::set_follow_path);
+    ClassDB::bind_method(D_METHOD("get_follow_path"), &SpriteStudioPartAttachment2D::get_follow_path);
 
     ClassDB::bind_method(D_METHOD("set_remote_path", "path"), &SpriteStudioPartAttachment2D::set_remote_path);
     ClassDB::bind_method(D_METHOD("get_remote_path"), &SpriteStudioPartAttachment2D::get_remote_path);
@@ -26,7 +26,7 @@ void SpriteStudioPartAttachment2D::_bind_methods() {
     ClassDB::bind_method(D_METHOD("get_on_part_hidden"), &SpriteStudioPartAttachment2D::get_on_part_hidden);
 
     ADD_PROPERTY(PropertyInfo(Variant::STRING, "part_name"), "set_part_name", "get_part_name");
-    ADD_PROPERTY(PropertyInfo(Variant::NODE_PATH, "player_path", PROPERTY_HINT_NODE_PATH_VALID_TYPES, "SpriteStudioPlayer2D"), "set_player_path", "get_player_path");
+    ADD_PROPERTY(PropertyInfo(Variant::NODE_PATH, "follow_path", PROPERTY_HINT_NODE_PATH_VALID_TYPES, "SpriteStudioPlayer2D"), "set_follow_path", "get_follow_path");
     ADD_PROPERTY(PropertyInfo(Variant::NODE_PATH, "remote_path", PROPERTY_HINT_NODE_PATH_VALID_TYPES, "Node2D"), "set_remote_path", "get_remote_path");
     ADD_PROPERTY(PropertyInfo(Variant::BOOL, "use_global_coordinates"), "set_use_global_coordinates", "get_use_global_coordinates");
 
@@ -43,8 +43,8 @@ void SpriteStudioPartAttachment2D::_bind_methods() {
 }
 
 SpriteStudioPlayer2D* SpriteStudioPartAttachment2D::_resolve_player() const {
-    if (!_player_path.is_empty()) {
-        Node* n = get_node_or_null(_player_path);
+    if (!_follow_path.is_empty()) {
+        Node* n = get_node_or_null(_follow_path);
         return Object::cast_to<SpriteStudioPlayer2D>(n);
     }
     // No explicit path: walk up to the nearest ancestor player.
@@ -75,7 +75,7 @@ void SpriteStudioPartAttachment2D::_connect_player() {
 }
 
 void SpriteStudioPartAttachment2D::_disconnect_player() {
-    // Resolve via the current member state — callers update _player_path only
+    // Resolve via the current member state — callers update _follow_path only
     // after disconnecting, so this finds the player we actually connected to.
     // A freed player auto-disconnects, so a null result here is safe to ignore.
     SpriteStudioPlayer2D* player = _resolve_player();
@@ -148,13 +148,13 @@ void SpriteStudioPartAttachment2D::set_part_name(const String& p_name) {
 }
 String SpriteStudioPartAttachment2D::get_part_name() const { return _part_name; }
 
-void SpriteStudioPartAttachment2D::set_player_path(const NodePath& p_path) {
+void SpriteStudioPartAttachment2D::set_follow_path(const NodePath& p_path) {
     if (is_inside_tree()) _disconnect_player();
-    _player_path = p_path;
+    _follow_path = p_path;
     if (is_inside_tree()) _connect_player();
     update_configuration_warnings();
 }
-NodePath SpriteStudioPartAttachment2D::get_player_path() const { return _player_path; }
+NodePath SpriteStudioPartAttachment2D::get_follow_path() const { return _follow_path; }
 
 void SpriteStudioPartAttachment2D::set_remote_path(const NodePath& p_path) {
     _remote_path = p_path;
@@ -196,7 +196,7 @@ void SpriteStudioPartAttachment2D::_notification(int p_what) {
             _connect_player();
             break;
         case NOTIFICATION_READY:
-            // Retry once the whole tree exists, for a player_path that points
+            // Retry once the whole tree exists, for a follow_path that points
             // to a node outside this subtree (not yet present at ENTER_TREE).
             // Idempotent: _connect_player guards on is_connected.
             _connect_player();
@@ -215,7 +215,7 @@ PackedStringArray SpriteStudioPartAttachment2D::get_configuration_warnings() con
     PackedStringArray warnings = Node2D::get_configuration_warnings();
 #endif
     if (_resolve_player() == nullptr) {
-        warnings.push_back(tr("No SpriteStudioPlayer2D found. Set \"player_path\" or place this node under a SpriteStudioPlayer2D."));
+        warnings.push_back(tr("No SpriteStudioPlayer2D found. Set \"follow_path\" or place this node under a SpriteStudioPlayer2D."));
     } else if (_part_name.is_empty()) {
         warnings.push_back(tr("Set \"part_name\" to the SpriteStudio part this node should follow."));
     }

--- a/ss_player/ss_part_attachment_2d.h
+++ b/ss_player/ss_part_attachment_2d.h
@@ -14,7 +14,7 @@ class SpriteStudioPlayer2D;
 
 // A user-owned node that mirrors a single SpriteStudio part's pose each frame.
 // Modeled on Godot's RemoteTransform2D (remote_path / use_global_coordinates /
-// update_position|rotation|scale) plus a part_name + player_path. The player
+// update_position|rotation|scale) plus a part_name + follow_path. The player
 // never creates, owns, or frees this node: the user authors it in the scene
 // tree and owns its (and its children's) lifecycle. The attachment only reads
 // the part pose the player already computes and drives a transform — either its
@@ -35,7 +35,7 @@ public:
 
 private:
     String _part_name;
-    NodePath _player_path;  // empty -> nearest ancestor SpriteStudioPlayer2D
+    NodePath _follow_path;  // empty -> nearest ancestor SpriteStudioPlayer2D
     NodePath _remote_path;  // empty -> drive self
     bool _use_global_coordinates = true;
     bool _update_position = true;
@@ -63,8 +63,8 @@ public:
     void set_part_name(const String& p_name);
     String get_part_name() const;
 
-    void set_player_path(const NodePath& p_path);
-    NodePath get_player_path() const;
+    void set_follow_path(const NodePath& p_path);
+    NodePath get_follow_path() const;
 
     void set_remote_path(const NodePath& p_path);
     NodePath get_remote_path() const;

--- a/ss_player/ss_part_attachment_2d.h
+++ b/ss_player/ss_part_attachment_2d.h
@@ -1,0 +1,92 @@
+#pragma once
+
+#ifdef SPRITESTUDIO_GODOT_EXTENSION
+#include <godot_cpp/classes/node2d.hpp>
+#include <godot_cpp/variant/node_path.hpp>
+#include <godot_cpp/variant/packed_string_array.hpp>
+#include <godot_cpp/variant/transform2d.hpp>
+using namespace godot;
+#else
+#include "scene/2d/node_2d.h"
+#endif
+
+class SpriteStudioPlayer2D;
+
+// A user-owned node that mirrors a single SpriteStudio part's pose each frame.
+// Modeled on Godot's RemoteTransform2D (remote_path / use_global_coordinates /
+// update_position|rotation|scale) plus a part_name + player_path. The player
+// never creates, owns, or frees this node: the user authors it in the scene
+// tree and owns its (and its children's) lifecycle. The attachment only reads
+// the part pose the player already computes and drives a transform — either its
+// own (children follow via scene-tree inheritance) or a remote Node2D's
+// (decoupled from the player's subtree). It connects to the player's
+// `frame_updated` signal so it mirrors the part in the same frame it renders,
+// independent of the player's process mode.
+class SpriteStudioPartAttachment2D : public Node2D {
+    GDCLASS(SpriteStudioPartAttachment2D, Node2D);
+
+public:
+    // Behaviour when the tracked part is hidden on the current frame. A part
+    // absent from the animation entirely always hides the target regardless.
+    enum HiddenBehavior {
+        FOLLOW_ALWAYS, // keep following the part's frame while it is hidden
+        HIDE_TARGET,   // hide the driven target while the part is hidden
+    };
+
+private:
+    String _part_name;
+    NodePath _player_path;  // empty -> nearest ancestor SpriteStudioPlayer2D
+    NodePath _remote_path;  // empty -> drive self
+    bool _use_global_coordinates = true;
+    bool _update_position = true;
+    bool _update_rotation = true;
+    bool _update_scale = false; // off by default (Godot Transform2D carries the
+                                // part's scale anyway when all three are on)
+    HiddenBehavior _on_part_hidden = FOLLOW_ALWAYS;
+
+    SpriteStudioPlayer2D* _resolve_player() const;
+    Node2D* _resolve_target();
+    void _connect_player();
+    void _disconnect_player();
+    void _on_player_frame_updated(float frame_no);
+    void _apply_transform(Node2D* p_target, const Transform2D& p_desired);
+
+protected:
+    void _notification(int p_what);
+    static void _bind_methods();
+    // Turns the `part_name` field into an editor dropdown of the resolved
+    // player's part names (editable, so a name still works when the player
+    // can't be resolved at edit time). Same signature in module + godot-cpp.
+    void _validate_property(PropertyInfo &p_property) const;
+
+public:
+    void set_part_name(const String& p_name);
+    String get_part_name() const;
+
+    void set_player_path(const NodePath& p_path);
+    NodePath get_player_path() const;
+
+    void set_remote_path(const NodePath& p_path);
+    NodePath get_remote_path() const;
+
+    void set_use_global_coordinates(bool p_enabled);
+    bool get_use_global_coordinates() const;
+
+    void set_update_position(bool p_enabled);
+    bool get_update_position() const;
+    void set_update_rotation(bool p_enabled);
+    bool get_update_rotation() const;
+    void set_update_scale(bool p_enabled);
+    bool get_update_scale() const;
+
+    void set_on_part_hidden(HiddenBehavior p_mode);
+    HiddenBehavior get_on_part_hidden() const;
+
+#ifdef SPRITESTUDIO_GODOT_EXTENSION
+    PackedStringArray _get_configuration_warnings() const override;
+#else
+    PackedStringArray get_configuration_warnings() const override;
+#endif
+};
+
+VARIANT_ENUM_CAST(SpriteStudioPartAttachment2D::HiddenBehavior);

--- a/ss_player/ss_player_node_2d.cpp
+++ b/ss_player/ss_player_node_2d.cpp
@@ -118,6 +118,36 @@ Ref<Texture2D> SpriteStudioPlayer2D::get_cellmap_texture(const String &cellmap_n
     return Ref<Texture2D>();
 }
 
+int SpriteStudioPlayer2D::get_part_index(const String& part_name) const {
+    return _internal->resolve_part_index(part_name);
+}
+
+Transform2D SpriteStudioPlayer2D::get_part_transform(const String& part_name) const {
+    Transform2D xf;
+    int idx = _internal->resolve_part_index(part_name);
+    if (idx >= 0) {
+        _internal->try_get_part_local_transform(idx, xf);
+    }
+    return xf;
+}
+
+bool SpriteStudioPlayer2D::is_part_hidden(const String& part_name) const {
+    int idx = _internal->resolve_part_index(part_name);
+    if (idx < 0) return false;
+    bool hidden = false;
+    _internal->try_get_part_hidden(idx, hidden);
+    return hidden;
+}
+
+PackedStringArray SpriteStudioPlayer2D::get_part_names() const {
+    PackedStringArray names;
+    int count = _internal->get_part_count();
+    for (int i = 0; i < count; i++) {
+        names.push_back(_internal->get_part_name(i));
+    }
+    return names;
+}
+
 void SpriteStudioPlayer2D::setAnimation(const String& strName) {
     _internal->setAnimation(strName);
     NOTIFY_PROPERTY_LIST_CHANGED();
@@ -302,6 +332,11 @@ void SpriteStudioPlayer2D::_bind_methods() {
     ClassDB::bind_method( D_METHOD( "set_flip_v", "flip_v" ), &SpriteStudioPlayer2D::set_flip_v );
     ClassDB::bind_method( D_METHOD( "is_flipped_v" ), &SpriteStudioPlayer2D::is_flipped_v );
 
+    ClassDB::bind_method( D_METHOD( "get_part_index", "part_name" ), &SpriteStudioPlayer2D::get_part_index );
+    ClassDB::bind_method( D_METHOD( "get_part_transform", "part_name" ), &SpriteStudioPlayer2D::get_part_transform );
+    ClassDB::bind_method( D_METHOD( "is_part_hidden", "part_name" ), &SpriteStudioPlayer2D::is_part_hidden );
+    ClassDB::bind_method( D_METHOD( "get_part_names" ), &SpriteStudioPlayer2D::get_part_names );
+
     ADD_SIGNAL(
         MethodInfo(
             "user_data",
@@ -320,6 +355,11 @@ void SpriteStudioPlayer2D::_bind_methods() {
     ADD_SIGNAL(MethodInfo("animation_started", PropertyInfo(Variant::STRING, "anim_name")));
     ADD_SIGNAL(MethodInfo("animation_finished", PropertyInfo(Variant::STRING, "anim_name")));
     ADD_SIGNAL(MethodInfo("animation_looped", PropertyInfo(Variant::STRING, "anim_name")));
+
+    // Emitted at the end of each processed tick, after the frame's world
+    // matrices are final. SpriteStudioPartAttachment2D connects to this to
+    // mirror a part's pose in the same frame it is rendered.
+    ADD_SIGNAL(MethodInfo("frame_updated", PropertyInfo(Variant::FLOAT, "frame_no")));
 
     ADD_PROPERTY(
         PropertyInfo(Variant::OBJECT, "ssab", PROPERTY_HINT_RESOURCE_TYPE, "SSABResource"),
@@ -546,12 +586,16 @@ void SpriteStudioPlayer2D::_notification(int p_notification) {
             if (_process_mode == ANIMATION_PROCESS_IDLE) {
                 _push_coverage_screen_scale();
                 _internal->update(get_process_delta_time());
+                // Post-update: world matrices are final this tick, so part
+                // attachments can mirror their parts in the same frame.
+                emit_signal(SNAME("frame_updated"), _internal->getFrame());
             }
             break;
         case NOTIFICATION_INTERNAL_PHYSICS_PROCESS:
             if (_process_mode == ANIMATION_PROCESS_PHYSICS) {
                 _push_coverage_screen_scale();
                 _internal->update(get_physics_process_delta_time());
+                emit_signal(SNAME("frame_updated"), _internal->getFrame());
             }
             break;
         case NOTIFICATION_DRAW:

--- a/ss_player/ss_player_node_2d.h
+++ b/ss_player/ss_player_node_2d.h
@@ -93,6 +93,17 @@ public:
     void set_cellmap_texture(const String &cellmap_name, const Ref<Texture2D> &texture);
     Ref<Texture2D> get_cellmap_texture(const String &cellmap_name) const;
 
+    // ---- Part query API (consumed by SpriteStudioPartAttachment2D) --------
+    // Resolve a part name to its index in the current binary; -1 if unknown.
+    int get_part_index(const String& part_name) const;
+    // Player-local Transform2D of the named part for the current frame. Returns
+    // the identity when the part is unknown (use get_part_index to disambiguate).
+    Transform2D get_part_transform(const String& part_name) const;
+    // True if the named part is hidden on the current frame. False when unknown.
+    bool is_part_hidden(const String& part_name) const;
+    // All part names in the current binary (for the attachment's dropdown).
+    PackedStringArray get_part_names() const;
+
 private:
     // Engine-agnostic playback / render core. The Node2D wrapper feeds it the
     // host canvas item and per-tick delta, and forwards its events back to


### PR DESCRIPTION
## 概要
指定した SpriteStudio のパーツに追従するノード `SpriteStudioPartAttachment2D` を追加します。SSPlayerForUnity の「パーツ追従」機能の Godot 移植です。

メンタルモデルは **Godot 標準 `BoneAttachment2D` / `RemoteTransform2D` の SpriteStudio 版**。プロパティ構成も `RemoteTransform2D` を踏襲しています。

## 設計の柱：所有権はユーザー側
プレーヤは追従ノードやその資産を **生成・所有・破棄しません**。プレーヤは自分が既に計算済みのパーツ姿勢を公開し、`frame_updated` シグナルを出すだけ。ノードの寿命はシーン作者が握ります。

これは SSPlayerForUnity の constraint-style をそのまま移植したもので、旧 Spine(SkeletonUtility) の「描画側が追従ノードを自動生成 → リビルドでぶら下げた資産ごと消える」事故を構造的に回避します。

## ランタイム改修なし
`ss_runtime_get_world_matrices`（既存）と `matrix_to_transform2d`（既存ヘルパ）で完結するため、**ssruntime / SDK サブモジュールの変更はありません**。Y 反転・座標系は runtime の world matrix に折り込み済みなので追従側の再変換も不要です。

## 変更点
- **`SpriteStudioPlayer2D`**
  - signal `frame_updated(frame_no: float)` を追加（各 tick の update 後、world matrix 確定後に emit。Physics/Idle 両プロセスモードで一貫）
  - パーツクエリ API: `get_part_index` / `get_part_transform` / `is_part_hidden` / `get_part_names`
- **`SsInternalPlayer`**（内部）
  - `resolve_part_index` / `try_get_part_local_transform`（`matrix_to_transform2d` 流用）/ `try_get_part_hidden`（毎フレーム hide キャッシュ）/ `get_part_count` / `get_part_name`
  - パーツ名→index マップを `setSSABResource` で再構築
- **`SpriteStudioPartAttachment2D`**（新規）
  - `frame_updated` に接続して追従。接続は ENTER_TREE/READY（冪等）・EXIT_TREE で切断・ノード free 時は Godot が自動切断
  - 自分を動かす or `remote_path` の外部 `Node2D` を駆動
  - 全トグル ON で完全な Transform2D 代入（skew・負スケールを保持）。部分時は component コピー
  - パーツ消失時 / `on_part_hidden = HIDE_TARGET` の hide フレームで対象を非表示（破棄はしない・自動復帰）
  - `part_name` は `_validate_property` でプレーヤのパーツ名ドロップダウン（`ENUM_SUGGESTION`＝手入力も可）

## プロパティ
| プロパティ | 役割 | 既定 |
|---|---|---|
| `part_name` | 追従するパーツ名（ドロップダウン） | 空（必須） |
| `follow_path` | 追従元プレーヤ（空＝最寄り祖先） | 空 |
| `remote_path` | 追従先 Node2D（空＝自分） | 空 |
| `use_global_coordinates` | グローバル/ローカル | on |
| `update_position`/`rotation`/`scale` | 反映する成分 | pos・rot=on / scale=off |
| `on_part_hidden` | hide フレームの挙動（FOLLOW_ALWAYS / HIDE_TARGET） | FOLLOW_ALWAYS |

`follow_path`（読み元）/ `remote_path`（書き先）の対で source/target を表します（`remote_path` は RemoteTransform2D 由来の名称）。

## ビルド
GDExtension・カスタムモジュール両方でビルド緑。

## 未対応（別フェーズ）
- Instance パーツ配下の追従
- 物理連携用の physics フレーム版シグナル（AnimatableBody 向け）
- Control(UI) ノードへの追従
- ドキュメント追記（`docs/ja`・`docs/en`）

## 動作確認
- 基本追従を実機で確認済み（OK）