### PR TITLE
Bump SpriteStudio-SDK; pass embedded=false to ss_converter_convert

### DIFF
--- a/ss_player/ss_importer.cpp
+++ b/ss_player/ss_importer.cpp
@@ -289,7 +289,7 @@ void *SSImporter::_process_file(const String &source_sspj_path, const String &ds
     CharString src_utf8 = source_sspj_path.utf8();
     CharString dst_utf8 = dst_dir_path.utf8();
 
-    ss_converter_convert(ctx, src_utf8.get_data(), dst_utf8.get_data(), [](const char *msg) {
+    ss_converter_convert(ctx, src_utf8.get_data(), dst_utf8.get_data(), false, [](const char *msg) {
         print_line(String::utf8(msg));
     });
 


### PR DESCRIPTION
## Summary

The SDK's `ss_converter_convert` C-API gained an `embedded: bool` parameter (cri-middleware/SpriteStudio-SDK#301). The Godot player does not support embedded `.ssab` (textures packed into the binary), so it always passes `embedded = false` and behaves exactly as before.

## Changes

- **`ss_player/SpriteStudio-SDK`**: bump the submodule to the SDK commit that adds the flag (`57483d8`).
- **`ss_player/ss_importer.cpp`**: pass `false` at the `ss_converter_convert` call site.
- The generated header `ss_player/runtime/include/ssconverter.h` is a gitignored artifact copied from the SDK during build, so the only tracked change is the call site above.

## Depends on

cri-middleware/SpriteStudio-SDK#301