### PR TITLE
ci(assetlib): Godot Asset Library への公開ワークフロー追加

### DIFF
--- a/.github/workflows/assetlib.yml
+++ b/.github/workflows/assetlib.yml
@@ -1,0 +1,113 @@
+name: publish to godot asset library
+# 再利用可能ワークフロー。release.yml から submit:true で呼ばれるか、単体
+# dispatch (既定 submit:false=ドライラン) で使う。GitHub Releases に上がった
+# GDExtension zip を、既存アセットへ「編集」として提出する。提出後は Asset
+# Library のモデレーション承認待ちで、自動公開はされない。
+# 初回のアセット登録は GUI で行い、採番された asset_id を
+# vars.GODOT_ASSETLIB_ASSET_ID に設定しておくこと。
+on:
+  workflow_call:
+    inputs:
+      tag:
+        required: true
+        type: string
+      api_version:
+        required: false
+        type: string
+        default: "4.6"
+      submit:
+        required: false
+        type: boolean
+        default: false
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag (例: v7.0.0)'
+        required: true
+        type: string
+      api_version:
+        description: '指す zip の Godot API 版'
+        required: true
+        type: choice
+        options:
+          - "4.6"
+          - "4.7"
+        default: "4.6"
+      submit:
+        description: 'true で実提出 / false はドライラン (zip 存在チェックのみ)'
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+jobs:
+  submit:
+    runs-on: ubuntu-latest
+    env:
+      ASSETLIB_API: https://godotengine.org/asset-library/api
+      REPO_URL: https://github.com/${{ github.repository }}
+      TAG: ${{ inputs.tag }}
+      API_VERSION: ${{ inputs.api_version }}
+      ASSET_ID: ${{ vars.GODOT_ASSETLIB_ASSET_ID }}
+
+    steps:
+      - name: Resolve & verify download URL
+        id: url
+        run: |
+          DL="$REPO_URL/releases/download/$TAG/ssplayer-godot-extension-$API_VERSION.zip"
+          echo "url=$DL" >> "$GITHUB_OUTPUT"
+          echo "Asset zip: $DL"
+          # Release アセットの伝播ラグを考慮して数回リトライ。
+          for i in 1 2 3 4 5; do
+            if curl -sSfIL -o /dev/null "$DL"; then ok=1; break; fi
+            echo "  not ready yet ($i/5)…"; sleep 5
+          done
+          [ "${ok:-}" = 1 ] || { echo "::error::zip が見つかりません: $DL"; exit 1; }
+
+      - name: Dry run (submit=false)
+        if: ${{ !inputs.submit }}
+        run: |
+          echo "submit=false: 提出はスキップ (ドライラン)"
+          echo "  asset_id=$ASSET_ID  version=${TAG#v}  godot=$API_VERSION"
+          echo "  download_url=${{ steps.url.outputs.url }}"
+
+      - name: Submit edit to Asset Library
+        if: ${{ inputs.submit }}
+        env:
+          USERNAME: ${{ secrets.GODOT_ASSETLIB_USERNAME }}
+          PASSWORD: ${{ secrets.GODOT_ASSETLIB_PASSWORD }}
+          DL: ${{ steps.url.outputs.url }}
+        run: |
+          set -euo pipefail
+          [ -n "$ASSET_ID" ] || { echo "::error::vars.GODOT_ASSETLIB_ASSET_ID が未設定"; exit 1; }
+
+          # 1) login → 短命トークンを取得。
+          token=$(curl -sSf -X POST "$ASSETLIB_API/login" \
+            -H 'Content-Type: application/json' \
+            -d "$(jq -n --arg u "$USERNAME" --arg p "$PASSWORD" '{username:$u,password:$p}')" \
+            | jq -er '.token')
+          echo "::add-mask::$token"
+          logout() {
+            curl -sS -X POST "$ASSETLIB_API/logout" -H 'Content-Type: application/json' \
+              -d "$(jq -n --arg t "$token" '{token:$t}')" >/dev/null || true
+          }
+          trap logout EXIT   # 失敗時も必ず logout してトークンを無効化。
+
+          # 2) 編集を提出。edit は変更フィールドのみで足りるため、初回 GUI 登録で
+          #    設定済みの title/description/category_id/cost/icon_url には触れない。
+          payload=$(jq -n \
+            --arg token   "$token" \
+            --arg version "${TAG#v}" \
+            --arg gv      "$API_VERSION" \
+            --arg commit  "$TAG" \
+            --arg dl      "$DL" \
+            --arg browse  "$REPO_URL" \
+            --arg issues  "$REPO_URL/issues" \
+            '{token:$token, version_string:$version, godot_version:$gv,
+              download_provider:"Custom", download_commit:$commit,
+              download_url:$dl, browse_url:$browse, issues_url:$issues}')
+          resp=$(curl -sSf -X POST "$ASSETLIB_API/asset/$ASSET_ID" \
+            -H 'Content-Type: application/json' -d "$payload")
+          echo "提出完了: edit #$(echo "$resp" | jq -er '.id') — モデレーション承認待ち"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -284,3 +284,19 @@ jobs:
           # 自動的に prerelease 扱いにする。正式版 (v7.1.0) は false。
           # draft 上に設定され、Publish 後もそのまま引き継がれる。
           prerelease: ${{ contains(github.ref_name, '-') }}
+
+  # Release 公開後、Godot Asset Library の既存アセットへ 4.6 zip を指す編集を
+  # 提出する (承認は人手)。upload_release=true の v* タグで 4.6 ビルドのときだけ。
+  # 提出ロジックは再利用可能ワークフロー assetlib.yml に委譲。
+  publish-assetlib:
+    needs: package
+    if: >-
+      startsWith(github.ref, 'refs/tags/v') &&
+      inputs.upload_release &&
+      inputs.godot_version == '4.6'
+    uses: ./.github/workflows/assetlib.yml
+    with:
+      tag: ${{ github.ref_name }}
+      api_version: "4.6"
+      submit: true
+    secrets: inherit


### PR DESCRIPTION
## 概要

GitHub Releases に上がった GDExtension zip を **Godot Asset Library** の既存アセットへ「編集」として提出するワークフローを追加します。提出後は Asset Library の**モデレーション承認待ち**で、自動公開はされません。

## 変更点

- **新規 `.github/workflows/assetlib.yml`**(再利用可能ワークフロー)
  - トリガー: `workflow_call`(release.yml から) + `workflow_dispatch`(単体)
  - 入力: `tag` / `api_version`(既定 `4.6`) / `submit`(既定 `false`=ドライラン)
  - 動作: Release zip の存在確認(リトライ付) → `submit=true` のときのみ `login` → `POST /asset/{id}` で編集提出 → `trap` で必ず `logout`
  - `download_provider: Custom`、`download_url` は `.../releases/download/<tag>/ssplayer-godot-extension-4.6.zip`(ビルド済みバイナリは git に無いため Release zip を直接指す)
  - edit は変更フィールドのみ送信し、初回 GUI 登録済みの title/description/category/cost/icon は維持
- **`.github/workflows/release.yml`** に `publish-assetlib` ジョブ追加
  - `needs: package` / `uses: ./.github/workflows/assetlib.yml` / `secrets: inherit`
  - ゲート: `v*` タグ ∧ `upload_release=true` ∧ `godot_version == '4.6'` → `submit: true`

## マージ前に必要な運用準備

1. **初回アセット登録は GUI**(Download provider=Custom / 4.6 zip / BSD-3-Clause / PNG アイコン)→ 承認後に `asset_id` を控える
2. **Secrets / Variables 登録**
   - `secrets.GODOT_ASSETLIB_USERNAME`
   - `secrets.GODOT_ASSETLIB_PASSWORD`
   - `vars.GODOT_ASSETLIB_ASSET_ID`
3. マージ後、`assetlib.yml` を単体 dispatch(`submit=false`)でドライラン確認

## 補足

- Asset Library API には API キー/PAT が無く、アカウントの username+password を短命トークンに交換する方式。公開用の**専用アカウント**推奨。
- 4.7 を dispatch した場合は Release に 4.7 zip は上がるが Asset Library は触らない(`godot_version == '4.6'` ゲート)。