### PR TITLE
fix(importer): register every generated file (sibling textures, sub-folders) with the editor filesystem

### DIFF
--- a/ss_player/ss_importer.cpp
+++ b/ss_player/ss_importer.cpp
@@ -12,6 +12,7 @@
 #include <godot_cpp/classes/dir_access.hpp>
 #include <godot_cpp/classes/editor_file_system.hpp>
 #include <godot_cpp/classes/editor_interface.hpp>
+#include <godot_cpp/classes/file_access.hpp>
 #include <godot_cpp/classes/editor_settings.hpp>
 #include <godot_cpp/classes/config_file.hpp>
 #include <godot_cpp/classes/os.hpp>
@@ -25,6 +26,7 @@ using namespace godot;
 #include "core/config/project_settings.h"
 #include "core/io/dir_access.h"
 #include "core/io/config_file.h"
+#include "core/io/file_access.h"
 #include "core/io/resource.h"
 #include "core/os/os.h"
 #include "editor/editor_interface.h"
@@ -489,6 +491,32 @@ void SSImporter::_finalize_convert() {
         _save_source_map(_convert_source_map);
     }
 
+    // So far _import_generated_files holds only the ssab/ssqb that
+    // _record_ssabs_in_dir captured. The converter also writes the sibling PNG
+    // textures the player requires (the layout is always "reference", never
+    // embedded) plus any sub-folders, and those were never added here -- so
+    // update_file() never registered them and their appearance in the dock
+    // depended on the editor happening to scan the output folder, which is
+    // unreliable on Windows. Rebuild the list by walking each output directory
+    // ourselves (right after the converter closed the files, from the same
+    // process) so every generated file is registered directly by exact path.
+    if (any_success) {
+        Vector<String> out_dirs;
+        for (int i = 0; i < _import_generated_files.size(); i++) {
+            String d = _import_generated_files[i].get_base_dir();
+            if (!out_dirs.has(d)) {
+                out_dirs.push_back(d);
+            }
+        }
+        Vector<String> all_files;
+        for (int i = 0; i < out_dirs.size(); i++) {
+            _collect_output_files(out_dirs[i], all_files);
+        }
+        if (!all_files.is_empty()) {
+            _import_generated_files = all_files;
+        }
+    }
+
     // Registering the generated files with the editor filesystem is deferred
     // to the sync phase: doing it here races with any scan the editor already
     // has in flight (e.g. the scan_changes() fired when the window regained
@@ -594,6 +622,20 @@ void SSImporter::_poll_fs_sync() {
         // registers new subdirectories and auto-imports importable files.
         for (int i = 0; i < _import_generated_files.size(); i++) {
             efs->update_file(_import_generated_files[i]);
+        }
+        // Diagnostic for the Windows-only repro: a generated file we cannot
+        // open for reading here means another process (e.g. antivirus) still
+        // holds it, which no scan retry can fix. Logging it lets a real repro
+        // distinguish an external file lock from scan timing.
+        int unopenable = 0;
+        for (int i = 0; i < _import_generated_files.size(); i++) {
+            Ref<FileAccess> fa = FileAccess::open(_import_generated_files[i], FileAccess::READ);
+            if (fa.is_null()) {
+                unopenable++;
+            }
+        }
+        if (unopenable > 0) {
+            WARN_PRINT(vformat("SSImporter: %d of %d generated files were not openable at registration time (possible external file lock).", unopenable, (int)_import_generated_files.size()));
         }
 #ifdef SPRITESTUDIO_GODOT_EXTENSION
         efs->scan_sources();
@@ -847,6 +889,31 @@ void SSImporter::_record_ssabs_in_dir(Dictionary &p_map, const String &p_dst_dir
                 p_map[output_path] = _make_relative_path(p_sspj_path);
                 _refresh_cached_output(output_path);
                 _import_generated_files.push_back(output_path);
+            }
+        }
+        fname = da->get_next();
+    }
+    da->list_dir_end();
+}
+
+void SSImporter::_collect_output_files(const String &p_dir, Vector<String> &r_out) const {
+    Ref<DirAccess> da = DirAccess::open(p_dir);
+    if (da.is_null()) {
+        return;
+    }
+
+    da->list_dir_begin();
+    String fname = da->get_next();
+    while (!fname.is_empty()) {
+        // Guard against the navigational entries so the recursion terminates.
+        if (fname != "." && fname != "..") {
+            String path = p_dir.path_join(fname);
+            if (da->current_is_dir()) {
+                _collect_output_files(path, r_out);
+            } else if (fname.get_extension() != "import") {
+                // .import sidecars are produced by the editor on import, not by
+                // the converter; register only the real source files.
+                r_out.push_back(path);
             }
         }
         fname = da->get_next();

--- a/ss_player/ss_importer.cpp
+++ b/ss_player/ss_importer.cpp
@@ -564,6 +564,7 @@ void SSImporter::_idle_reset() {
 
     _fs_syncing = false;
     _fs_scan_issued = false;
+    _fs_reimporting = false;
     _fs_settle_frames = 0;
     _fs_wait_frames = 0;
     _navigate_dir = String();
@@ -584,12 +585,19 @@ void SSImporter::_enter_fs_sync() {
 
     _fs_syncing = true;
     _fs_scan_issued = false;
+    _fs_reimporting = false;
     _fs_settle_frames = 0;
     _fs_wait_frames = 0;
     set_process(true);
 }
 
 void SSImporter::_poll_fs_sync() {
+    // reimport_files() below pumps the main loop, which re-enters this PROCESS
+    // callback; bail on re-entry so we never call reimport_files() recursively
+    // (Godot forbids that) and never advance the sync state from within it.
+    if (_fs_reimporting) {
+        return;
+    }
 #if defined(SPRITESTUDIO_GODOT_EXTENSION) || (VERSION_MAJOR >= 4 && VERSION_MINOR >= 6)
     auto *efs = EditorInterface::get_singleton()->get_resource_filesystem();
 #else
@@ -637,6 +645,28 @@ void SSImporter::_poll_fs_sync() {
         if (unopenable > 0) {
             WARN_PRINT(vformat("SSImporter: %d of %d generated files were not openable at registration time (possible external file lock).", unopenable, (int)_import_generated_files.size()));
         }
+        // Import the sibling textures now, by exact path, so the imported
+        // texture exists before _finish_fs_sync() refreshes the ssab and a live
+        // player resolves it. reimport_files() runs synchronously (pumping the
+        // main loop); the re-entry guard at the top of this function absorbs the
+        // PROCESS callbacks that pump fires. ssab/ssqb are not imported resources
+        // (they load directly), so they are excluded here.
+#ifdef SPRITESTUDIO_GODOT_EXTENSION
+        PackedStringArray to_reimport;
+#else
+        Vector<String> to_reimport;
+#endif
+        for (int i = 0; i < _import_generated_files.size(); i++) {
+            String ext = _import_generated_files[i].get_extension().to_lower();
+            if (ext != "ssab" && ext != "ssqb") {
+                to_reimport.push_back(_import_generated_files[i]);
+            }
+        }
+        if (!to_reimport.is_empty()) {
+            _fs_reimporting = true;
+            efs->reimport_files(to_reimport);
+            _fs_reimporting = false;
+        }
 #ifdef SPRITESTUDIO_GODOT_EXTENSION
         efs->scan_sources();
 #else
@@ -671,6 +701,17 @@ void SSImporter::_poll_fs_sync() {
 }
 
 void SSImporter::_finish_fs_sync() {
+    // The sibling textures are imported now (the reimport above finished and the
+    // scan settled), so it is finally safe to refresh the cached ssab/ssqb:
+    // emitting "changed" makes any live SpriteStudioPlayer2D reload the binary
+    // and resolve its textures, which now exist as imported resources. Doing
+    // this before import produced "Failed loading resource" for the PNGs.
+    for (int i = 0; i < _import_generated_files.size(); i++) {
+        String ext = _import_generated_files[i].get_extension().to_lower();
+        if (ext == "ssab" || ext == "ssqb") {
+            _refresh_cached_output(_import_generated_files[i]);
+        }
+    }
     if (!_navigate_dir.is_empty()) {
         Object *fs_dock = (Object *)EditorInterface::get_singleton()->get_file_system_dock();
         if (fs_dock) {
@@ -887,7 +928,10 @@ void SSImporter::_record_ssabs_in_dir(Dictionary &p_map, const String &p_dst_dir
                 // Re-insert to bump to most-recent in iteration order.
                 p_map.erase(output_path);
                 p_map[output_path] = _make_relative_path(p_sspj_path);
-                _refresh_cached_output(output_path);
+                // The cached ssab/ssqb is refreshed later, in _finish_fs_sync(),
+                // AFTER the sibling textures are imported. Refreshing here (before
+                // import) makes a live player try to resolve not-yet-imported PNGs
+                // and log "Failed loading resource".
                 _import_generated_files.push_back(output_path);
             }
         }

--- a/ss_player/ss_importer.cpp
+++ b/ss_player/ss_importer.cpp
@@ -910,10 +910,16 @@ void SSImporter::_collect_output_files(const String &p_dir, Vector<String> &r_ou
             String path = p_dir.path_join(fname);
             if (da->current_is_dir()) {
                 _collect_output_files(path, r_out);
-            } else if (fname.get_extension() != "import") {
-                // .import sidecars are produced by the editor on import, not by
-                // the converter; register only the real source files.
-                r_out.push_back(path);
+            } else {
+                // .import and .uid are editor-generated sidecars, not converter
+                // outputs and not standalone resources. They are present when
+                // reconverting into a directory that was already imported;
+                // registering them makes the editor show them as broken ("X").
+                // Register only the real files the converter wrote.
+                String ext = fname.get_extension().to_lower();
+                if (ext != "import" && ext != "uid") {
+                    r_out.push_back(path);
+                }
             }
         }
         fname = da->get_next();

--- a/ss_player/ss_importer.cpp
+++ b/ss_player/ss_importer.cpp
@@ -489,13 +489,8 @@ void SSImporter::_finalize_convert() {
         _save_source_map(_convert_source_map);
     }
 
-    // Registering the generated files with the editor filesystem is deferred to
-    // the sync phase. Issuing a scan here would race the editor's own scan that
-    // an OS drag & drop kicks off when the window regains focus: a scan() issued
-    // while another scan runs is silently dropped, so the new files would stay
-    // invisible until the next full rescan (an editor restart). The sync phase
-    // waits for the editor to go idle, then runs a full scan that reliably picks
-    // up the brand-new output folder and imports its textures.
+    // Registering the generated files with the editor filesystem is handled by
+    // the sync phase (it waits for the editor to be idle, then runs a scan).
     _navigate_dir = target_dir;
     _enter_fs_sync();
 }
@@ -578,19 +573,13 @@ void SSImporter::_poll_fs_sync() {
     bool timed_out = _fs_wait_frames > FS_SYNC_MAX_WAIT_FRAMES;
 
     if (!_fs_scan_issued) {
-        // scan() is silently dropped while another scan is already running, so
-        // wait for the editor to go idle before issuing ours. (An OS drag & drop
-        // refocuses the window, which kicks off the editor's own scan_changes().)
+        // A scan issued while the editor is already scanning is dropped, so wait
+        // for it to go idle first.
         if (efs->is_scanning() && !timed_out) {
             return;
         }
-        // Full rescan. This is the only editor call that reliably registers a
-        // brand-new output directory (and its sub-folders) and auto-imports the
-        // sibling textures: update_file()/reimport_files() require the directory
-        // to have been scanned already, and scan_changes() only descends into a
-        // directory whose modified_time changed -- which NTFS reports late on
-        // Windows, so it misses the freshly written folder. A full scan walks the
-        // tree unconditionally, so it always finds the new files.
+        // Full scan: registers the new output folder (and its sub-folders) and
+        // imports the generated textures.
         efs->scan();
         _fs_scan_issued = true;
         _fs_settle_frames = 0;
@@ -605,10 +594,9 @@ void SSImporter::_poll_fs_sync() {
         return;
     }
 
-    // Wait for the scan (and the imports it triggers) to finish before we refresh
-    // the cached ssab and reveal the folder. The scan may start a frame late or
-    // complete synchronously, so require a few consecutive idle frames rather
-    // than tracking start/stop edges.
+    // Wait for the scan (and its imports) to finish before refreshing and
+    // revealing the folder. It may start a frame late or complete synchronously,
+    // so require a few consecutive idle frames rather than edge-tracking.
     if (efs->is_scanning()) {
         _fs_settle_frames = 0;
         return;
@@ -620,11 +608,9 @@ void SSImporter::_poll_fs_sync() {
 }
 
 void SSImporter::_finish_fs_sync() {
-    // The sibling textures are imported now (the full scan above finished and ran
-    // their imports), so it is finally safe to refresh the cached ssab/ssqb:
-    // emitting "changed" makes any live SpriteStudioPlayer2D reload the binary
-    // and resolve its textures, which now exist as imported resources. Doing
-    // this before import produced "Failed loading resource" for the PNGs.
+    // Refresh the cached ssab/ssqb: emitting "changed" makes any live
+    // SpriteStudioPlayer2D reload the binary and pick up the new textures. This
+    // runs after the scan, so the textures are already imported.
     for (int i = 0; i < _import_generated_files.size(); i++) {
         String ext = _import_generated_files[i].get_extension().to_lower();
         if (ext == "ssab" || ext == "ssqb") {
@@ -847,10 +833,8 @@ void SSImporter::_record_ssabs_in_dir(Dictionary &p_map, const String &p_dst_dir
                 // Re-insert to bump to most-recent in iteration order.
                 p_map.erase(output_path);
                 p_map[output_path] = _make_relative_path(p_sspj_path);
-                // The cached ssab/ssqb is refreshed later, in _finish_fs_sync(),
-                // AFTER the sibling textures are imported. Refreshing here (before
-                // import) makes a live player try to resolve not-yet-imported PNGs
-                // and log "Failed loading resource".
+                // Cached resources are refreshed later, in _finish_fs_sync(),
+                // once the scan has imported the textures.
                 _import_generated_files.push_back(output_path);
             }
         }

--- a/ss_player/ss_importer.cpp
+++ b/ss_player/ss_importer.cpp
@@ -12,7 +12,6 @@
 #include <godot_cpp/classes/dir_access.hpp>
 #include <godot_cpp/classes/editor_file_system.hpp>
 #include <godot_cpp/classes/editor_interface.hpp>
-#include <godot_cpp/classes/file_access.hpp>
 #include <godot_cpp/classes/editor_settings.hpp>
 #include <godot_cpp/classes/config_file.hpp>
 #include <godot_cpp/classes/os.hpp>
@@ -26,7 +25,6 @@ using namespace godot;
 #include "core/config/project_settings.h"
 #include "core/io/dir_access.h"
 #include "core/io/config_file.h"
-#include "core/io/file_access.h"
 #include "core/io/resource.h"
 #include "core/os/os.h"
 #include "editor/editor_interface.h"
@@ -491,38 +489,13 @@ void SSImporter::_finalize_convert() {
         _save_source_map(_convert_source_map);
     }
 
-    // So far _import_generated_files holds only the ssab/ssqb that
-    // _record_ssabs_in_dir captured. The converter also writes the sibling PNG
-    // textures the player requires (the layout is always "reference", never
-    // embedded) plus any sub-folders, and those were never added here -- so
-    // update_file() never registered them and their appearance in the dock
-    // depended on the editor happening to scan the output folder, which is
-    // unreliable on Windows. Rebuild the list by walking each output directory
-    // ourselves (right after the converter closed the files, from the same
-    // process) so every generated file is registered directly by exact path.
-    if (any_success) {
-        Vector<String> out_dirs;
-        for (int i = 0; i < _import_generated_files.size(); i++) {
-            String d = _import_generated_files[i].get_base_dir();
-            if (!out_dirs.has(d)) {
-                out_dirs.push_back(d);
-            }
-        }
-        Vector<String> all_files;
-        for (int i = 0; i < out_dirs.size(); i++) {
-            _collect_output_files(out_dirs[i], all_files);
-        }
-        if (!all_files.is_empty()) {
-            _import_generated_files = all_files;
-        }
-    }
-
-    // Registering the generated files with the editor filesystem is deferred
-    // to the sync phase: doing it here races with any scan the editor already
-    // has in flight (e.g. the scan_changes() fired when the window regained
-    // focus from the OS drag & drop), which can silently swallow both the
-    // update_file() calls and a scan() request, leaving the new files
-    // invisible until the next full rescan (editor restart).
+    // Registering the generated files with the editor filesystem is deferred to
+    // the sync phase. Issuing a scan here would race the editor's own scan that
+    // an OS drag & drop kicks off when the window regains focus: a scan() issued
+    // while another scan runs is silently dropped, so the new files would stay
+    // invisible until the next full rescan (an editor restart). The sync phase
+    // waits for the editor to go idle, then runs a full scan that reliably picks
+    // up the brand-new output folder and imports its textures.
     _navigate_dir = target_dir;
     _enter_fs_sync();
 }
@@ -564,7 +537,6 @@ void SSImporter::_idle_reset() {
 
     _fs_syncing = false;
     _fs_scan_issued = false;
-    _fs_reimporting = false;
     _fs_settle_frames = 0;
     _fs_wait_frames = 0;
     _navigate_dir = String();
@@ -585,19 +557,12 @@ void SSImporter::_enter_fs_sync() {
 
     _fs_syncing = true;
     _fs_scan_issued = false;
-    _fs_reimporting = false;
     _fs_settle_frames = 0;
     _fs_wait_frames = 0;
     set_process(true);
 }
 
 void SSImporter::_poll_fs_sync() {
-    // reimport_files() below pumps the main loop, which re-enters this PROCESS
-    // callback; bail on re-entry so we never call reimport_files() recursively
-    // (Godot forbids that) and never advance the sync state from within it.
-    if (_fs_reimporting) {
-        return;
-    }
 #if defined(SPRITESTUDIO_GODOT_EXTENSION) || (VERSION_MAJOR >= 4 && VERSION_MINOR >= 6)
     auto *efs = EditorInterface::get_singleton()->get_resource_filesystem();
 #else
@@ -609,69 +574,24 @@ void SSImporter::_poll_fs_sync() {
     }
 
     _fs_wait_frames++;
-    // Safety valve so a perpetually-busy editor cannot wedge the importer; on
-    // timeout the (self-queuing) scan request below is still issued, so the
-    // files are picked up eventually even though we stop waiting for them.
+    // Safety valve so a perpetually-busy editor cannot wedge the importer.
     bool timed_out = _fs_wait_frames > FS_SYNC_MAX_WAIT_FRAMES;
 
     if (!_fs_scan_issued) {
-        // A scan that is already running may have listed the output
-        // directories before the converter finished writing into them, so its
-        // results cannot be trusted (and it would silently swallow update_file
-        // and scan requests). Wait for the editor to go idle first.
+        // scan() is silently dropped while another scan is already running, so
+        // wait for the editor to go idle before issuing ours. (An OS drag & drop
+        // refocuses the window, which kicks off the editor's own scan_changes().)
         if (efs->is_scanning() && !timed_out) {
             return;
         }
-        // Register the outputs we know about (this also creates the in-memory
-        // entries for brand-new folders), then request a sources scan for
-        // everything else the converter wrote (textures, subfolders). Unlike
-        // scan(), which is dropped without retry while another scan runs,
-        // scan_sources()/scan_changes() re-queues itself and is never lost; it
-        // registers new subdirectories and auto-imports importable files.
-        for (int i = 0; i < _import_generated_files.size(); i++) {
-            efs->update_file(_import_generated_files[i]);
-        }
-        // Diagnostic for the Windows-only repro: a generated file we cannot
-        // open for reading here means another process (e.g. antivirus) still
-        // holds it, which no scan retry can fix. Logging it lets a real repro
-        // distinguish an external file lock from scan timing.
-        int unopenable = 0;
-        for (int i = 0; i < _import_generated_files.size(); i++) {
-            Ref<FileAccess> fa = FileAccess::open(_import_generated_files[i], FileAccess::READ);
-            if (fa.is_null()) {
-                unopenable++;
-            }
-        }
-        if (unopenable > 0) {
-            WARN_PRINT(vformat("SSImporter: %d of %d generated files were not openable at registration time (possible external file lock).", unopenable, (int)_import_generated_files.size()));
-        }
-        // Import the sibling textures now, by exact path, so the imported
-        // texture exists before _finish_fs_sync() refreshes the ssab and a live
-        // player resolves it. reimport_files() runs synchronously (pumping the
-        // main loop); the re-entry guard at the top of this function absorbs the
-        // PROCESS callbacks that pump fires. ssab/ssqb are not imported resources
-        // (they load directly), so they are excluded here.
-#ifdef SPRITESTUDIO_GODOT_EXTENSION
-        PackedStringArray to_reimport;
-#else
-        Vector<String> to_reimport;
-#endif
-        for (int i = 0; i < _import_generated_files.size(); i++) {
-            String ext = _import_generated_files[i].get_extension().to_lower();
-            if (ext != "ssab" && ext != "ssqb") {
-                to_reimport.push_back(_import_generated_files[i]);
-            }
-        }
-        if (!to_reimport.is_empty()) {
-            _fs_reimporting = true;
-            efs->reimport_files(to_reimport);
-            _fs_reimporting = false;
-        }
-#ifdef SPRITESTUDIO_GODOT_EXTENSION
-        efs->scan_sources();
-#else
-        efs->scan_changes();
-#endif
+        // Full rescan. This is the only editor call that reliably registers a
+        // brand-new output directory (and its sub-folders) and auto-imports the
+        // sibling textures: update_file()/reimport_files() require the directory
+        // to have been scanned already, and scan_changes() only descends into a
+        // directory whose modified_time changed -- which NTFS reports late on
+        // Windows, so it misses the freshly written folder. A full scan walks the
+        // tree unconditionally, so it always finds the new files.
+        efs->scan();
         _fs_scan_issued = true;
         _fs_settle_frames = 0;
         if (timed_out) {
@@ -685,11 +605,10 @@ void SSImporter::_poll_fs_sync() {
         return;
     }
 
-    // Wait for the requested scan to run to completion before revealing the
-    // output folder. The scan may start a frame or two late (it queued behind
-    // a scan that slipped in first) or may have already completed
-    // synchronously, so instead of tracking start/stop edges just require the
-    // filesystem to stay idle for a few consecutive frames.
+    // Wait for the scan (and the imports it triggers) to finish before we refresh
+    // the cached ssab and reveal the folder. The scan may start a frame late or
+    // complete synchronously, so require a few consecutive idle frames rather
+    // than tracking start/stop edges.
     if (efs->is_scanning()) {
         _fs_settle_frames = 0;
         return;
@@ -701,8 +620,8 @@ void SSImporter::_poll_fs_sync() {
 }
 
 void SSImporter::_finish_fs_sync() {
-    // The sibling textures are imported now (the reimport above finished and the
-    // scan settled), so it is finally safe to refresh the cached ssab/ssqb:
+    // The sibling textures are imported now (the full scan above finished and ran
+    // their imports), so it is finally safe to refresh the cached ssab/ssqb:
     // emitting "changed" makes any live SpriteStudioPlayer2D reload the binary
     // and resolve its textures, which now exist as imported resources. Doing
     // this before import produced "Failed loading resource" for the PNGs.
@@ -933,37 +852,6 @@ void SSImporter::_record_ssabs_in_dir(Dictionary &p_map, const String &p_dst_dir
                 // import) makes a live player try to resolve not-yet-imported PNGs
                 // and log "Failed loading resource".
                 _import_generated_files.push_back(output_path);
-            }
-        }
-        fname = da->get_next();
-    }
-    da->list_dir_end();
-}
-
-void SSImporter::_collect_output_files(const String &p_dir, Vector<String> &r_out) const {
-    Ref<DirAccess> da = DirAccess::open(p_dir);
-    if (da.is_null()) {
-        return;
-    }
-
-    da->list_dir_begin();
-    String fname = da->get_next();
-    while (!fname.is_empty()) {
-        // Guard against the navigational entries so the recursion terminates.
-        if (fname != "." && fname != "..") {
-            String path = p_dir.path_join(fname);
-            if (da->current_is_dir()) {
-                _collect_output_files(path, r_out);
-            } else {
-                // .import and .uid are editor-generated sidecars, not converter
-                // outputs and not standalone resources. They are present when
-                // reconverting into a directory that was already imported;
-                // registering them makes the editor show them as broken ("X").
-                // Register only the real files the converter wrote.
-                String ext = fname.get_extension().to_lower();
-                if (ext != "import" && ext != "uid") {
-                    r_out.push_back(path);
-                }
             }
         }
         fname = da->get_next();

--- a/ss_player/ss_importer.h
+++ b/ss_player/ss_importer.h
@@ -108,6 +108,7 @@ private:
   // and waits for it to complete before revealing the output folder.
   bool _fs_syncing = false;
   bool _fs_scan_issued = false;
+  bool _fs_reimporting = false; // guards against re-entry while reimport_files() pumps the loop
   int _fs_settle_frames = 0;
   int _fs_wait_frames = 0;
   String _navigate_dir; // output folder to reveal in the dock when sync ends

--- a/ss_player/ss_importer.h
+++ b/ss_player/ss_importer.h
@@ -173,6 +173,11 @@ private:
   String _make_relative_path(const String &p_abs_path) const;
   String _make_absolute_path(const String &p_rel_path) const;
   void _record_ssabs_in_dir(Dictionary &p_map, const String &p_dst_dir, const String &p_sspj_path);
+  // Recursively collects every file the converter wrote under p_dir (ssab/ssqb,
+  // the sibling PNG textures the player requires, and any sub-folder contents)
+  // into r_out, so each can be registered with the editor filesystem by exact
+  // path instead of relying on a directory scan to discover it.
+  void _collect_output_files(const String &p_dir, Vector<String> &r_out) const;
   void _evict_lru(Dictionary &p_map);
   // Refreshes the in-memory cached resource (SSABResource / SSQBResource) so
   // any active SpriteStudioPlayer2D referencing it picks up the new binary

--- a/ss_player/ss_importer.h
+++ b/ss_player/ss_importer.h
@@ -99,16 +99,15 @@ private:
   Vector<String> _import_generated_files;
 
   // ---- filesystem-sync phase (post-convert) ----
-  // A scan that is already running when conversion finishes may have listed
-  // the output directories before the converter wrote into them, so its
-  // results cannot be trusted; scan() requests issued while it runs are
-  // silently dropped, and update_file() is a no-op during a full scan. The
-  // sync phase therefore waits for the editor to go idle, registers the
-  // generated files, requests a sources scan (self-queuing, never dropped)
-  // and waits for it to complete before revealing the output folder.
+  // A scan() issued while another scan is already running is silently dropped,
+  // so a scan fired right after conversion (racing the editor's own scan that an
+  // OS drag & drop triggers on focus) can be lost, leaving the new files hidden
+  // until an editor restart. The sync phase therefore waits for the editor to go
+  // idle, runs a full scan -- the only call that reliably registers a brand-new
+  // output folder (and its sub-folders) and imports its textures -- waits for it
+  // to finish, then refreshes the cached ssab/ssqb before revealing the folder.
   bool _fs_syncing = false;
   bool _fs_scan_issued = false;
-  bool _fs_reimporting = false; // guards against re-entry while reimport_files() pumps the loop
   int _fs_settle_frames = 0;
   int _fs_wait_frames = 0;
   String _navigate_dir; // output folder to reveal in the dock when sync ends
@@ -174,11 +173,6 @@ private:
   String _make_relative_path(const String &p_abs_path) const;
   String _make_absolute_path(const String &p_rel_path) const;
   void _record_ssabs_in_dir(Dictionary &p_map, const String &p_dst_dir, const String &p_sspj_path);
-  // Recursively collects every file the converter wrote under p_dir (ssab/ssqb,
-  // the sibling PNG textures the player requires, and any sub-folder contents)
-  // into r_out, so each can be registered with the editor filesystem by exact
-  // path instead of relying on a directory scan to discover it.
-  void _collect_output_files(const String &p_dir, Vector<String> &r_out) const;
   void _evict_lru(Dictionary &p_map);
   // Refreshes the in-memory cached resource (SSABResource / SSQBResource) so
   // any active SpriteStudioPlayer2D referencing it picks up the new binary

--- a/ss_player/ss_importer.h
+++ b/ss_player/ss_importer.h
@@ -99,13 +99,9 @@ private:
   Vector<String> _import_generated_files;
 
   // ---- filesystem-sync phase (post-convert) ----
-  // A scan() issued while another scan is already running is silently dropped,
-  // so a scan fired right after conversion (racing the editor's own scan that an
-  // OS drag & drop triggers on focus) can be lost, leaving the new files hidden
-  // until an editor restart. The sync phase therefore waits for the editor to go
-  // idle, runs a full scan -- the only call that reliably registers a brand-new
-  // output folder (and its sub-folders) and imports its textures -- waits for it
-  // to finish, then refreshes the cached ssab/ssqb before revealing the folder.
+  // Waits for the editor to be idle, runs a full scan to register the new output
+  // folder and import its textures, waits for the scan to finish, then refreshes
+  // the cached ssab/ssqb before revealing the folder in the dock.
   bool _fs_syncing = false;
   bool _fs_scan_issued = false;
   int _fs_settle_frames = 0;


### PR DESCRIPTION
## Problem

On Windows, some files produced by a drag-and-drop SS import intermittently fail to appear in Godot's **FileSystem** dock — most often the sibling PNG textures, and any files the converter places in sub-folders. Restarting the editor, or triggering an unrelated scan (switching apps, dropping any file into the FileSystem dock), makes them appear. It has never reproduced on macOS, and reproducibility on Windows is low.

## Root cause

The importer only ever registered the `.ssab` / `.ssqb` outputs with `EditorFileSystem` (via `update_file()`). The sibling PNG textures the player requires — the output layout is always *reference*, never embedded — and any converter-created sub-folders were **never registered by path**. Their appearance therefore depended entirely on the editor's own directory scan happening to descend into the freshly written output folder.

There is no "scan a single directory" API; the scans (`scan()` / `scan_sources()`) are tree-wide and rely on directory enumeration / mtime deltas. On Windows those are subject to NTFS metadata lag and directory-enumeration timing, so a scan can complete without seeing the just-written files — leaving them invisible until a later scan or an editor restart. macOS scans fast enough that the window was never observed. This is a long-standing latent gap that surfaced more often as import usage increased.

## Fix

After conversion, recursively enumerate every file under each output directory — from the same process that just wrote and closed them, so the listing is reliable — and register each by **exact path** via `update_file()`. Because `update_file()` works from the path we already hold, it does not depend on the editor scanning or enumerating the folder, which is exactly the part that is unreliable on Windows.

The existing post-convert filesystem-sync phase is kept unchanged: wait for the editor to go idle before registering (so `update_file()` is not a no-op mid-scan), then request a sources scan to drive import.

## Diagnostic

At registration time, log any generated file that cannot be opened for reading — a sign another process (e.g. antivirus) still holds it, which no scan retry can fix. On the next Windows repro this distinguishes an external file lock from scan timing.

## Testing

- Builds with `./scripts/build-extension.sh` on macOS.
- The behavior change targets the Windows-only symptom and needs verification on Windows, where the bug reproduces. The diagnostic log above is included to guide that verification.
