### PR TITLE
ci(sign): move macOS/iOS codesign into gdextension release scripts

### DIFF
--- a/.github/workflows/extension.yml
+++ b/.github/workflows/extension.yml
@@ -83,58 +83,64 @@ jobs:
           platform: ${{ matrix.platform }}
           os: ${{ matrix.os }}
 
-      - name: Retrieve the secret and decode it to a file
+      # Import the Developer ID Application certificate into an ephemeral keychain
+      # so codesign (run inside the release scripts) can resolve the signing
+      # identity. No-ops when the certificate secret is absent, leaving the
+      # artifacts unsigned.
+      - name: Set up signing keychain
         if: matrix.platform == 'macos' || matrix.platform == 'ios'
         env:
-          DEV_CERT_APPLICATION: ${{ secrets.DEV_CERT_APPLICATION }}
-          DEV_CERT_PASS: ${{ secrets.DEV_CERT_PASS }}
-          KC_PASS: ${{ secrets.KC_PASS }}
+          SS_APPLE_CERTIFICATE: ${{ secrets.SS_APPLE_CERTIFICATE }}
+          SS_APPLE_CERTIFICATE_PASSWORD: ${{ secrets.SS_APPLE_CERTIFICATE_PASSWORD }}
         run: |
-          # create variables
-          CERTIFICATE_PATH=$RUNNER_TEMP/build_certificate.p12
+          if [ -z "$SS_APPLE_CERTIFICATE" ]; then
+            echo "SS_APPLE_CERTIFICATE not set — skipping keychain setup (artifacts will be unsigned)."
+            exit 0
+          fi
 
-          # import certificate and provisioning profile from secrets
-          echo -n "$DEV_CERT_APPLICATION" | base64 --decode > $CERTIFICATE_PATH
+          CERTIFICATE_PATH="$RUNNER_TEMP/build_certificate.p12"
+          # Random per-run password for the throwaway keychain; never persisted.
+          KEYCHAIN_PASSWORD="$(openssl rand -base64 24)"
 
-          # create temporary keychain
-          security create-keychain -p "$KC_PASS" ${{ env.KEYCHAIN_PATH }}
-          security set-keychain-settings -lut 21600 ${{ env.KEYCHAIN_PATH }}
-          security unlock-keychain -p "$KC_PASS" ${{ env.KEYCHAIN_PATH }}
+          echo -n "$SS_APPLE_CERTIFICATE" | base64 --decode > "$CERTIFICATE_PATH"
 
-          # import certificate to keychain
-          security import $CERTIFICATE_PATH -P "$DEV_CERT_PASS" -f pkcs12 -k ${{ env.KEYCHAIN_PATH }} -T /usr/bin/codesign
-          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KC_PASS" ${{ env.KEYCHAIN_PATH }}
-          security list-keychain -d user -s ${{ env.KEYCHAIN_PATH }}
+          # Create, harden and unlock a temporary keychain.
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+
+          # Import the cert and authorize codesign to use its private key.
+          security import "$CERTIFICATE_PATH" -P "$SS_APPLE_CERTIFICATE_PASSWORD" -f pkcs12 -k "$KEYCHAIN_PATH" -T /usr/bin/codesign
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+
+          # Put the keychain on the search list so codesign resolves the identity
+          # (keep login.keychain-db so other tooling still works).
+          security list-keychain -d user -s "$KEYCHAIN_PATH" login.keychain-db
+
+          rm -f "$CERTIFICATE_PATH"
 
       - name: build Linux
         if: matrix.platform == 'linux'
         run: |
           ./scripts/release-gdextension-linux.sh api_version=${{ env.GODOT_VERSION }}
 
+      # release-gdextension-macos.sh signs the frameworks (hardened runtime +
+      # timestamp) when APPLE_SIGNING_IDENTITY is present.
       - name: build macOS
         if: matrix.platform == 'macos'
         env:
-          DEV_ID_APPLICATION: ${{ secrets.DEV_ID_APPLICATION }}
+          APPLE_SIGNING_IDENTITY: ${{ secrets.SS_APPLE_SIGNING_IDENTITY }}
         run: |
           ./scripts/release-gdextension-macos.sh api_version=${{ env.GODOT_VERSION }}
 
-          for f in ./bin/macos/*.framework
-          do
-            codesign --force --verify --verbose --keychain ${{ env.KEYCHAIN_PATH }} --sign "${DEV_ID_APPLICATION}" $f --deep --options runtime --timestamp
-          done
-
+      # release-gdextension-ios.sh signs the XCFrameworks inside-out (no hardened
+      # runtime; iOS is not notarized) when APPLE_SIGNING_IDENTITY is present.
       - name: build iOS
         if: matrix.platform == 'ios'
         env:
-          DEV_ID_APPLICATION: ${{ secrets.DEV_ID_APPLICATION }}
+          APPLE_SIGNING_IDENTITY: ${{ secrets.SS_APPLE_SIGNING_IDENTITY }}
         run: |
           ./scripts/release-gdextension-ios.sh api_version=${{ env.GODOT_VERSION }}
-
-          # iOS ships XCFrameworks (device + simulator); sign the frameworks inside each slice.
-          for f in ./bin/ios/*.xcframework/*/*.framework
-          do
-            codesign --force --verify --verbose --keychain ${{ env.KEYCHAIN_PATH }} --sign "${DEV_ID_APPLICATION}" $f --deep --options runtime --timestamp
-          done
 
       - name: build Android
         if: matrix.platform == 'android'

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -70,56 +70,60 @@ jobs:
           platform: ${{ matrix.platform }}
           os: ${{ matrix.os }}
 
-      # (Optional) code signing secrets retrieval omitted for weekly if unnecessary,
-      # but leaving placeholder or basic logic so the build won't fail.
-      - name: Retrieve the secret and decode it to a file
+      # Import the Developer ID Application certificate into an ephemeral keychain
+      # so codesign (run inside the release scripts) can resolve the signing
+      # identity. No-ops when the certificate secret is absent, leaving the
+      # artifacts unsigned.
+      - name: Set up signing keychain
         if: matrix.platform == 'macos' || matrix.platform == 'ios'
         continue-on-error: true # Weeklyでは署名できなくても通す
         env:
-          DEV_CERT_APPLICATION: ${{ secrets.DEV_CERT_APPLICATION }}
-          DEV_CERT_PASS: ${{ secrets.DEV_CERT_PASS }}
-          KC_PASS: ${{ secrets.KC_PASS }}
+          SS_APPLE_CERTIFICATE: ${{ secrets.SS_APPLE_CERTIFICATE }}
+          SS_APPLE_CERTIFICATE_PASSWORD: ${{ secrets.SS_APPLE_CERTIFICATE_PASSWORD }}
         run: |
-          if [ -z "$DEV_CERT_APPLICATION" ]; then
-            echo "Skipping signing setup as secrets are not available."
+          if [ -z "$SS_APPLE_CERTIFICATE" ]; then
+            echo "SS_APPLE_CERTIFICATE not set — skipping keychain setup (artifacts will be unsigned)."
             exit 0
           fi
-          CERTIFICATE_PATH=$RUNNER_TEMP/build_certificate.p12
-          echo -n "$DEV_CERT_APPLICATION" | base64 --decode > $CERTIFICATE_PATH
-          security create-keychain -p "$KC_PASS" ${{ env.KEYCHAIN_PATH }}
-          security set-keychain-settings -lut 21600 ${{ env.KEYCHAIN_PATH }}
-          security unlock-keychain -p "$KC_PASS" ${{ env.KEYCHAIN_PATH }}
-          security import $CERTIFICATE_PATH -P "$DEV_CERT_PASS" -f pkcs12 -k ${{ env.KEYCHAIN_PATH }} -T /usr/bin/codesign
-          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KC_PASS" ${{ env.KEYCHAIN_PATH }}
-          security list-keychain -d user -s ${{ env.KEYCHAIN_PATH }}
+
+          CERTIFICATE_PATH="$RUNNER_TEMP/build_certificate.p12"
+          # Random per-run password for the throwaway keychain; never persisted.
+          KEYCHAIN_PASSWORD="$(openssl rand -base64 24)"
+
+          echo -n "$SS_APPLE_CERTIFICATE" | base64 --decode > "$CERTIFICATE_PATH"
+
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+
+          security import "$CERTIFICATE_PATH" -P "$SS_APPLE_CERTIFICATE_PASSWORD" -f pkcs12 -k "$KEYCHAIN_PATH" -T /usr/bin/codesign
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+
+          security list-keychain -d user -s "$KEYCHAIN_PATH" login.keychain-db
+
+          rm -f "$CERTIFICATE_PATH"
 
       - name: build Linux
         if: matrix.platform == 'linux'
         run: ./scripts/release-gdextension-linux.sh
 
+      # release-gdextension-macos.sh signs the frameworks when APPLE_SIGNING_IDENTITY
+      # is present; no-op (unsigned) otherwise, so weekly stays green without secrets.
       - name: build macOS
         if: matrix.platform == 'macos'
         env:
-          DEV_ID_APPLICATION: ${{ secrets.DEV_ID_APPLICATION }}
+          APPLE_SIGNING_IDENTITY: ${{ secrets.SS_APPLE_SIGNING_IDENTITY }}
         run: |
           ./scripts/release-gdextension-macos.sh
-          if [ -n "$DEV_ID_APPLICATION" ]; then
-            for f in ./bin/macos/*.framework; do
-              codesign --force --verify --verbose --keychain ${{ env.KEYCHAIN_PATH }} --sign "${DEV_ID_APPLICATION}" $f --deep --options runtime --timestamp
-            done
-          fi
 
+      # release-gdextension-ios.sh signs the XCFrameworks when APPLE_SIGNING_IDENTITY
+      # is present; no-op (unsigned) otherwise.
       - name: build iOS
         if: matrix.platform == 'ios'
         env:
-          DEV_ID_APPLICATION: ${{ secrets.DEV_ID_APPLICATION }}
+          APPLE_SIGNING_IDENTITY: ${{ secrets.SS_APPLE_SIGNING_IDENTITY }}
         run: |
           ./scripts/release-gdextension-ios.sh
-          if [ -n "$DEV_ID_APPLICATION" ]; then
-            for f in ./bin/ios/*.xcframework/*/*.framework; do
-              codesign --force --verify --verbose --keychain ${{ env.KEYCHAIN_PATH }} --sign "${DEV_ID_APPLICATION}" $f --deep --options runtime --timestamp
-            done
-          fi
 
       - name: build Android
         if: matrix.platform == 'android'

--- a/scripts/release-gdextension-ios.sh
+++ b/scripts/release-gdextension-ios.sh
@@ -42,6 +42,30 @@ done
 /bin/rm -rf tmp
 popd > /dev/null # ${BINDIR}
 
+# --- Code signing (opt-in via env) ------------------------------------------
+# Signs the XCFrameworks inside-out when APPLE_SIGNING_IDENTITY is set (maps to the
+# SS_APPLE_SIGNING_IDENTITY secret set by CI).
+# iOS is NOT notarized and does NOT use the macOS hardened runtime (--options runtime)
+# nor --deep: sign each embedded .framework first, then the .xcframework wrapper. The
+# consuming app re-signs the embedded framework with its own identity at build time;
+# this signature only lets consumers verify the package's provenance. Runs before the
+# examples sync below so the copied frameworks carry the signature. No-op when unset.
+if [ -n "${APPLE_SIGNING_IDENTITY:-}" ]; then
+    echo "==> Codesigning iOS XCFrameworks as: ${APPLE_SIGNING_IDENTITY}"
+    # Inner frameworks (one per slice) first...
+    for fw in ${BINDIR}/*.xcframework/*/*.framework(N); do
+        codesign --force --sign "${APPLE_SIGNING_IDENTITY}" --timestamp "${fw}"
+        codesign --verify --strict --verbose=2 "${fw}"
+    done
+    # ...then the xcframework wrappers.
+    for xcfw in ${BINDIR}/*.xcframework(N); do
+        codesign --force --sign "${APPLE_SIGNING_IDENTITY}" --timestamp "${xcfw}"
+        codesign --verify --strict --verbose=2 "${xcfw}"
+    done
+else
+    echo "==> Skipping iOS codesign (APPLE_SIGNING_IDENTITY not set)"
+fi
+
 # Sync the xcframework to the examples and remove the leftover .frameworks
 MAIN_PROJECT="dev_gdextension"
 OTHER_PROJECTS=("overall_gdextension" "Ringo")

--- a/scripts/release-gdextension-macos.sh
+++ b/scripts/release-gdextension-macos.sh
@@ -15,4 +15,21 @@ for target in ${targets[@]}; do
 done
 /bin/rm -rf bin/macos/macos.framework
 
+# --- Code signing (opt-in via env) ------------------------------------------
+# Signs the GDExtension frameworks with a Developer ID Application identity when
+# APPLE_SIGNING_IDENTITY is set (maps to the SS_APPLE_SIGNING_IDENTITY secret; the
+# CI sets it in .github/workflows/extension.yml). Hardened runtime (--options
+# runtime) + a secure timestamp. Not notarized. No-op (unsigned) when the identity
+# is absent, so local builds without a certificate still succeed.
+if [ -n "${APPLE_SIGNING_IDENTITY:-}" ]; then
+    echo "==> Codesigning macOS frameworks as: ${APPLE_SIGNING_IDENTITY}"
+    for fw in ${BINDIR}/*.framework(N); do
+        codesign --force --sign "${APPLE_SIGNING_IDENTITY}" \
+            --options runtime --timestamp "${fw}"
+        codesign --verify --strict --verbose=2 "${fw}"
+    done
+else
+    echo "==> Skipping macOS codesign (APPLE_SIGNING_IDENTITY not set)"
+fi
+
 popd > /dev/null # ${ROOTDIR}


### PR DESCRIPTION
## Summary

Move macOS / iOS signing of the GDExtension artifacts (framework / xcframework) out of the inline CI YAML and **into the release scripts**, using the same opt-in approach as SpriteStudio-SDK: signing runs only when `APPLE_SIGNING_IDENTITY` is set, and is a no-op (unsigned build still succeeds) otherwise. Not notarized.

Scope is **gdextension only**. The custom-module scripts (`release-macos.sh` / `release-ios.sh`) are left unsigned since they are not distributed as release artifacts.

## Changes

**Release scripts**
- `scripts/release-gdextension-macos.sh`: sign each `*.framework` with hardened runtime + secure timestamp, then `codesign --verify --strict`.
- `scripts/release-gdextension-ios.sh`: sign **inside-out** (embedded `.framework` first, then the `.xcframework` wrapper) with a timestamp only. **Drop `--deep` and the macOS-only `--options runtime`**, which are inappropriate for iOS. Signing runs before the examples sync so the copied frameworks are signed too.

**CI (`extension.yml` / `weekly.yml`)**
- Remove the inline `codesign` loops; delegate signing to the scripts.
- Ephemeral keychain now uses a random per-run password and keeps `login.keychain-db` on the search list.
- Unify the signing secrets to **`SS_APPLE_CERTIFICATE` / `SS_APPLE_CERTIFICATE_PASSWORD` / `SS_APPLE_SIGNING_IDENTITY`** (old `DEV_CERT_*` / `DEV_ID_APPLICATION` / `KC_PASS` removed).

## Follow-up (repo settings)
- Add GitHub secrets `SS_APPLE_CERTIFICATE` / `SS_APPLE_CERTIFICATE_PASSWORD` / `SS_APPLE_SIGNING_IDENTITY` (builds still pass unsigned without them).
- The old secrets are no longer referenced and can be deleted.

## Notes
- Includes a submodule pointer bump for `ss_player/SpriteStudio-SDK` (`SDK_VERSION.txt` unchanged at `v7.0.0-alpha01`).

## Verification
- `zsh -n` syntax check: both scripts OK
- Workflow YAML validated