### PR TITLE
feat: Add iOS Simulator and Device support via XCFramework

### DIFF
--- a/.github/workflows/extension.yml
+++ b/.github/workflows/extension.yml
@@ -121,7 +121,8 @@ jobs:
         run: |
           ./scripts/release-gdextension-ios.sh
 
-          for f in ./bin/ios/*.framework
+          # iOS ships XCFrameworks (device + simulator); sign the frameworks inside each slice.
+          for f in ./bin/ios/*.xcframework/*/*.framework
           do
             codesign --force --verify --verbose --keychain ${{ env.KEYCHAIN_PATH }} --sign "${DEV_ID_APPLICATION}" $f --deep --options runtime --timestamp
           done

--- a/SConstruct
+++ b/SConstruct
@@ -119,7 +119,14 @@ if platform == 'macos':
     env.Append(LINKFLAGS=["-framework", "CoreFoundation", "-framework", "CoreServices"])
 
 if platform == "ios":
-    ios_flags = ["-miphoneos-version-min=12.0"]
+    # godot-cpp's ios tool already selects the iphoneos/iphonesimulator SDK and
+    # archs from `ios_simulator`; match its deployment-target flag here. A
+    # hardcoded -miphoneos-version-min forces a device target and breaks the
+    # simulator build (object built for 'iOS' vs 'iOS-simulator' link mismatch).
+    if env["ios_simulator"]:
+        ios_flags = ["-mios-simulator-version-min=12.0"]
+    else:
+        ios_flags = ["-miphoneos-version-min=12.0"]
     env.Append(CCFLAGS=ios_flags)
     env.Append(LINKFLAGS=ios_flags)
 

--- a/misc/spritestudio.gdextension
+++ b/misc/spritestudio.gdextension
@@ -9,8 +9,8 @@ macos.editor = "bin/macos/libSSGodot.macos.editor.framework"
 macos.debug = "bin/macos/libSSGodot.macos.template_debug.framework"
 macos.release = "bin/macos/libSSGodot.macos.template_release.framework"
 
-ios.debug = "bin/ios/libSSGodot.ios.template_debug.framework"
-ios.release = "bin/ios/libSSGodot.ios.template_release.framework"
+ios.debug = "bin/ios/libSSGodot.ios.template_debug.xcframework"
+ios.release = "bin/ios/libSSGodot.ios.template_release.xcframework"
 
 windows.editor.x86_64 = "bin/windows/libSSGodot.windows.editor.x86_64.dll"
 windows.debug.x86_64 = "bin/windows/libSSGodot.windows.template_debug.x86_64.dll"

--- a/scripts/build-runtime.ps1
+++ b/scripts/build-runtime.ps1
@@ -72,8 +72,8 @@ if ($IS_HOST_BUILD) {
         if ($ARCH -eq "arm64") { $script = "./scripts/release-windows-arm64.ps1" }
         echo "Executing $script $BUILD_MODE..."
         & $script $BUILD_MODE
-    } elseif ($PLATFORM -eq "ios" -and $IOS_SIMULATOR -eq "yes") {
-        & sh ./scripts/release-ios-sim.sh $BUILD_MODE
+    } elseif ($PLATFORM -eq "ios") {
+        & sh ./scripts/release-ios-xcframework.sh $BUILD_MODE
     } elseif ($PLATFORM -eq "web") {
         & sh ./scripts/release-emscripten.sh $BUILD_MODE
     } else {
@@ -117,6 +117,14 @@ if ($PLATFORM -eq "windows") { $LIB_EXT = ".lib" }
 # Determine source directory
 if ($IS_HOST_BUILD) {
     $SRC_DIR = "$SDK_DIR/target/$BUILD_MODE"
+} elseif ($PLATFORM -eq "ios") {
+    # iOS: pick the matching static slice from the SDK XCFramework
+    # (release-ios-xcframework.sh already lipo'd the simulator archs).
+    if ($IOS_SIMULATOR -eq "yes") {
+        $SRC_DIR = "$SDK_DIR/target/xcframework/static/libssruntime.xcframework/ios-arm64_x86_64-simulator"
+    } else {
+        $SRC_DIR = "$SDK_DIR/target/xcframework/static/libssruntime.xcframework/ios-arm64"
+    }
 } else {
     # Architecture mapping for cross-compilation
     $TARGET_TRIPLE = ""
@@ -126,12 +134,6 @@ if ($IS_HOST_BUILD) {
         elseif ($ARCH -eq "x86_64") { $TARGET_TRIPLE = "x86_64-linux-android" }
     } elseif ($PLATFORM -eq "web") {
         $TARGET_TRIPLE = "wasm32-unknown-unknown"
-    } elseif ($PLATFORM -eq "ios") {
-        if ($IOS_SIMULATOR -eq "yes") {
-            $TARGET_TRIPLE = "universal-apple-ios-sim"
-        } else {
-            $TARGET_TRIPLE = "universal-apple-ios"
-        }
     } elseif ($PLATFORM -eq "macos" -and $ARCH -eq "universal") {
         $TARGET_TRIPLE = "universal-apple-darwin"
     } elseif ($PLATFORM -eq "windows" -and $ARCH -eq "x86_64") {

--- a/scripts/build-runtime.sh
+++ b/scripts/build-runtime.sh
@@ -89,12 +89,15 @@ else
             SRC_DIR="target/universal-apple-darwin/$BUILD_MODE"
             ;;
         ios)
+            # The SDK now emits a single XCFramework (device + simulator slices).
+            # Godot links one variant at a time into its per-variant libSSGodot
+            # framework, so pick the matching static slice: device (arm64) or the
+            # universal simulator slice (arm64 + x86_64, already lipo'd by the SDK).
+            ./scripts/release-ios-xcframework.sh $BUILD_MODE
             if [[ "$IOS_SIMULATOR" == "yes" ]]; then
-                ./scripts/release-ios-sim.sh $BUILD_MODE
-                SRC_DIR="target/universal-apple-ios-sim/$BUILD_MODE"
+                SRC_DIR="target/xcframework/static/libssruntime.xcframework/ios-arm64_x86_64-simulator"
             else
-                ./scripts/release-ios.sh $BUILD_MODE
-                SRC_DIR="target/universal-apple-ios/$BUILD_MODE"
+                SRC_DIR="target/xcframework/static/libssruntime.xcframework/ios-arm64"
             fi
             ;;
         android)

--- a/scripts/release-gdextension-ios.sh
+++ b/scripts/release-gdextension-ios.sh
@@ -11,24 +11,53 @@ pushd ${ROOTDIR} > /dev/null
 BINDIR=$(pwd)/bin/ios
 /bin/rm -rf ${BINDIR}
 targets=("template_release" "template_debug")
+
+# Build a simulator framework and a device framework per target, then combine
+# them into one XCFramework (device + simulator) referenced by the .gdextension.
+#
+# Per-variant handling:
+#   1. libssruntime: device and simulator need different slices and CI has no
+#      separate provisioning step, so (re)build/place the runtime here per
+#      variant via build-runtime.sh (ios_simulator selects the slice).
+#   2. ss_player/*.os are not namespaced by device/simulator (unlike godot-cpp's
+#      objects), so clear them before each variant build to avoid linking the
+#      wrong slice into the binary.
+# Order matters: build the simulator first. build-extension.sh renames the
+# simulator output to *.simulator.framework, freeing the plain *.framework name
+# for the device build; doing device first would let the simulator build clobber
+# it before the rename.
+build_variant() {
+    local target=$1 sim=$2 rtmode=$3
+    find ${ROOTDIR}/ss_player -name '*.os' -delete 2>/dev/null || true
+    scripts/build-runtime.sh platform=ios build=${rtmode} ios_simulator=${sim}
+    scripts/build-extension.sh platform=ios arch=universal compiledb=no strip=yes target=${target} ios_simulator=${sim}
+}
+
 for target in ${targets[@]}; do
-#   scripts/build-extension.sh platform=ios arch=universal compiledb=no strip=yes target=${target} ios_simulator=yes
-    scripts/build-extension.sh platform=ios arch=universal compiledb=no strip=yes target=${target} ios_simulator=no
+    if [[ "${target}" == "template_debug" ]]; then
+        rtmode="debug"
+    else
+        rtmode="release"
+    fi
+    build_variant ${target} yes ${rtmode}
+    build_variant ${target} no  ${rtmode}
 done
 
-pushd ${BINDIR}
-
-## create xcframeworks
-#for target in ${targets[@]}; do
-#    rm -rf tmp
-#    mkdir -p tmp/ios tmp/ios-simulator
-#    mv $BINDIR/libSSGodot.ios.${target}.framework tmp/ios/libSSGodot.ios.${target}.framework
-#    mv $BINDIR/libSSGodot.ios.${target}.simulator.framework tmp/ios-simulator/libSSGodot.ios.${target}.framework
-#    xcodebuild -create-xcframework -framework tmp/ios/libSSGodot.ios.${target}.framework -framework tmp/ios-simulator/libSSGodot.ios.${target}.framework -output libSSGodot.ios.${target}.xcframework
-#done
-#/bin/rm -rf tmp
-
-/bin/rm -rf ios.framework
+# Combine device + simulator frameworks into XCFrameworks. xcodebuild requires
+# each framework's bundle name to match its binary, so stage the device and
+# simulator frameworks under the same bundle name in separate directories first.
+pushd ${BINDIR} > /dev/null
+for target in ${targets[@]}; do
+    /bin/rm -rf tmp
+    /bin/mkdir -p tmp/ios tmp/ios-simulator
+    /bin/mv libSSGodot.ios.${target}.framework tmp/ios/libSSGodot.ios.${target}.framework
+    /bin/mv libSSGodot.ios.${target}.simulator.framework tmp/ios-simulator/libSSGodot.ios.${target}.framework
+    xcodebuild -create-xcframework \
+        -framework tmp/ios/libSSGodot.ios.${target}.framework \
+        -framework tmp/ios-simulator/libSSGodot.ios.${target}.framework \
+        -output libSSGodot.ios.${target}.xcframework
+done
+/bin/rm -rf tmp
 popd > /dev/null # ${BINDIR}
 
 popd > /dev/null # ${ROOTDIR}

--- a/scripts/release-ios.sh
+++ b/scripts/release-ios.sh
@@ -10,7 +10,18 @@ pushd ${ROOTDIR} > /dev/null
 
 targets=("editor" "template_release" "template_debug")
 for target in ${targets[@]}; do
+    if [[ "${target}" == "template_debug" ]]; then
+        rtmode="debug"
+    else
+        rtmode="release"
+    fi
+    # build.sh does not provision libssruntime, and device/simulator need
+    # different slices (arm64 vs arm64+x86_64), so place the matching runtime
+    # before each variant. Custom-module object files are namespaced by Godot
+    # (…arm64[.simulator].o), so no object cleanup is needed between variants.
+    scripts/build-runtime.sh platform=ios build=${rtmode} ios_simulator=no
     scripts/build.sh platform=ios arch=arm64 compiledb=no strip=yes target=${target} ios_simulator=no
+    scripts/build-runtime.sh platform=ios build=${rtmode} ios_simulator=yes
     scripts/build.sh platform=ios arch=universal compiledb=no strip=yes target=${target} ios_simulator=yes
 done
 

--- a/ss_player/SCsub
+++ b/ss_player/SCsub
@@ -50,7 +50,15 @@ if env['target'] == 'editor':
         env.Append(LINKFLAGS=["Userenv.lib", "Bcrypt.lib", "Ntdll.lib", "Ws2_32.lib"])
         env.Append(LINKFLAGS=["/FORCE:MULTIPLE", "/IGNORE:4006"])
 
-env.Append(LIBS=["ssruntime"])
+# On Apple embedded platforms (iOS) the engine is archived into a single static
+# library: platform/ios/SCsub feeds env["LIBS"] as *input files* to
+# combine_libs_apple_embedded, so a bare "-lssruntime" name is resolved as a
+# missing source. Pass the static archive by full path instead. Other platforms
+# link it normally via -l from LIBPATH.
+if platform == "ios":
+    env.Append(LIBS=[File(os.path.join(runtime_libpath, "libssruntime.a"))])
+else:
+    env.Append(LIBS=["ssruntime"])
 
 # --- Compilation Flags ---
 if not env_ss.msvc:


### PR DESCRIPTION
## Description
Supports building for both iOS simulator and iOS devices using XCFrameworks.

### Changes:
- Configured iOS builder scripts to output XCFramework bundles combining device and simulator frameworks.
- Updated extension configuration file to use the new `.xcframework` paths.
- Updated build flags to correctly distinguish between iOS device and simulator targets to avoid linkage mismatches (`-mios-simulator-version-min` vs `-miphoneos-version-min`).
- Updated `SpriteStudio-SDK` submodule to point to the new XCFramework build.

ref
https://github.com/cri-middleware/SpriteStudio-SDK/pull/263