### PR TITLE
build: install AccessKit/ANGLE deps and fix build script arguments

### DIFF
--- a/.github/actions/setup-godot/action.yml
+++ b/.github/actions/setup-godot/action.yml
@@ -27,16 +27,7 @@ runs:
       run: python ./godot/misc/scripts/install_d3d12_sdk_windows.py
       if: inputs.platform == 'windows'
 
-    - name: Download pre-built ANGLE static libraries
-      uses: dsaltares/fetch-gh-release-asset@1.1.2
-      with:
-        repo: godotengine/godot-angle-static
-        version: tags/chromium/6601.2
-        file: godot-angle-static-x86_64-msvc-release.zip
-        target: angle/angle.zip
-      if: inputs.platform == 'windows'
-
-    - name: Extract pre-built ANGLE static libraries
-      shell: pwsh
-      run: Expand-Archive -Force angle/angle.zip ${{github.workspace}}/
-      if: inputs.platform == 'windows'
+    # AccessKit (screen reader) and ANGLE (OpenGL ES) are installed by
+    # scripts/build.sh / build.ps1 (`deps=yes`, the default) using the
+    # installers from the Godot checkout, so their versions always match the
+    # engine revision being built. Nothing to pin here.

--- a/docs/en/setup/build.md
+++ b/docs/en/setup/build.md
@@ -36,6 +36,18 @@ For build tools (compiler, Python, SCons, etc.) on each platform, follow the off
 
 ### Notes
 
+#### Godot third-party build dependencies (AccessKit / ANGLE)
+
+Godot 4.7 links two prebuilt SDKs that are not part of the engine source tree: **AccessKit** (screen reader support) and **ANGLE** (the OpenGL ES rendering driver). If they are missing, `scons` prints a warning and silently disables those drivers, producing binaries that lack features the official Godot builds ship with.
+
+`build.sh` / `build.ps1` download them on the first desktop build (using the installers in the `godot/` checkout, so the versions always match the engine revision) into `godot/bin/build_deps/` — or `%LOCALAPPDATA%\Godot\build_deps` on Windows. Pass `deps=no` to skip the download and build without those drivers:
+
+```sh
+./scripts/build.sh deps=no
+```
+
+The mobile and web platforms do not use either dependency, so nothing is downloaded for them.
+
 #### Building Universal Binaries on macOS
 
 The `molten-vk` package distributed via Homebrew only provides binaries for the host architecture, so linking fails when building with `arch=universal`. Install the universal-capable [Vulkan SDK for MoltenVK](https://vulkan.lunarg.com/sdk/home) instead.

--- a/docs/ja/setup/build.md
+++ b/docs/ja/setup/build.md
@@ -36,6 +36,18 @@ git clone https://github.com/godotengine/godot-cpp.git -b master
 
 ### 注意点
 
+#### Godot のサードパーティビルド依存 (AccessKit / ANGLE)
+
+Godot 4.7 は、エンジンのソースツリーに含まれない 2 つのビルド済み SDK をリンクします。**AccessKit** (スクリーンリーダー対応) と **ANGLE** (OpenGL ES レンダリングドライバ) です。これらが無い場合、`scons` は警告を出したうえで該当ドライバを無効化してビルドを続行するため、公式 Godot ビルドにある機能を欠いたバイナリができあがります。
+
+`build.sh` / `build.ps1` は、デスクトップ向けの初回ビルド時にこれらを `godot/bin/build_deps/` (Windows では `%LOCALAPPDATA%\Godot\build_deps`) へ自動でダウンロードします。インストーラは `godot/` チェックアウト内のものを使うため、依存のバージョンはビルド対象のエンジンリビジョンと常に一致します。ダウンロードを行わず、該当ドライバ無しでビルドしたい場合は `deps=no` を指定してください。
+
+```sh
+./scripts/build.sh deps=no
+```
+
+モバイル / Web プラットフォームはどちらの依存も使わないため、ダウンロードは行われません。
+
 #### macOS で Universal Binary をビルドする場合
 
 Homebrew で配布されている `molten-vk` はホストアーキ向けのバイナリのみ提供されるため、`arch=universal` 指定で Universal Binary をビルドする際はリンクに失敗します。代わりに [Vulkan SDK for MoltenVK](https://vulkan.lunarg.com/sdk/home) (Universal 対応版) をインストールしてください。

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -38,6 +38,8 @@ $winbuild_default_opts = @{
     cpus = $cpus
     ccache = "no"
     version = "4.7"
+    strip = "no"
+    deps = "yes"
 }
 
 $opts = @{}
@@ -53,6 +55,8 @@ function usage() {
     echo "  cpus=<nums>         number of scons -j option (default: $cpus)"
     # echo "  ccache=<yes|no>     Enable ccache (default: $($winbuild_default_opts.ccache))"
     echo "  version=<version>   Godot version. $APP uses this version at can not getting Godot version from git branch or tag. (default: $($winbuild_default_opts.version))"
+    echo "  strip=<yes|no>      Accepted for parity with build.sh; MSVC keeps debug info in a separate .pdb, so nothing is stripped (default: $($winbuild_default_opts.strip))"
+    echo "  deps=<yes|no>       Install the missing Godot third-party build dependencies (AccessKit / ANGLE) before building (default: $($winbuild_default_opts.deps))"
     echo "Godot scons options: "
     pushd $rootDirectory/godot
     scons --help
@@ -97,7 +101,7 @@ if (![string]::IsNullOrEmpty($GODOT_BRANCH)) {
 echo "Godot Version: ${VERSION}"
 
 # validate scons command options from winbuild options
-$scons_command_opts = "platform=$($internal_opts.platform)"
+$scons_command_opts = ""
 foreach ($key in $opts.Keys) {
     if ($winbuild_default_opts.ContainsKey($key)) {
         # skip winbuild default options
@@ -106,10 +110,45 @@ foreach ($key in $opts.Keys) {
     $scons_command_opts += " $key=$($opts[$key])"
 }
 $j = $opts["cpus"]
-$scons_command_opts += "$scons_command_opts -j $j"
-
+$scons_command_opts += " -j $j"
 
 echo "scons command options: $scons_command_opts"
+
+# Godot 4.6+ links two prebuilt third-party SDKs that are not part of the engine
+# source tree: AccessKit (screen reader support) and ANGLE (OpenGL ES driver).
+# Without them scons silently disables those drivers, so the produced editor and
+# templates would lack features the official builds ship with. The installers
+# come from the Godot checkout itself, which keeps the dependency versions in
+# sync with the engine revision being built.
+function install_godot_deps() {
+    # Mirrors the destination logic of godot/misc/scripts/install_*.py.
+    if ($env:LOCALAPPDATA -and -not $env:MSYSTEM) {
+        $deps_dir = Join-Path (Join-Path $env:LOCALAPPDATA "Godot") "build_deps"
+    } else {
+        $deps_dir = Join-Path (Join-Path (Join-Path $rootDirectory "godot") "bin") "build_deps"
+    }
+
+    # install_angle.py unpacks one directory per arch (angle-<arch>-<abi>).
+    $angle_dirs = @(Get-ChildItem -Path $deps_dir -Directory -Filter "angle*" -ErrorAction SilentlyContinue)
+
+    # The installers resolve their destination relative to the working directory.
+    pushd $rootDirectory/godot
+    if (-not (Test-Path (Join-Path $deps_dir "accesskit"))) {
+        echo "Installing AccessKit into $deps_dir ..."
+        python misc/scripts/install_accesskit.py
+    }
+    if ($angle_dirs.Count -eq 0) {
+        echo "Installing ANGLE into $deps_dir ..."
+        python misc/scripts/install_angle.py
+    }
+    popd
+}
+
+# AccessKit and ANGLE only apply to the desktop platforms; the mobile and web
+# platforms have no such dependency, so skip the download there.
+if ($opts.deps -eq "yes" -and @("windows", "win") -contains $opts.platform) {
+    install_godot_deps
+}
 
 pushd $rootDirectory/godot
 Invoke-Expression "scons $scons_command_opts"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -39,6 +39,7 @@ declare -A build_default_opts=(
     [ccache]="no"
     [version]="4.7"
     [strip]="no"
+    [deps]="yes"
 )
 
 declare -A opts=(
@@ -57,6 +58,7 @@ func usage() {
     echo "  ccache=<yes|no>     Enable ccache (default: ${build_default_opts[ccache]})"
     echo "  version=<version>   Godot version. $APP uses this version at can not getting Godot version from git branch or tag. (default: ${build_default_opts[version]})"
     echo "  strip=<yes|no>      Execute strip command to the app binary (default: ${build_default_opts[strip]})"
+    echo "  deps=<yes|no>       Install the missing Godot third-party build dependencies (AccessKit / ANGLE) before building (default: ${build_default_opts[deps]})"
     echo "Godot scons options: "
     pushd $ROOTDIR/godot > /dev/null
     scons --help
@@ -145,9 +147,56 @@ for key value in ${(kv)opts}; do
     fi
     scons_command_opts="$scons_command_opts $key=$value"
 done
-scons_command_opts="$scons_command_opts -j $build_default_opts[cpus]"
+scons_command_opts="$scons_command_opts -j ${opts[cpus]}"
 
 echo "scons command options: $scons_command_opts"
+
+# Godot 4.6+ links two prebuilt third-party SDKs that are not part of the engine
+# source tree: AccessKit (screen reader support) and ANGLE (OpenGL ES driver).
+# Without them scons silently disables those drivers, so the produced editor and
+# templates would lack features the official builds ship with. The installers
+# come from the Godot checkout itself, which keeps the dependency versions in
+# sync with the engine revision being built.
+func install_godot_deps() {
+    # Mirrors the destination logic of godot/misc/scripts/install_*.py.
+    local deps_dir
+    if [[ -n ${LOCALAPPDATA} && -z ${MSYSTEM} ]]; then
+        deps_dir="${LOCALAPPDATA}/Godot/build_deps"
+    else
+        deps_dir="${ROOTDIR}/godot/bin/build_deps"
+    fi
+
+    # install_angle.py unpacks one directory per arch (angle-<arch>-<abi>).
+    local angle_dirs=(${deps_dir}/angle*(N))
+
+    local python_bin="python3"
+    if ! type python3 > /dev/null 2>&1; then
+        python_bin="python"
+    fi
+
+    # The installers resolve their destination relative to the working directory.
+    pushd ${ROOTDIR}/godot > /dev/null
+    if [[ ! -d ${deps_dir}/accesskit ]]; then
+        echo "Installing AccessKit into ${deps_dir} ..."
+        ${python_bin} misc/scripts/install_accesskit.py
+    fi
+    if [[ $1 != "linux" && ${#angle_dirs} -eq 0 ]]; then
+        echo "Installing ANGLE into ${deps_dir} ..."
+        ${python_bin} misc/scripts/install_angle.py
+    fi
+    popd > /dev/null
+}
+
+# AccessKit and ANGLE only apply to the desktop platforms; the mobile and web
+# platforms have no such dependency, so skip the download there. ANGLE is
+# additionally macOS/Windows only.
+if [[ ${opts[deps]} == "yes" ]]; then
+    case ${opts[platform]} in
+        macos)               install_godot_deps macos ;;
+        win | windows)       install_godot_deps windows ;;
+        linux | linuxbsd)    install_godot_deps linux ;;
+    esac
+fi
 
 pushd $ROOTDIR/godot
 


### PR DESCRIPTION
## Description

Godot 4.7 links two prebuilt SDKs that are not part of the engine source tree: **AccessKit** (screen reader support) and **ANGLE** (the OpenGL ES rendering driver). When they are missing, `scons` only prints a warning and silently disables those drivers, so the editor/templates we build lack features the official Godot builds ship with:

```
WARNING: The screen reader support driver requires dependencies to be installed.
WARNING: The ANGLE rendering driver requires dependencies to be installed.
```

`build.sh` / `build.ps1` now install them before invoking scons, using the installers from the `godot/` checkout so the dependency versions always match the engine revision being built. A new `deps=<yes|no>` option (default `yes`) controls this; already-installed dependencies are skipped, mobile/web platforms use neither, and ANGLE is additionally skipped on Linux.

While verifying the 4.7 build, a few build-script defects surfaced and are fixed here as well:

- `build.sh` ignored `cpus=` and always passed the default value to `scons -j` (`$build_default_opts[cpus]` instead of `${opts[cpus]}`).
- `build.ps1` seeded its scons argument string from an undefined `$internal_opts` (emitting an empty `platform=`) and then concatenated the whole string onto itself (`+=` with the full string).
- `build.ps1` forwarded `release-windows.ps1`'s `strip=yes` to scons instead of consuming it as a build-script option. It is now a recognized option, documented as a no-op on MSVC (debug info lives in a separate `.pdb`).
- `.github/actions/setup-godot` fetched ANGLE pinned at `chromium/6601.2` (4.7 needs `chromium/7219`) and unpacked it outside `build_deps`. Those steps are removed since the build scripts now cover it; the Vulkan SDK and D3D12 steps are kept.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Verification

Verified on macOS (arm64) against `godot` @ 4.7 (v4.7.2.rc) and `godot-cpp` @ master:

| Check | Result |
| --- | --- |
| `./scripts/build.sh` (custom module, `target=editor`) | Succeeds; both warnings gone, links with `ANGLE_ENABLED` |
| `./scripts/build-extension.sh` (GDExtension, `api_version=4.7`) | Succeeds |
| Built `Godot.app`: `SpriteStudioPlayer2D` / `SSABResource` registered and instantiable | OK |
| Re-running `build.sh` with dependencies present | Skips both downloads (no re-fetch) |

Windows and Linux are **not** verified by an actual build; `build.ps1` was checked by parser validation and a dry run of its scons argument assembly.

## Notes

- Linking now emits `duplicate symbol` warnings for Rust symbols (`rust_eh_personality`, `__rust_alloc`, ...) shared between `libssruntime`, `libssconverter` and 4.7's new `libaccesskit`. The link succeeds; recorded here as a known 4.7 artifact.
- `build.sh` still carries a dead `if [[ ${VERSION} =~ ^3\..* ]]` branch for Godot 3.x. Left untouched to keep this change scoped.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules