### PR TITLE
feat: consume the flat SDK layout and cache the download for reuse

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ compile_commands.json
 /ss_player/runtime/include
 /ss_player/runtime/libs
 /ss_player/runtime/*.md
+/scripts/.sdk-cache/
 /examples/dev_*/ssab_generated
 /examples/dev_*/.ssplayer_sources.cfg
 /examples/*/addons/spritestudio

--- a/scripts/download-sdk.ps1
+++ b/scripts/download-sdk.ps1
@@ -5,6 +5,9 @@ $rootDirectory = Split-Path -Parent $baseDirectory
 $targetDir = "$rootDirectory/ss_player"
 $versionFile = "$baseDirectory/SDK_VERSION.txt"
 $currentVersionFile = "$targetDir/runtime/VERSION"
+# Downloaded zip is cached here (gitignored) so a re-run that needs the same
+# version reuses it instead of re-downloading tens of MB.
+$cacheDir = "$baseDirectory/.sdk-cache"
 
 $targetVersion = (Get-Content $versionFile).Trim()
 
@@ -18,47 +21,51 @@ if (Test-Path $currentVersionFile) {
 
 $baseUrl = "https://github.com/cri-middleware/SpriteStudio-SDK/releases/download/$targetVersion"
 $asset = "spritestudio-sdk-static-libs.zip"
-$zipFile = "$targetDir/sdk.zip"
-$sumsFile = "$targetDir/SHA256SUMS"
+# Keep the release asset's own name so it matches the SHA256SUMS entry directly.
+$zipFile = "$cacheDir/$asset"
+$sumsFile = "$cacheDir/SHA256SUMS"
 
 Write-Host "Target SDK Version: $targetVersion"
+New-Item -ItemType Directory -Force -Path $cacheDir | Out-Null
 
-# Fetch the release's SHA256SUMS manifest and verify the downloaded zip against
-# it before extracting, so a corrupted or tampered download fails loudly.
+function Get-Sha256($file) { (Get-FileHash -Algorithm SHA256 -Path $file).Hash.ToLower() }
+
+# Fetch the checksum manifest (small): it both verifies integrity and decides
+# whether an already-cached zip can be reused without re-downloading.
 Write-Host "Downloading checksum manifest: $baseUrl/SHA256SUMS"
 Invoke-WebRequest -Uri "$baseUrl/SHA256SUMS" -OutFile $sumsFile
 
-Write-Host "Downloading SDK: $baseUrl/$asset"
-Invoke-WebRequest -Uri "$baseUrl/$asset" -OutFile $zipFile
-
-# Verify <file> against the manifest entry for <asset-name>. Get-FileHash returns
-# an upper-case hash; sha256sum writes lower-case, so compare case-insensitively.
-function Assert-Sha256($file, $name) {
-    $expected = $null
-    foreach ($line in Get-Content $sumsFile) {
-        $parts = $line -split '\s+', 2
-        if ($parts.Count -eq 2 -and $parts[1].Trim() -eq $name) { $expected = $parts[0].ToLower(); break }
-    }
-    if (-not $expected) {
-        Write-Error "No checksum entry for $name in SHA256SUMS"
-        exit 1
-    }
-    $actual = (Get-FileHash -Algorithm SHA256 -Path $file).Hash.ToLower()
-    if ($expected -ne $actual) {
-        Write-Error "Checksum mismatch for $name`n  expected: $expected`n  actual:   $actual"
-        exit 1
-    }
-    Write-Host "Checksum OK: $name"
+$expected = $null
+foreach ($line in Get-Content $sumsFile) {
+    $parts = $line -split '\s+', 2
+    if ($parts.Count -eq 2 -and $parts[1].Trim() -eq $asset) { $expected = $parts[0].ToLower(); break }
 }
-Assert-Sha256 $zipFile $asset
+if (-not $expected) {
+    Write-Error "No checksum entry for $asset in SHA256SUMS"
+    exit 1
+}
 
+# Reuse the cached zip when it already matches the manifest; otherwise download.
+if ((Test-Path $zipFile) -and ((Get-Sha256 $zipFile) -eq $expected)) {
+    Write-Host "Reusing cached $asset"
+} else {
+    Write-Host "Downloading SDK: $baseUrl/$asset"
+    Invoke-WebRequest -Uri "$baseUrl/$asset" -OutFile $zipFile
+    if ((Get-Sha256 $zipFile) -ne $expected) {
+        Remove-Item -Force $zipFile
+        Write-Error "Checksum mismatch for $asset"
+        exit 1
+    }
+}
+Write-Host "Checksum OK: $asset"
+
+# The release archive is a flat tree (libs/, include/, VERSION, …) with no
+# wrapper directory, so extract it straight into ss_player/runtime/.
 Write-Host "Extracting SDK..."
 if (Test-Path "$targetDir/runtime") {
     Remove-Item -Recurse -Force "$targetDir/runtime"
 }
-Expand-Archive -Path $zipFile -DestinationPath $targetDir -Force
-Remove-Item $zipFile
-Remove-Item $sumsFile
+Expand-Archive -Path $zipFile -DestinationPath "$targetDir/runtime" -Force
 
 # Godot Custom Module compatibility (Windows x86_64)
 $winLibDir = "$targetDir/runtime/libs/windows/x86_64"

--- a/scripts/download-sdk.sh
+++ b/scripts/download-sdk.sh
@@ -6,6 +6,9 @@ ROOTDIR=$(cd "$BASEDIR/.." && pwd -P)
 TARGET_DIR="${ROOTDIR}/ss_player"
 VERSION_FILE="${SCRIPTDIR}/SDK_VERSION.txt"
 CURRENT_VERSION_FILE="${TARGET_DIR}/runtime/VERSION"
+# Downloaded zip is cached here (gitignored) so a re-run that needs the same
+# version reuses it instead of re-downloading tens of MB.
+CACHE_DIR="${SCRIPTDIR}/.sdk-cache"
 
 TARGET_VERSION=$(tr -d ' \r\n' < "$VERSION_FILE")
 
@@ -19,47 +22,50 @@ fi
 
 BASE_URL="https://github.com/cri-middleware/SpriteStudio-SDK/releases/download/${TARGET_VERSION}"
 ASSET="spritestudio-sdk-static-libs.zip"
-ZIP_FILE="${TARGET_DIR}/sdk.zip"
-SUMS_FILE="${TARGET_DIR}/SHA256SUMS"
+# Keep the release asset's own name so it matches the SHA256SUMS entry directly.
+ZIP_FILE="${CACHE_DIR}/${ASSET}"
+SUMS_FILE="${CACHE_DIR}/SHA256SUMS"
 
 echo "Target SDK Version: ${TARGET_VERSION}"
+mkdir -p "$CACHE_DIR"
 
-# Fetch the release's SHA256SUMS manifest and verify the downloaded zip against
-# it before extracting, so a corrupted or tampered download fails loudly.
+sha256_of() {
+    if command -v sha256sum >/dev/null 2>&1; then
+        sha256sum "$1" | awk '{print $1}'
+    else
+        shasum -a 256 "$1" | awk '{print $1}'
+    fi
+}
+
+# Fetch the checksum manifest (small): it both verifies integrity and decides
+# whether an already-cached zip can be reused without re-downloading.
 echo "Downloading checksum manifest: ${BASE_URL}/SHA256SUMS"
 curl -fL -o "$SUMS_FILE" "${BASE_URL}/SHA256SUMS"
+EXPECTED=$(awk -v n="$ASSET" '$2 == n {print $1}' "$SUMS_FILE")
+if [ -z "$EXPECTED" ]; then
+    echo "ERROR: no checksum entry for ${ASSET} in SHA256SUMS" >&2
+    exit 1
+fi
 
-echo "Downloading SDK: ${BASE_URL}/${ASSET}"
-curl -fL -o "$ZIP_FILE" "${BASE_URL}/${ASSET}"
-
-# Verify <file> against the manifest entry for <asset-name>. Uses sha256sum
-# (Linux) or shasum -a 256 (macOS), matching the manifest line by asset name.
-verify_sha256() {
-    local file="$1" name="$2" expected actual
-    expected=$(awk -v n="$name" '$2 == n {print $1}' "$SUMS_FILE")
-    if [ -z "$expected" ]; then
-        echo "ERROR: no checksum entry for ${name} in SHA256SUMS" >&2
+# Reuse the cached zip when it already matches the manifest; otherwise download.
+if [ -f "$ZIP_FILE" ] && [ "$(sha256_of "$ZIP_FILE")" = "$EXPECTED" ]; then
+    echo "Reusing cached ${ASSET}"
+else
+    echo "Downloading SDK: ${BASE_URL}/${ASSET}"
+    curl -fL -o "$ZIP_FILE" "${BASE_URL}/${ASSET}"
+    if [ "$(sha256_of "$ZIP_FILE")" != "$EXPECTED" ]; then
+        echo "ERROR: checksum mismatch for ${ASSET}" >&2
+        rm -f "$ZIP_FILE"
         exit 1
     fi
-    if command -v sha256sum >/dev/null 2>&1; then
-        actual=$(sha256sum "$file" | awk '{print $1}')
-    else
-        actual=$(shasum -a 256 "$file" | awk '{print $1}')
-    fi
-    if [ "$expected" != "$actual" ]; then
-        echo "ERROR: checksum mismatch for ${name}" >&2
-        echo "  expected: ${expected}" >&2
-        echo "  actual:   ${actual}" >&2
-        exit 1
-    fi
-    echo "Checksum OK: ${name}"
-}
-verify_sha256 "$ZIP_FILE" "$ASSET"
+fi
+echo "Checksum OK: ${ASSET}"
 
+# The release archive is a flat tree (libs/, include/, VERSION, …) with no
+# wrapper directory, so extract it straight into ss_player/runtime/.
 echo "Extracting SDK..."
 rm -rf "${TARGET_DIR}/runtime"
-unzip -q -o "$ZIP_FILE" -d "${TARGET_DIR}/"
-rm "$ZIP_FILE" "$SUMS_FILE"
+unzip -q -o "$ZIP_FILE" -d "${TARGET_DIR}/runtime"
 
 echo "$TARGET_VERSION" > "$CURRENT_VERSION_FILE"
 


### PR DESCRIPTION
## Summary

Adapt `scripts/download-sdk` to the SpriteStudio-SDK release archives' new **flat** layout and add a **resume cache** so re-runs don't re-download.

- **Flat:** the release archive is now a flat tree (`libs/`, `include/`, `bindings/`, `VERSION` at the root, no wrapper dir), so extract straight into `ss_player/runtime/`. This maps 1:1 to what `scripts/build-runtime.sh` produces locally.
- **Resume:** cache the zip under `scripts/.sdk-cache/` (gitignored) keyed by its original asset name (matches the `SHA256SUMS` entry). The manifest is fetched on each install-needed run and doubles as the integrity check **and** the cache-validity check — a stale/corrupted cached zip fails the match and is re-downloaded. The zip is no longer deleted after extraction. The version-skip fast path (no network when already up to date) is unchanged.

## Verification

Ran the real `.sh` over `file://` against an archive reconstructed from a QA build, across all four paths: fresh install (extracts flat to `ss_player/runtime/`, VERSION + libs land correctly, no double-nesting), cache reuse (runtime wiped, `.sdk-cache` kept → "Reusing cached", no download), version-skip, and corrupted-cache → re-download.

## Notes

- Depends on the SDK's flat-archive change (cri-middleware/SpriteStudio-SDK#317). Dormant until the first flat release exists; bumping `scripts/SDK_VERSION.txt` to that release is a separate release-time step.
- `download-sdk.ps1` mirrors the `.sh` line-for-line but could not be executed here (no PowerShell on the dev host) — worth a quick Windows check.