### PR TITLE
fix(ffi): use .hpp extension for SS-SDK C++ headers

### DIFF
--- a/scripts/build-runtime.ps1
+++ b/scripts/build-runtime.ps1
@@ -85,8 +85,8 @@ popd
 # 1. Collect Headers
 $INCLUDE_OUTPUT = "$rootDirectory/ss_player/runtime/include"
 New-Item -ItemType Directory -Path $INCLUDE_OUTPUT -Force | Out-Null
-Copy-Item "$SDK_DIR/libs/ssconverter/target/ssconverter.h" "$INCLUDE_OUTPUT/" -Force
-Copy-Item "$SDK_DIR/libs/ssruntime/target/ssruntime.h" "$INCLUDE_OUTPUT/" -Force
+Copy-Item "$SDK_DIR/libs/ssconverter/target/ssconverter.hpp" "$INCLUDE_OUTPUT/" -Force
+Copy-Item "$SDK_DIR/libs/ssruntime/target/ssruntime.hpp" "$INCLUDE_OUTPUT/" -Force
 
 # 1.5. Collect Licenses
 $RUNTIME_OUTPUT = "$rootDirectory/ss_player/runtime"

--- a/scripts/build-runtime.sh
+++ b/scripts/build-runtime.sh
@@ -129,9 +129,9 @@ RUNTIME_DIR=${ROOTDIR}/ss_player/runtime
 
 # Headers
 mkdir -p ${RUNTIME_DIR}/include
-cp ${SDK_DIR}/libs/ssruntime/target/ssruntime.h ${RUNTIME_DIR}/include/
+cp ${SDK_DIR}/libs/ssruntime/target/ssruntime.hpp ${RUNTIME_DIR}/include/
 if [[ "$PLATFORM" == "macos" || "$PLATFORM" == "windows" || "$PLATFORM" == "linux" ]]; then
-    cp ${SDK_DIR}/libs/ssconverter/target/ssconverter.h ${RUNTIME_DIR}/include/
+    cp ${SDK_DIR}/libs/ssconverter/target/ssconverter.hpp ${RUNTIME_DIR}/include/
 fi
 
 # Licenses

--- a/ss_player/ss_import_dock.cpp
+++ b/ss_player/ss_import_dock.cpp
@@ -41,7 +41,7 @@ using namespace godot;
 #include "ss_clickable_label.h"
 #include "ss_import_dock.h"
 #include "ss_importer.h"
-#include "ssconverter.h"
+#include "ssconverter.hpp"
 
 // Plugin version, stamped at build time from VERSION.txt + git hash.
 // Generated into ss_player/gen/ by generate_version_header() (ss_player/sources.py).

--- a/ss_player/ss_importer.cpp
+++ b/ss_player/ss_importer.cpp
@@ -40,7 +40,7 @@ using namespace godot;
 #endif
 #endif
 
-#include "ssconverter.h"
+#include "ssconverter.hpp"
 
 void SSImporter::_bind_methods() {
     ADD_SIGNAL(MethodInfo("import_started"));

--- a/ss_player/ss_internal_player.cpp
+++ b/ss_player/ss_internal_player.cpp
@@ -1,7 +1,7 @@
 #include "ss_internal_player.h"
 #include "format/ssab.h"
 #include "format/effect_draw_plan.h"
-#include "ssruntime.h"
+#include "ssruntime.hpp"
 #include "format/framedata.h"
 #include <mutex>
 #include <cstring>

--- a/ss_player/ss_internal_player.h
+++ b/ss_player/ss_internal_player.h
@@ -37,7 +37,7 @@ using namespace godot;
 
 #include "ssab_resource.h"
 
-// Forward declaration; full definition comes from runtime/include/ssruntime.h.
+// Forward declaration; full definition comes from runtime/include/ssruntime.hpp.
 struct ss_event_instance_info;
 
 namespace ss {


### PR DESCRIPTION
## Summary

SS-SDK changed its header naming convention so that C headers are emitted as `*.h` and C++ headers as `*.hpp` (cbindgen `Language::C` / `Language::Cxx`). Godot previously consumed `*.h` assuming it was the C++ header, so this PR switches to the C++ variant (`*.hpp`).

## Changes

- **Switch C++ source includes to `.hpp`**
  - `ss_player/ss_internal_player.cpp`: `ssruntime.h` → `ssruntime.hpp`
  - `ss_player/ss_import_dock.cpp`: `ssconverter.h` → `ssconverter.hpp`
  - `ss_player/ss_importer.cpp`: `ssconverter.h` → `ssconverter.hpp`
  - `ss_player/ss_internal_player.h`: update the referenced path in a comment to `.hpp`
- **Copy the C++ (`.hpp`) headers from the SDK `target/` in the build-runtime scripts**
  - `scripts/build-runtime.sh` / `scripts/build-runtime.ps1`: copy `ssruntime.hpp` / `ssconverter.hpp`
- **Bump the SDK submodule to the commit that ships the renamed headers**
  - `ss_player/SpriteStudio-SDK`: `57483d8` → `70997ca`

`scripts/download-sdk.sh` / `.ps1` extract the release zip into `runtime/` as-is, and the release bundles both `.h` (C) and `.hpp` (C++), so no change is needed there. `runtime/include` is a gitignored build artifact.

## Verification

- Ran `./scripts/build-runtime.sh` (macos/arm64/debug) → confirmed `ssruntime.hpp` / `ssconverter.hpp` are generated into `runtime/include/`.
- Ran `./scripts/build-extension.sh` → the GDExtension, including the 3 affected translation units, compiles and links successfully.

> The link-time `duplicate symbol` warnings (`rust_begin_unwind` / `rust_eh_personality`) are pre-existing: `libssruntime.a` and `libssconverter.a` both carry Rust's panic/unwind symbols. They are unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)