### PR TITLE
Fix instance part alpha fading not applying

### DIFF
--- a/ss_player/ss_internal_player.cpp
+++ b/ss_player/ss_internal_player.cpp
@@ -1495,6 +1495,9 @@ void SsInternalPlayer::_emit_instance_slot(const DrawFrame& f, RID ci, int p_idx
     child->setRootTransform(slot_xf);
     child->setRootVisible(true);
 
+    const float part_alpha = _parts_by_idx[p_idx] ? _parts_by_idx[p_idx]->alpha() : 1.0f;
+    f.rs->canvas_item_set_modulate(ci, Color(1, 1, 1, part_alpha));
+
     bool vis_inside = false;
     bool mask_target = false;
     if (_mask_coverage_valid && f.binary && f.binary->parts()


### PR DESCRIPTION
## 原因
Instanceパーツのアルファ値（不透明度）が Godot 側の `CanvasItem` に反映されておらず、SpriteStudio 側で設定したインスタンスパーツのフェードアウトが Godot 上で反映されない（不透明のまま見え続ける）不具合がありました。

## 修正内容
`ss_internal_player.cpp` の `_emit_instance_slot` において、パーツ自身の `alpha` 値を取得し、Godot の `canvas_item_set_modulate` を使用して設定するよう処理を1行追加しました。

これにより、子インスタンス全体に親の不透明度が正しく乗算されるようになります（SSPlayerForUnity等における事前合成アプローチと同等の結果になります）。また、使い捨ての CanvasItem への設定であるため副作用もありません。