### PR TITLE
Editor: Support floating bottom dock and improve frame spinbox stepping

### DIFF
--- a/ss_player/ss_editor_plugin.cpp
+++ b/ss_player/ss_editor_plugin.cpp
@@ -84,9 +84,13 @@ void SSEditorPlugin::_install_playback_panel() {
     playback_panel = memnew(SSPlaybackPanel);
     playback_panel->set_name(String::utf8("SSPlayback"));
     playback_panel_button = add_control_to_bottom_panel(playback_panel, String::utf8("SpriteStudio"), Ref<Shortcut>());
-    // Contextual: only reveal the tab while a SpriteStudioPlayer2D is selected.
-    if (playback_panel_button) {
-        playback_panel_button->hide();
+    // Contextual: Godot 4.3+ bottom panels do not work well in floating windows if we hide the tab button.
+    // So we leave it visible and clear the player when nothing is selected.
+    // Additionally, add_control_to_bottom_panel disables floating by default for backwards compatibility.
+    // We can explicitly enable it by modifying the available_layouts property on the parent EditorDock.
+    if (playback_panel->get_parent()) {
+        // 2 (Horizontal) | 4 (Floating) = 6
+        playback_panel->get_parent()->set("available_layouts", 6);
     }
 }
 
@@ -124,16 +128,10 @@ void SSEditorPlugin::_make_visible(bool p_visible) {
 void SSEditorPlugin::make_visible(bool p_visible) {
 #endif
     if (p_visible) {
-        if (playback_panel_button) {
-            playback_panel_button->show();
-        }
         if (playback_panel) {
             make_bottom_panel_item_visible(playback_panel);
         }
     } else {
-        if (playback_panel_button) {
-            playback_panel_button->hide();
-        }
         if (playback_panel) {
             playback_panel->set_player(nullptr);
         }

--- a/ss_player/ss_editor_plugin.h
+++ b/ss_player/ss_editor_plugin.h
@@ -34,10 +34,9 @@ class SSEditorPlugin : public EditorPlugin {
     Ref<SSResourceInspectorPlugin> inspector_plugin;
     SSCanvasDropOverlay *canvas_drop_overlay = nullptr;
 
-    // Bottom-panel transport UI (AnimationPlayer-style) shown only while a
-    // SpriteStudioPlayer2D is selected. `playback_panel_button` is the tab
-    // toggle returned by add_control_to_bottom_panel; we hide/show it to make
-    // the panel contextual.
+    // Bottom-panel transport UI (AnimationPlayer-style) shown when a
+    // SpriteStudioPlayer2D is selected. The dock is always visible
+    // to support Godot 4.3+ floating windows, but disabled when unselected.
     SSPlaybackPanel *playback_panel = nullptr;
     Button *playback_panel_button = nullptr;
 

--- a/ss_player/ss_playback_panel.cpp
+++ b/ss_player/ss_playback_panel.cpp
@@ -145,6 +145,9 @@ void SSPlaybackPanel::_build_ui() {
     _frame_spin = memnew(SpinBox);
     _frame_spin->set_min(0.0);
     _frame_spin->set_step(0.01);
+    // Godot 4.3+ allows setting a custom step for the UI arrows while keeping a fine-grained underlying step.
+    // Using string "set" ensures compilation compatibility with older Godot 4.x GDExtension headers.
+    _frame_spin->set("custom_arrow_step", 1.0);
     _frame_spin->set_tooltip_text(tr("Current frame."));
     _frame_spin->connect("value_changed", callable_mp(this, &SSPlaybackPanel::_on_frame_spin_changed));
     scrubber->add_child(_frame_spin);


### PR DESCRIPTION
## Description

- **Added support for floating bottom docks (Make Floating) in Godot 4.3+:**
  - Previously, calling `playback_panel_button->hide()` forced the floating dock to close. This has been resolved by keeping the tab button visible, allowing the floating window to remain active while clearing the selected player context instead.
  - Since Godot 4.3's `add_control_to_bottom_panel` disables floating by default for backwards compatibility, the `available_layouts` property of the parent dock is now explicitly set to `6` (Horizontal | Floating).
- **Improved UX for the current frame `SpinBox` in the playback panel:**
  - Maintains the precision required for smooth playback updates (`step = 0.01`), but introduces a custom stepping of `1.0` when users click the up/down arrow buttons.
  - This utilizes Godot 4.3+'s new `custom_arrow_step` property safely via `set()` to maintain compatibility with older Godot 4.x GDExtension headers.