### PR TITLE
fix(player): keep Shape/Mesh default parts in rank order past per-part parts

### DIFF
--- a/ss_player/ss_internal_player.cpp
+++ b/ss_player/ss_internal_player.cpp
@@ -2392,8 +2392,31 @@ void SsInternalPlayer::_emit_shape_batch(const DrawFrame& f, RID ci,
     // shape pipeline now shares the PartColor shader with Normal/Mesh, so
     // the GPU framebuffer blend is selected via _apply_partcolor_material.
     const auto ssab_blend = (ss::format::BlendType)batch->blend_type();
-    bool batch_material_applied = false;
     const bool masking_active = _mask_coverage_valid;
+
+    // Default (shared-shader) parts of a batch must interleave with its per-part
+    // parts by rank, not all sink behind them onto the single batch CI (whose
+    // draw_index is fixed before any part is processed). Emit each contiguous run
+    // of default parts onto its own canvas item, indexed at that run's rank
+    // position: the first run reuses the batch CI; a run resumed after a per-part
+    // part takes a fresh pooled CI. (Same fix as _emit_normal_batch.)
+    RID run_ci;
+    bool batch_ci_used = false;
+    auto default_run_ci = [&]() -> RID {
+        if (run_ci.is_valid()) return run_ci;
+        if (!batch_ci_used) {
+            run_ci = ci;
+            batch_ci_used = true;
+            // Override the placeholder draw_index the caller set before the
+            // per-part/default split (and thus the rank order) was known.
+            f.rs->canvas_item_set_draw_index(ci, _draw_seq++);
+        } else {
+            run_ci = _acquire_per_part_canvas_item(); // draw_index = _draw_seq++
+        }
+        f.rs->canvas_item_set_transform(run_ci, Transform2D());
+        _apply_partcolor_material(f.rs, run_ci, s_default_shader_id_hash, ssab_blend);
+        return run_ci;
+    };
 
     for (uint16_t k = 0; k < count; k++) {
         int p_idx = (int)draw_order_data[batch->start_rank() + k];
@@ -2429,6 +2452,7 @@ void SsInternalPlayer::_emit_shape_batch(const DrawFrame& f, RID ci,
 
         PartShaderInfo psi = _resolve_part_shader_info(f, part);
         if (psi.is_per_part || masked) {
+            run_ci = RID(); // end the current default run; a later default part starts a new CI after this one
             RID part_ci = _acquire_per_part_canvas_item();
             Ref<ShaderMaterial> mat = _acquire_per_part_material(psi.id_hash, ssab_blend);
             // Shape parts have no bound cellmap texture; pass a zero
@@ -2446,18 +2470,14 @@ void SsInternalPlayer::_emit_shape_batch(const DrawFrame& f, RID ci,
                                  _shape_buf.colors, _shape_buf.uvs, _shape_buf.custom0,
                                  RID());
         } else {
-            if (!batch_material_applied) {
-                _apply_partcolor_material(f.rs, ci, s_default_shader_id_hash, ssab_blend);
-                batch_material_applied = true;
-            }
-            _emit_partcolor_mesh(f.rs, ci, _shape_buf.indices, _shape_buf.verts,
+            _emit_partcolor_mesh(f.rs, default_run_ci(), _shape_buf.indices, _shape_buf.verts,
                                  _shape_buf.colors, _shape_buf.uvs, _shape_buf.custom0,
                                  RID());
         }
     }
-    if (!batch_material_applied) {
-        // Every Shape part in this batch took the per-part route. Clear stale
-        // commands on the batch CI so the previous frame's draws don't linger.
+    if (!batch_ci_used) {
+        // Every Shape part in this batch took the per-part route (batch CI unused).
+        // Clear stale commands so the previous frame's draws don't linger.
         f.rs->canvas_item_clear(ci);
     }
 }
@@ -2483,8 +2503,28 @@ void SsInternalPlayer::_emit_mesh_batch(const DrawFrame& f, RID ci,
     // BlendType by raw u8 value (same convention as _emit_normal_batch).
     const auto ssab_blend = (ss::format::BlendType)batch->blend_type();
     const RID tex_rid = tex->get_rid();
-    bool batch_material_applied = false;
     const bool masking_active = _mask_coverage_valid;
+
+    // Interleave default (shared-shader) parts with per-part parts by rank —
+    // emit each contiguous default run onto its own rank-indexed canvas item
+    // (first run reuses the batch CI, later runs take pooled CIs) instead of
+    // collapsing them all onto the batch CI behind the per-part parts.
+    // (Same fix as _emit_normal_batch.)
+    RID run_ci;
+    bool batch_ci_used = false;
+    auto default_run_ci = [&]() -> RID {
+        if (run_ci.is_valid()) return run_ci;
+        if (!batch_ci_used) {
+            run_ci = ci;
+            batch_ci_used = true;
+            f.rs->canvas_item_set_draw_index(ci, _draw_seq++);
+        } else {
+            run_ci = _acquire_per_part_canvas_item(); // draw_index = _draw_seq++
+        }
+        f.rs->canvas_item_set_transform(run_ci, Transform2D());
+        _apply_partcolor_material(f.rs, run_ci, s_default_shader_id_hash, ssab_blend);
+        return run_ci;
+    };
 
     for (uint16_t k = 0; k < count; k++) {
         int p_idx = (int)draw_order_data[batch->start_rank() + k];
@@ -2513,6 +2553,7 @@ void SsInternalPlayer::_emit_mesh_batch(const DrawFrame& f, RID ci,
 
         PartShaderInfo psi = _resolve_part_shader_info(f, part);
         if (psi.is_per_part || masked) {
+            run_ci = RID(); // end the current default run; a later default part starts a new CI after this one
             RID part_ci = _acquire_per_part_canvas_item();
             Ref<ShaderMaterial> mat = _acquire_per_part_material(psi.id_hash, ssab_blend);
             const Vector4 cell_rect = _resolve_cell_rect_uv(f, p_idx, inv_tex_size);
@@ -2527,16 +2568,12 @@ void SsInternalPlayer::_emit_mesh_batch(const DrawFrame& f, RID ci,
                                  _mesh_buf.colors, _mesh_buf.uvs, _mesh_buf.custom0,
                                  tex_rid);
         } else {
-            if (!batch_material_applied) {
-                _apply_partcolor_material(f.rs, ci, s_default_shader_id_hash, ssab_blend);
-                batch_material_applied = true;
-            }
-            _emit_partcolor_mesh(f.rs, ci, _mesh_buf.indices, _mesh_buf.verts,
+            _emit_partcolor_mesh(f.rs, default_run_ci(), _mesh_buf.indices, _mesh_buf.verts,
                                  _mesh_buf.colors, _mesh_buf.uvs, _mesh_buf.custom0,
                                  tex_rid);
         }
     }
-    if (!batch_material_applied) {
+    if (!batch_ci_used) {
         f.rs->canvas_item_clear(ci);
     }
 }


### PR DESCRIPTION
## 概要

#211 で `_emit_normal_batch` に入れた draw-order 修正を、**同型のバグが残っていた `_emit_shape_batch` / `_emit_mesh_batch` にも展開**します。

同じバッチが「default（共有シェーダ）パーツ」と「per-part パーツ（カスタムシェーダ or マスク）」を混在して含むとき、**default パーツが rank を無視して per-part パーツの背面に沈む**問題です（Shape/Mesh 版）。

## 原因

Shape/Mesh バッチも、default パーツを**1枚のバッチ canvas item**（draw_index はパーツ処理前に確定）にまとめて描き、per-part パーツは処理中に個別 CI（＝より後＝前面の draw_index）を取得します。結果、**同一バッチ内では default が per-part の常に背面**になり、rank 順が壊れます。#211 で直した Normal と全く同じ機序です。

## 修正

`_emit_shape_batch` / `_emit_mesh_batch` を、**連続する default パーツのランごとに専用 canvas item を rank 位置で採番**する方式へ（`default_run_ci` ラムダ）：

- 最初の default ランはバッチ CI を再利用（その時点で draw_index を採番し直す）。
- per-part パーツで分断された後続ランは per-part プールから新規 CI を確保。
- これで default と per-part が **rank 順に正しくインターリーブ**します。
- 全 default／全 per-part のバッチは従来どおり（末尾で未使用バッチ CI をクリア）。

`_emit_normal_batch` の修正（#211）の行単位ミラーです。変更は `ss_player/ss_internal_player.cpp` の2関数のみ（+53 / -16）。

## 検証

- コンパイル緑（モジュールビルド）。
- 回帰描画：overall の **Shape**（グラデ図形）／**Mesh**（チェック柄）／マスクの **True_light**（クリッピング）すべて正常、表示崩れなし。ユーザー実機目視でも表示関係の異常なしを確認。
- 注記：Shape/Mesh で「per-part パーツが default より**低い rank**」という反転シナリオを踏む既存テストデータが手元に無いため、before/after の視覚比較は取れていません。ただし本修正は #211（Signal/face で視覚実証済み）の Normal 修正と同一機序の行単位ミラーで、回帰も無しです。

## 備考

CI（PR Build）は submodule `cri-middleware/SpriteStudio-SDK` の clone がトークン権限で 404 になる**リポジトリ全体の既存障害**により赤になりますが、本 PR とは無関係です（develop の定期ビルド含め 2026-06-24 以降 全 CI が同じ場所で失敗）。
