### PR TITLE
feat(player): standardize independent playback; reset slot key memory on replay

### DIFF
--- a/ss_player/ss_internal_player.cpp
+++ b/ss_player/ss_internal_player.cpp
@@ -383,6 +383,11 @@ bool SsInternalPlayer::isPlaying() const {
 }
 
 void SsInternalPlayer::play(float p_start_frame) {
+    // play() always heads out (rewinds to a start frame); "resume" is pause()'s
+    // toggle, not play(). So a fresh play must clear each slot's "last started
+    // key" memory, otherwise a re-played animation would debounce an already-
+    // fired independent effect/instance as the same key and never re-fire it.
+    _reset_slots_playback_state();
     if (p_start_frame >= 0.0f) {
         ss_runtime_play_with_start_frame(runtime_ctx, p_start_frame);
     } else {
@@ -1429,6 +1434,19 @@ void SsInternalPlayer::_setup_effect_slots() {
             continue;
         }
         _effect_slots[i].effect_slot = effect_slot;
+    }
+}
+
+void SsInternalPlayer::_reset_slots_playback_state() {
+    for (uint32_t i = 0; i < _effect_slots.size(); i++) {
+        if (_effect_slots[i].effect_slot) ss_effect_slot_reset(_effect_slots[i].effect_slot);
+    }
+    for (uint32_t i = 0; i < _instance_children.size(); i++) {
+        InstanceChildState& st = _instance_children[i];
+        if (st.instance_slot) ss_instance_slot_reset(st.instance_slot);
+        // Recurse so a re-play also restarts independent effects/instances
+        // nested inside instance children (their slots live on the child).
+        if (st.player) st.player->_reset_slots_playback_state();
     }
 }
 

--- a/ss_player/ss_internal_player.h
+++ b/ss_player/ss_internal_player.h
@@ -624,6 +624,14 @@ private:
     void _clear_instance_children();
     void _setup_effect_slots();
     void _clear_effect_slots();
+
+    // Reset every effect/instance slot's "last started key" memory (and recurse
+    // into instance children) so an explicit head-out re-fires independent
+    // effects/instances from scratch instead of debouncing the first key as the
+    // same one the slot last started. Called from `play()`. The reset itself
+    // lives in the runtime (`ss_effect_slot_reset` / `ss_instance_slot_reset`);
+    // the host only iterates the slots it owns.
+    void _reset_slots_playback_state();
     // Per-tick instance child driver. Runs in the sim phase (called from
     // `update`), before `_drawAnimation`. Per slot, queries
     // `ss_runtime_get_active_event_instance` (returns SS6 default semantics


### PR DESCRIPTION
## 概要

独立再生（independent）の確定スペック対応の **プレーヤ側** PR です。SDK 側 PR（cri-middleware/SpriteStudio-SDK#270）の bump を含みます。

## 変更内容

- **SDK bump**: `50123d5` → `088d2bc`（独立再生キー調停の確定 + `ss_*_slot_reset` C-API。develop 最新 `f0036aa` 取り込み込み）。
- **`play()` でスロット記憶をリセット**: `play()` は常に頭出し（再開は `pause()` のトグルが兼任）なので、各 Effect / Instance スロットの「最後に再生を始めたキー」記憶を新 C-API `ss_effect_slot_reset` / `ss_instance_slot_reset` でクリア。これが無いと、再 play したアニメで既発火の独立エフェクト / インスタンスが「同一キー → 無視」となり再発火しない（spec §6）。
- ホストは自分が所有するスロットを舐めて reset を呼ぶだけ（インスタンス子へ再帰）。調停ロジック本体は runtime 側。

## 依存・マージ順
⚠️ submodule ポインタは SDK の feature ブランチ上のコミット `088d2bc` を指します。**先に SDK PR #270 をマージ**してから本 PR をマージしてください（順序が逆だと submodule 参照が解決できません）。

## 検証
- SDK 側: fmt / clippy / test / no_std すべて緑
- Godot 実機目視で #2（一発限り）/ #7（区間ループ持続）/ 再 play 復活を確認済み
- ランタイム再ビルド（新シンボル）→ 拡張ビルドでリンク確認

備考: `ss_player/runtime/include/ssruntime.h` は `.gitignore` 対象（cbindgen 生成物）のため差分には含まれません。runtime 再ビルド時に新宣言が自動生成されます。