### PR TITLE
feat: wire SDK download, notarization, and 4.6+ targets into release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,9 +9,6 @@ on:
         required: true
         type: choice
         options:
-          - "4.3"
-          - "4.4"
-          - "4.5"
           - "4.6"
           - "4.7"
         default: "4.6"
@@ -77,6 +74,18 @@ jobs:
           owner: 'godotengine'
           repository: 'godot-cpp'
 
+      # Fetch the prebuilt SDK runtime (headers + static libs) that the
+      # GDExtension build links against. Requires the SpriteStudio-SDK release
+      # assets to be downloadable from GitHub Releases.
+      - name: Download Prebuilt SDK (ssruntime)
+        if: matrix.platform != 'windows'
+        run: ./scripts/download-sdk.sh
+
+      - name: Download Prebuilt SDK (ssruntime, Windows)
+        if: matrix.platform == 'windows'
+        shell: pwsh
+        run: ./scripts/download-sdk.ps1
+
       - name: setup for gdextension
         uses: ./.github/actions/setup-extension
         with:
@@ -119,17 +128,36 @@ jobs:
 
           rm -f "$CERTIFICATE_PATH"
 
+      # Decode the App Store Connect API key (.p8) used to notarize the macOS
+      # frameworks and expose its path to the macOS build step. No-ops when the
+      # secret is absent. macOS only (iOS is not notarized).
+      - name: Prepare Apple API key
+        if: matrix.platform == 'macos'
+        env:
+          SS_APPLE_API_KEY_BASE64: ${{ secrets.SS_APPLE_API_KEY_BASE64 }}
+        run: |
+          if [ -z "$SS_APPLE_API_KEY_BASE64" ]; then
+            echo "SS_APPLE_API_KEY_BASE64 not set — skipping API key setup (frameworks will not be notarized)."
+            exit 0
+          fi
+          echo "$SS_APPLE_API_KEY_BASE64" | base64 --decode > "$RUNNER_TEMP/apple_api_key.p8"
+          echo "APPLE_API_KEY_PATH=$RUNNER_TEMP/apple_api_key.p8" >> "$GITHUB_ENV"
+
       - name: build Linux
         if: matrix.platform == 'linux'
         run: |
           ./scripts/release-gdextension-linux.sh api_version=${{ env.GODOT_VERSION }}
 
       # release-gdextension-macos.sh signs the frameworks (hardened runtime +
-      # timestamp) when APPLE_SIGNING_IDENTITY is present.
+      # timestamp) when APPLE_SIGNING_IDENTITY is present, and notarizes them
+      # when the APPLE_API_* App Store Connect credentials are also present.
+      # APPLE_API_KEY_PATH is set by the "Prepare Apple API key" step above.
       - name: build macOS
         if: matrix.platform == 'macos'
         env:
           APPLE_SIGNING_IDENTITY: ${{ secrets.SS_APPLE_SIGNING_IDENTITY }}
+          APPLE_API_ISSUER: ${{ secrets.SS_APPLE_API_ISSUER }}
+          APPLE_API_KEY: ${{ secrets.SS_APPLE_API_KEY }}
         run: |
           ./scripts/release-gdextension-macos.sh api_version=${{ env.GODOT_VERSION }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -238,6 +238,12 @@ jobs:
           cd ../output
           zip -r ssplayer-godot-extension-${{ env.GODOT_VERSION }}.zip addons/
 
+          # Canonical checksum manifest so a consumer can verify the downloaded
+          # zip's integrity (`sha256sum -c SHA256SUMS --ignore-missing`). Covers
+          # the zips built by THIS run; a follow-up dispatch for another Godot
+          # version replaces it with one covering only its own zip.
+          sha256sum *.zip > SHA256SUMS
+
       - name: Upload final release package
         uses: actions/upload-artifact@v7
         with:
@@ -246,8 +252,14 @@ jobs:
 
       - name: Create GitHub Release
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
-          files: output/ssplayer-godot-extension-${{ env.GODOT_VERSION }}.zip
-          draft: true
+          files: |
+            output/ssplayer-godot-extension-${{ env.GODOT_VERSION }}.zip
+            output/SHA256SUMS
+          tag_name: ${{ github.ref_name }}
           generate_release_notes: true
+          draft: false
+          # SemVer プレリリース (例: v7.0.0-beta.1) はタグ名に '-' を含むため
+          # 自動的に prerelease 扱いにする。正式版 (v7.1.0) は false。
+          prerelease: ${{ contains(github.ref_name, '-') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -259,7 +259,11 @@ jobs:
             output/SHA256SUMS
           tag_name: ${{ github.ref_name }}
           generate_release_notes: true
-          draft: false
+          # SDK の release.yml と違い、こちらはタグ push で自動起動するため
+          # draft で作成し、内容確認後に手動で Publish する (SDK 側は
+          # upload_release=true を付けた明示的な dispatch 自体が公開ゲート)。
+          draft: true
           # SemVer プレリリース (例: v7.0.0-beta.1) はタグ名に '-' を含むため
           # 自動的に prerelease 扱いにする。正式版 (v7.1.0) は false。
+          # draft 上に設定され、Publish 後もそのまま引き継がれる。
           prerelease: ${{ contains(github.ref_name, '-') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,14 @@ on:
           - "4.7"
         default: "4.6"
         description: "Target Godot API version"
+      upload_release:
+        # タグ push は常にアップロードする。手動実行 (workflow_dispatch) では
+        # 既定でビルドのみ行い、true を指定した場合だけ Release へ添付する
+        # (v* タグの ref 上で実行したときのみ有効)。
+        description: 'Upload to GitHub Release (only effective on a v* tag ref)'
+        required: false
+        default: false
+        type: boolean
 
 env:
   GODOT_VERSION: ${{ inputs.godot_version || '4.6' }}
@@ -20,6 +28,7 @@ env:
   LC_ALL: en_US.UTF-8
   PYTHONIOENCODING: utf8
   KEYCHAIN_PATH: app-signing.keychain-db
+  SCONS_CACHE: ~/.scons_cache
 
 concurrency:
   group: ci-scons-${{ github.actor }}-${{ github.head_ref || github.run_number }}-${{ github.ref }}
@@ -91,6 +100,14 @@ jobs:
         with:
           platform: ${{ matrix.platform }}
           os: ${{ matrix.os }}
+
+      - name: Setup SCons Cache
+        uses: actions/cache@v3
+        with:
+          path: ~/.scons_cache
+          key: ${{ runner.os }}-${{ matrix.platform }}-scons-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.platform }}-scons-
 
       # Import the Developer ID Application certificate into an ephemeral keychain
       # so codesign (run inside the release scripts) can resolve the signing
@@ -250,8 +267,10 @@ jobs:
           name: ssplayer-godot-extension-${{ env.GODOT_VERSION }}-${{ steps.commit.outputs.short }}
           path: output
 
+      # タグ push では常に draft を作成。workflow_dispatch では upload_release=true
+      # を付けた場合のみ (SDK の release.yml と同じゲート)。どちらも v* タグ上に限る。
       - name: Create GitHub Release
-        if: startsWith(github.ref, 'refs/tags/v')
+        if: startsWith(github.ref, 'refs/tags/v') && (github.event_name == 'push' || inputs.upload_release)
         uses: softprops/action-gh-release@v3
         with:
           files: |

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -62,7 +62,13 @@ jobs:
           repository: 'godot-cpp'
 
       - name: Download Prebuilt SDK (ssruntime)
+        if: matrix.platform != 'windows'
         run: ./scripts/download-sdk.sh
+
+      - name: Download Prebuilt SDK (ssruntime, Windows)
+        if: matrix.platform == 'windows'
+        shell: pwsh
+        run: ./scripts/download-sdk.ps1
 
       - name: setup for gdextension
         uses: ./.github/actions/setup-extension

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -10,6 +10,7 @@ env:
   LC_ALL: en_US.UTF-8
   PYTHONIOENCODING: utf8
   KEYCHAIN_PATH: app-signing.keychain-db
+  SCONS_CACHE: ~/.scons_cache
 
 jobs:
   gdextension:
@@ -61,20 +62,72 @@ jobs:
           owner: 'godotengine'
           repository: 'godot-cpp'
 
-      - name: Download Prebuilt SDK (ssruntime)
-        if: matrix.platform != 'windows'
-        run: ./scripts/download-sdk.sh
-
-      - name: Download Prebuilt SDK (ssruntime, Windows)
-        if: matrix.platform == 'windows'
-        shell: pwsh
-        run: ./scripts/download-sdk.ps1
-
       - name: setup for gdextension
         uses: ./.github/actions/setup-extension
         with:
           platform: ${{ matrix.platform }}
           os: ${{ matrix.os }}
+
+      - name: Setup Rust (Stable)
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Setup Rust Cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: "ss_player/SpriteStudio-SDK"
+          key: ${{ matrix.platform }}
+
+      - name: Setup SCons Cache
+        uses: actions/cache@v3
+        with:
+          path: ~/.scons_cache
+          key: ${{ runner.os }}-${{ matrix.platform }}-scons-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.platform }}-scons-
+
+      # weekly は develop HEAD の検証なので、リリース版 SDK (download-sdk) では
+      # なく submodule のソースから runtime をビルドする (pr.yml と同じ方針)。
+      - name: Build Runtime (SDK)
+        if: matrix.platform == 'linux'
+        run: ./scripts/build-runtime.sh platform=linux build=release
+
+      - name: Build Runtime (SDK, macOS universal)
+        if: matrix.platform == 'macos'
+        run: |
+          rustup target add aarch64-apple-darwin
+          rustup target add x86_64-apple-darwin
+          ./scripts/build-runtime.sh platform=macos arch=universal build=release
+
+      - name: Build Runtime (SDK, iOS)
+        if: matrix.platform == 'ios'
+        run: |
+          rustup target add aarch64-apple-ios
+          rustup target add aarch64-apple-ios-sim
+          rustup target add x86_64-apple-ios
+          ./scripts/build-runtime.sh platform=ios build=release
+
+      - name: Build Runtime (SDK, Android)
+        if: matrix.platform == 'android'
+        run: |
+          cargo install cargo-ndk
+          rustup target add aarch64-linux-android
+          rustup target add armv7-linux-androideabi
+          rustup target add x86_64-linux-android
+          ./scripts/build-runtime.sh platform=android build=release
+
+      - name: Build Runtime (SDK, Web)
+        if: matrix.platform == 'web'
+        run: |
+          rustup target add wasm32-unknown-unknown
+          rustup toolchain install nightly
+          rustup target add wasm32-unknown-unknown --toolchain nightly
+          rustup component add rust-src --toolchain nightly
+          ./scripts/build-runtime.sh platform=web build=release
+
+      - name: Build Runtime (SDK, Windows)
+        if: matrix.platform == 'windows'
+        shell: pwsh
+        run: ./scripts/build-runtime.ps1 platform=windows build=release
 
       # Import the Developer ID Application certificate into an ephemeral keychain
       # so codesign (run inside the release scripts) can resolve the signing

--- a/SConstruct
+++ b/SConstruct
@@ -18,6 +18,13 @@ def validate_parent_dir(key, val, env):
 # --- Environment Setup ---
 localEnv = Environment(tools=["default"], PLATFORM="")
 
+# Derived-file cache: share compiled objects across builds/targets when
+# SCONS_CACHE points at a directory (the CI wires it to an actions/cache
+# path). ~ is expanded here because SCons does not do it itself.
+scons_cache = os.environ.get("SCONS_CACHE")
+if scons_cache:
+    CacheDir(os.path.expanduser(scons_cache))
+
 # Import shared source definitions
 sys.path.append(os.path.join(str(Dir("#").abspath), "ss_player"))
 import sources

--- a/scripts/release-gdextension-macos.sh
+++ b/scripts/release-gdextension-macos.sh
@@ -15,12 +15,18 @@ for target in ${targets[@]}; do
 done
 /bin/rm -rf bin/macos/macos.framework
 
-# --- Code signing (opt-in via env) ------------------------------------------
+# --- Code signing & notarization (opt-in via env) ----------------------------
 # Signs the GDExtension frameworks with a Developer ID Application identity when
 # APPLE_SIGNING_IDENTITY is set (maps to the SS_APPLE_SIGNING_IDENTITY secret; the
 # CI sets it in .github/workflows/release.yml). Hardened runtime (--options
-# runtime) + a secure timestamp. Not notarized. No-op (unsigned) when the identity
-# is absent, so local builds without a certificate still succeed.
+# runtime) + a secure timestamp. Notarization of the frameworks additionally
+# needs an App Store Connect API key:
+#   APPLE_API_KEY_PATH — path to the .p8 private key file
+#   APPLE_API_KEY      — the key ID
+#   APPLE_API_ISSUER   — the issuer ID
+# These map to the SS_APPLE_* GitHub secrets — see .github/workflows/release.yml
+# for the CI wiring. No-op (unsigned) when the identity is absent, so local
+# builds without a certificate still succeed.
 if [ -n "${APPLE_SIGNING_IDENTITY:-}" ]; then
     echo "==> Codesigning macOS frameworks as: ${APPLE_SIGNING_IDENTITY}"
     for fw in ${BINDIR}/*.framework(N); do
@@ -28,6 +34,25 @@ if [ -n "${APPLE_SIGNING_IDENTITY:-}" ]; then
             --options runtime --timestamp "${fw}"
         codesign --verify --strict --verbose=2 "${fw}"
     done
+
+    # Notarize the signed frameworks. A framework cannot be stapled (stapling
+    # targets .app/.dmg/.pkg only), so we notarize a zip of the signed
+    # frameworks and rely on Gatekeeper's online ticket check when the Godot
+    # editor first loads the library.
+    if [ -n "${APPLE_API_KEY_PATH:-}" ] && [ -n "${APPLE_API_KEY:-}" ] && [ -n "${APPLE_API_ISSUER:-}" ]; then
+        echo "==> Notarizing macOS frameworks"
+        NOTARIZE_ZIP="${BINDIR}/frameworks.notarize.zip"
+        /bin/rm -f "${NOTARIZE_ZIP}"
+        ( cd "${BINDIR}" && /usr/bin/zip -qry frameworks.notarize.zip *.framework )
+        xcrun notarytool submit "${NOTARIZE_ZIP}" \
+            --key "${APPLE_API_KEY_PATH}" \
+            --key-id "${APPLE_API_KEY}" \
+            --issuer "${APPLE_API_ISSUER}" \
+            --wait
+        /bin/rm -f "${NOTARIZE_ZIP}"
+    else
+        echo "==> Skipping notarization (APPLE_API_KEY_PATH / APPLE_API_KEY / APPLE_API_ISSUER not all set)"
+    fi
 else
     echo "==> Skipping macOS codesign (APPLE_SIGNING_IDENTITY not set)"
 fi


### PR DESCRIPTION
## Summary
- **Godot versions**: drop `4.3` / `4.4` / `4.5` from the `workflow_dispatch` options — `4.6` (default) and `4.7` remain.
- **SDK download**: add the `Download Prebuilt SDK` step (`download-sdk.sh`, `download-sdk.ps1` on Windows via pwsh) before the build, assuming the SpriteStudio-SDK release assets are downloadable from GitHub Releases. Mirrors weekly.yml, but with a correct pwsh split for Windows (weekly.yml runs the .sh under the zsh default there).
- **Signing / notarization** (adapted from SpriteStudio-SDK's `release.yml`):
  - New `Prepare Apple API key` step decodes `SS_APPLE_API_KEY_BASE64` into `$RUNNER_TEMP/apple_api_key.p8` and exports `APPLE_API_KEY_PATH`.
  - The macOS build now receives `SS_APPLE_API_ISSUER` / `SS_APPLE_API_KEY`.
  - `release-gdextension-macos.sh` notarizes the signed frameworks when the `APPLE_API_*` credentials are present — zip + `notarytool submit --wait` + Gatekeeper online ticket check, since frameworks cannot be stapled (same approach as the SDK's CLI notarization). Skips cleanly when credentials are absent, so unsigned local builds keep working.
  - iOS stays signing-only (not notarized), same as the SDK.
- **Release upload** (adapted from SpriteStudio-SDK's packaging):
  - Generate a `SHA256SUMS` manifest over the built zips and upload it alongside the zip.
  - `softprops/action-gh-release@v3` with explicit `tag_name`, created as a **draft** — unlike the SDK (where the explicit `upload_release=true` dispatch is itself the human gate), this workflow fires automatically on tag push, so the manual publish is the release gate.
  - SemVer prereleases (tags containing `-`) are marked `prerelease` automatically.
- **weekly.yml**: apply the same Windows split to its `Download Prebuilt SDK` step — the job's zsh default shell does not exist on windows-latest, so the step could never run there.
- **upload_release input**: like the SDK, `workflow_dispatch` now takes `upload_release` (default false) — manual runs are build-only unless it is set, and a second `godot_version` is attached to the existing draft with `-f upload_release=true` on the tag ref. Tag pushes still always create the draft.
- **weekly.yml builds the SDK from source**: weekly validates develop HEAD (whose submodule pointer may be ahead of the released SDK), so it now builds the runtime from the submodule via `build-runtime.sh` / `.ps1` (pr.yml policy) instead of download-sdk, with per-platform Rust targets mirroring the SDK's release.yml.
- **Build caches**: `SConstruct` now honors `SCONS_CACHE` via `CacheDir()` (the env pr.yml already set was inert without it); weekly gets rust-cache (per-platform key) + scons cache, release.yml gets scons cache.

## Required secrets (same names as SpriteStudio-SDK)
`SS_APPLE_CERTIFICATE`, `SS_APPLE_CERTIFICATE_PASSWORD`, `SS_APPLE_SIGNING_IDENTITY`, `SS_APPLE_API_KEY_BASE64`, `SS_APPLE_API_KEY`, `SS_APPLE_API_ISSUER`

## Verification
- YAML parsed OK; step order: Checkout → clone godot-cpp → Download SDK → setup → keychain → API key → builds.
- `zsh -n scripts/release-gdextension-macos.sh` passes.
- Not exercised end-to-end: CI checkout still fails while the SDK repo is private, and no SDK release assets exist yet for download-sdk to fetch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
