### PR TITLE
fix: drop previous_child_frame from ss_instance_slot_step

### DIFF
--- a/ss_player/ss_internal_player.cpp
+++ b/ss_player/ss_internal_player.cpp
@@ -1594,7 +1594,7 @@ void SsInternalPlayer::_drive_instance_slot(InstanceChildState& state,
     // child Player's event sink on transition (via play()), and the redraw.
     const ss_instance_step_result r = ss_instance_slot_step(
         state.instance_slot, info, child->runtime_ctx,
-        child->previous_frame_no, parent_frame_no, delta_seconds, parent_looped);
+        parent_frame_no, delta_seconds, parent_looped);
 
     if (r.transitioned) {
         // Controller is already configured + playing inside step(); play()


### PR DESCRIPTION
Follows [SpriteStudio-SDK#311](https://github.com/cri-middleware/SpriteStudio-SDK/pull/311), which removes the `previous_child_frame` parameter from `ss_instance_slot_step`.

## Why the SDK dropped it

The parameter fed an inference of the child's loop edge — "the child's frame moved backwards, so it looped." That only holds for forward `Normal` playback. A `reverse` child's frame decreases every tick and a `pingpong` child's decreases for its whole return leg, so `child_looped` fired on nearly every tick (measured: 237 loops over 240 ticks on an 80-frame animation, against 3). It now reads the child controller's own `is_looped` pulse, leaving the argument dead.

That misfire mattered here: this Player feeds `r.child_looped` down as `parent_looped` via `_redraw_child_if_frame_changed` → `_drawAnimation`, and `parent_looped` re-arms the grandchildren's playback keys. A reverse or ping-pong independent instance child was restarting every grandchild under it on nearly every tick.

## This change

- `ss_instance_slot_step` call site: drop the argument.
- Bump the SDK submodule to the fix.

`previous_frame_no` stays — unlike the other Players' equivalents, it is also this Player's redraw guard (`ss_internal_player.cpp:815`, `:1615`, `:1622`), so only the argument goes.

Worth noting what was being passed: `previous_frame_no` holds the *rounded* draw frame when sub-frame is off, so the SDK was comparing a raw child frame against a rounded previous one. The inference was doubly wrong here, not only on reverse/ping-pong.

## Verification

- `./scripts/build-runtime.sh` — regenerates `ssruntime.hpp` at the new submodule commit; confirmed the 6-arg signature.
- `./scripts/build-extension.sh` — builds clean. (The `ld` duplicate-symbol warnings for `rust_begin_unwind` / `rust_eh_personality` are pre-existing and unrelated.)