### PR TITLE
fix(mask): keep clipping alive across coverage size-class transitions

### DIFF
--- a/ss_player/ss_internal_player.cpp
+++ b/ss_player/ss_internal_player.cpp
@@ -50,6 +50,23 @@ int ss_quantize_coverage_dim(float px, int min_dim, int max_dim) {
     while (c < v) c <<= 1;
     return c;
 }
+
+// Like ss_quantize_coverage_dim, but sticky: only shrink to a smaller class once
+// the footprint is `shrink_hyst` below the class boundary. This keeps a mask that
+// hovers on a boundary from flip-flopping (each flip is a coverage transition).
+// Growing is prompt (no hysteresis) so the coverage never under-resolves.
+int ss_hysteretic_coverage_dim(float px, int current, int min_dim, int max_dim, float shrink_hyst) {
+    int desired = ss_quantize_coverage_dim(px, min_dim, max_dim);
+    if (desired < current && current > min_dim) {
+        // Class `current` covers (current/2, current]; require px comfortably
+        // below current/2 before dropping down.
+        const float lower_edge = (float)current * 0.5f;
+        if (px > lower_edge * (1.0f - shrink_hyst)) {
+            desired = current; // stay in the larger class
+        }
+    }
+    return desired;
+}
 } // namespace
 
 // One pooled coverage render target of a fixed size class. Global scope so the
@@ -790,15 +807,27 @@ void SsInternalPlayer::_acquire_mask_target(int w, int h) {
     }
     RenderingServer* rs = RenderingServer::get_singleton();
     if (_mask_target) {
-        SsMaskCoveragePool::get().release(rs, _mask_target);
+        // Size-class transition: keep the outgoing target one more frame so the
+        // coverage pass can sample its still-valid coverage while the freshly
+        // acquired target warms up (see _render_mask_coverage). Any earlier
+        // leftover (defensive; normally cleared at the pass start) is returned.
+        if (_mask_prev) {
+            SsMaskCoveragePool::get().release(rs, _mask_prev);
+        }
+        _mask_prev = _mask_target;
         _mask_target = nullptr;
     }
     _mask_target = SsMaskCoveragePool::get().acquire(rs, w, h);
 }
 
 void SsInternalPlayer::_release_mask_target() {
+    RenderingServer* rs = RenderingServer::get_singleton();
+    if (_mask_prev) {
+        SsMaskCoveragePool::get().release(rs, _mask_prev);
+        _mask_prev = nullptr;
+    }
     if (_mask_target) {
-        SsMaskCoveragePool::get().release(RenderingServer::get_singleton(), _mask_target);
+        SsMaskCoveragePool::get().release(rs, _mask_target);
         _mask_target = nullptr;
     }
     _mask_coverage_valid = false;
@@ -839,6 +868,12 @@ Ref<ShaderMaterial> SsInternalPlayer::_acquire_mask_write_material() {
 
 void SsInternalPlayer::_render_mask_coverage(const DrawFrame& f) {
     _mask_coverage_valid = false;
+    // Return the transition leftover held for last frame's sampling; if we are
+    // still transitioning, _acquire_mask_target re-establishes it below.
+    if (_mask_prev) {
+        SsMaskCoveragePool::get().release(RenderingServer::get_singleton(), _mask_prev);
+        _mask_prev = nullptr;
+    }
     if (_mask_writers.is_empty() || !f.frameData) return;
     // Borrow a pooled target of the size class decided last frame (stable thanks
     // to quantization), then re-request its one-shot render this frame.
@@ -1033,16 +1068,27 @@ void SsInternalPlayer::_render_mask_coverage(const DrawFrame& f) {
 
     // Decide the size class to borrow next frame from this frame's footprint.
     // Screen-linked: ~one coverage texel per on-screen pixel of the bbox.
-    _mask_next_w = ss_quantize_coverage_dim(bsize.x * _coverage_screen_scale, MASK_COVERAGE_MIN_DIM, MASK_COVERAGE_MAX_DIM);
-    _mask_next_h = ss_quantize_coverage_dim(bsize.y * _coverage_screen_scale, MASK_COVERAGE_MIN_DIM, MASK_COVERAGE_MAX_DIM);
+    _mask_next_w = ss_hysteretic_coverage_dim(bsize.x * _coverage_screen_scale, _mask_target->w,
+                                              MASK_COVERAGE_MIN_DIM, MASK_COVERAGE_MAX_DIM, MASK_SIZE_SHRINK_HYSTERESIS);
+    _mask_next_h = ss_hysteretic_coverage_dim(bsize.y * _coverage_screen_scale, _mask_target->h,
+                                              MASK_COVERAGE_MIN_DIM, MASK_COVERAGE_MAX_DIM, MASK_SIZE_SHRINK_HYSTERESIS);
 
     // A freshly (re)acquired target still holds the previous tenant's coverage
-    // (or nothing). With one-frame-latency sampling, using it this frame would
-    // show that stale content, so skip masking for one frame — our coverage,
-    // rendered this frame, is what next frame samples.
+    // (or nothing), and with one-frame-latency sampling it is not ready this
+    // frame. On a size-class transition we instead sample `_mask_prev` — last
+    // frame's target, whose coverage is still valid (same one-frame latency as
+    // any normal frame, just at the previous resolution for this one frame) —
+    // so masking never drops for a frame while zooming across a class boundary.
     if (_mask_target->fresh) {
         _mask_target->fresh = false;
-        _mask_coverage_valid = false;
+        if (_mask_prev) {
+            _mask_coverage_tex = rs->viewport_get_texture(_mask_prev->viewport);
+            _mask_coverage_valid = true;
+        } else {
+            // Genuinely the first coverage frame (no previous target to fall back
+            // on) — nothing valid to sample yet, so skip masking this one frame.
+            _mask_coverage_valid = false;
+        }
     } else {
         _mask_coverage_valid = true;
     }

--- a/ss_player/ss_internal_player.h
+++ b/ss_player/ss_internal_player.h
@@ -512,6 +512,13 @@ private:
     // `_release_mask_target` / `_free_mask_targets`. The viewport renders with
     // UPDATE_ONCE (one-frame latency, sidesteps inter-viewport ordering).
     SsMaskCoverageTarget* _mask_target = nullptr; // borrowed; null when idle
+    // The target used on the PREVIOUS frame, held one extra frame across a
+    // size-class transition. On the transition frame the freshly acquired
+    // `_mask_target` has no coverage yet (one-frame viewport latency), so the
+    // coverage pass samples this still-valid previous target instead of dropping
+    // masking for a frame. Released at the start of the next coverage pass (and on
+    // teardown). null when not mid-transition.
+    SsMaskCoverageTarget* _mask_prev = nullptr;
     bool _mask_pool_registered = false;        // this player counts as a pool user
     Ref<Shader> _mask_write_shader;            // loaded from SS_MASK_WRITE
     Vector<Ref<ShaderMaterial>> _mask_write_materials; // per-instance, pooled
@@ -527,6 +534,11 @@ private:
     // the render target is not reallocated as the mask animates.
     static constexpr int MASK_COVERAGE_MAX_DIM = 1024;
     static constexpr int MASK_COVERAGE_MIN_DIM = 64;
+    // Hysteresis on shrinking the size class: only drop to a smaller class once
+    // the footprint is this fraction below the boundary, so a mask hovering on a
+    // class boundary does not flip-flop and thrash a transition every frame.
+    // Growing stays prompt to avoid under-resolution.
+    static constexpr float MASK_SIZE_SHRINK_HYSTERESIS = 0.15f;
     // Local-unit -> screen-pixel scale fed by the Node2D wrapper (see setter).
     float _coverage_screen_scale = 1.0f;
     // Size class to borrow next frame, decided from this frame's footprint. The


### PR DESCRIPTION
## 概要

マスク（クリッピング）のフットプリントがアニメで拡大・縮小し、coverage の**サイズクラス（2の冪）境界を跨ぐ瞬間に、1フレームだけマスキングが無効化されて内容が抜ける**バグを修正します。

`Mask/True_light` の円形マスクが、フットプリントが 512px を跨ぐフレームで一瞬消える（奥の青い光が赤背景に塗り潰される）現象の原因です。連続ズームでは境界を跨ぐたびにチラつきます。

## 原因

coverage テクスチャはサイズクラス（power-of-two）に量子化してプールから借りています。サイズクラスが変わると新しいプールターゲットを acquire しますが、**Godot の viewport テクスチャは1フレーム遅延**でしか読めないため、取得直後のターゲットには有効な coverage がありません。従来はこの遷移フレームで `_mask_coverage_valid=false` としてマスキングを丸ごとスキップ → クリップ対象が無クリップで描かれ、マスク内容が1フレーム抜けていました。

## 修正（A＋C の2点、いずれも mask coverage 経路限定）

**A. 遷移フレームは直前フレームのターゲットをサンプル（軽量ダブルバッファ）**
サイズクラス遷移時、旧ターゲットを即解放せず `_mask_prev` として1フレーム保持し、その遷移フレームだけ**旧ターゲットの（まだ有効な）coverage をサンプル**します。サンプリング UV は毎フレーム現 bbox 基準なので、これは**通常フレームと同じ1フレーム遅延**（その1フレームだけ旧解像度）に過ぎず、マスクは落ちません。`_mask_prev` は次の coverage pass 冒頭とteardownで解放。二重描画は行いません。

**C. サイズクラス決定に縮小側ヒステリシス**
`ss_hysteretic_coverage_dim` を追加。**拡大は即応**（解像度を落とさない）、**縮小は境界を 15% 下回るまで現クラスを維持**（`MASK_SIZE_SHRINK_HYSTERESIS = 0.15`）。境界付近で揺れるマスクが毎フレーム遷移を起こす（バタつき）のを抑えます。非対称なのは、拡大を渋ると縁がブロック状に荒れる（見える品質バグ）一方、縮小の居座りは VRAM/フィルが少し増えるだけ（見えないコスト）だからです。

A が「遷移が起きても落とさない」、C が「そもそもムダな遷移を起こさない」を担い、補完します。

変更は `ss_player/ss_internal_player.cpp` + `ss_internal_player.h` の2ファイル（+66 / -8）。非マスクアニメ・通常マスクフレームは経路不変です。

## 検証（モジュール版を再ビルドして実描画）

`Mask/True_light`（円形マスクが bbox 212→637→432 と連続スケール、512px を拡大・縮小で2回跨ぐ）で計装＋スクショ確認：

- 修正前：跨ぎフレームで `valid=0` → マスク内容（青い光）が消え赤で塗り潰し。
- 修正後：跨ぎフレームで **`_mask_prev` をサンプルして `valid=1`** を維持 → マスク内容が正常に表示。範囲内は初回ウォームアップ（1フレーム目）以外すべて `valid=1`。
- 縮小遷移はヒステリシスで遅延（＝高解像度時間が延びる）＋ A でシームレス。
- Basic / Mask / Mesh / Bounding 等に回帰なし。

## 備考

- CI（PR Build）は submodule `cri-middleware/SpriteStudio-SDK` のクローンがトークン権限で 404 になる**リポジトリ全体の既存障害**により赤になりますが、本 PR とは無関係です（develop の定期ビルド含め 2026-06-24 以降 全 CI が同じ場所で失敗）。

## 別途フォロー予定（本 PR 対象外）

`_emit_shape_batch` / `_emit_mesh_batch` に、先の #211 で直した Normal と同型の per-part/default draw-order 反転が残存しています。同じ flush 方式で別 PR にて対応予定です。
