### PR TITLE
docs+ci: release-readiness fixes (package icons, security policy, class reference, changelog)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -259,6 +259,13 @@ jobs:
           cp ../misc/spritestudio.gdextension addons/spritestudio/
           cp ../LICENSE.md addons/spritestudio/
 
+          # Editor icons referenced by the [icons] section of
+          # spritestudio.gdextension. They are source files, not build outputs,
+          # so they never reach the platform artifacts — copy them straight from
+          # the tree (same set as scripts/build-extension.sh).
+          mkdir -p addons/spritestudio/icons
+          cp ../ss_player/icons/icon_*.svg addons/spritestudio/icons/
+
           # Bundle third-party license notices next to the statically-linked
           # native binaries: FlatBuffers (Apache-2.0), godot-cpp (MIT), and the
           # Rust runtime crates. The runtime crate licenses were staged into

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [7.0.0-beta.1] - Unreleased
 
+First release of the SpriteStudio 7 generation of the plugin, and a rewrite of the 1.x
+player. Playback is now driven by `libssruntime` from
+[SpriteStudio-SDK](https://github.com/cri-middleware/SpriteStudio-SDK) and consumes
+converted binaries (`.ssab`) instead of parsing `.sspj` at runtime. See the
+[Migration Guide](./docs/en/migration_from_v1.md) for moving a 1.x project across.
+
 ### Added
-- **Initial Public Release**: SpriteStudio 7 SDK (`ssconverter-cli` + `Godot Plugin`).
-- **Core Runtime**: Engine-agnostic, `#![no_std]` brain with zero-math integration and SIMD (f32x4) state computation.
-- **Features**: Supports Mesh Deformation, Particles (SSEE), Instances, and SS7.1 parts (Skew, 9-Slice, Shape).
-- **Integrations**: C-API and Web (WASM) ready.
-- **Custom Allocator Injection**: `custom_alloc` feature lets game engines / consoles supply their own allocator and abort handler via `ss_custom_alloc` / `ss_custom_free` / `ss_custom_abort` C symbols — no wrapper crate required.
-- **Documentation**: Overhauled bilingual (EN/JA) README and contribution guidelines.
+- **`SpriteStudioPlayer2D` node**: plays an `.ssab` animation as an ordinary `Node2D`.
+  Transport (`play` / `pause` / `stop`), frame seeking, playback sections, direction,
+  speed scale, loop count, frame skipping and sub-frame interpolation.
+- **Asset pipeline**: the **SS Import Dock** converts a SpriteStudio project (`.sspj`) to
+  `.ssab` by drag & drop and reconverts from the Inspector. `ssconverter-cli` performs the
+  same conversion for CI/CD.
+- **Resource classes**: `SSABResource` (animation binary) and `SSQBResource` (sequence
+  binary). `.ssab` is loaded zero-copy, so playback starts without a parse step.
+- **Per-part Override Layer API**: override a part's color, cell and visibility at runtime,
+  addressed by part name or part index, each with a matching `clear_*` call.
+- **CellMap overrides**: swap an animation's textures at runtime for equipment changes and
+  color variants.
+- **`SpriteStudioPartAttachment2D` node**: mirrors one part's pose onto a `Node2D` so Godot
+  content can be pinned to a part. Modeled on `RemoteTransform2D`.
+- **Signals**: timeline `user_data` and `signal_emitted` events, audio events, animation
+  lifecycle (`animation_started` / `_changed` / `_finished` / `_looped`), and `frame_updated`.
+- **AnimationPlayer integration**: drive playback from Godot's own animation tooling.
+- **Audio playback**: audio parts play through Godot, with volume and backend selection.
+- **Builds**: GDExtension and custom module, for Windows, macOS, Linux, Android, iOS and
+  Web, targeting Godot 4.7.
+- **Documentation**: bilingual (EN/JA) documentation site, class reference and contribution
+  guidelines.
 
 ### Known Limitations
-- Text/Font Bitmap rendering pending validation.
-- macOS/iOS binaries are not yet code-signed.
+- Text / bitmap font rendering is not yet validated.
+- Sequence playback is not implemented. `SSQBResource` loads `.ssqb` files, but no node
+  consumes them yet.
+- macOS / iOS binaries are not code-signed.
+- Web builds are single-threaded only and require WebAssembly SIMD, plus an engine template
+  built with `dlink_enabled=yes`.
+- For the playback constraints inherited from the shared runtime, see
+  [Limitations & Scope](./docs/en/limitations.md).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,73 @@
+# Security Policy
+
+## Supported Versions
+
+Security fixes are applied to the most recent release. Fixes are not backported to earlier major versions.
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 7.0.x   | :white_check_mark: |
+| 1.x     | :x:                |
+
+## Reporting a Vulnerability
+
+**Please do not report security issues through public GitHub Issues.** A public report exposes the problem to users before a fix is available.
+
+Instead, use the official Help Center inquiry form, which is a private channel and also supports file uploads for reproduction data:
+
+👉 [**CRI Middleware Help Center (Inquiry Form)**](https://www.webtech.co.jp/help/en/spritestudio7/inquiries/ssplayer_tool/)
+
+Please include as much of the following as you can:
+
+- The version of SSPlayerForGodot (release tag or commit hash) and whether you use the GDExtension or custom module build.
+- Your Godot Engine version, platform, and export target.
+- A description of the issue and its impact.
+- Steps to reproduce, and a minimal project or data file if one is needed.
+
+We will acknowledge your report and keep you informed as we investigate. Please give us a reasonable opportunity to release a fix before disclosing the issue publicly. If you would like credit in the release notes, say so in your report.
+
+## Scope
+
+This project plays animation binaries (`.ssab` / `.ssqb`) through `libssruntime`, which is maintained in [SpriteStudio-SDK](https://github.com/cri-middleware/SpriteStudio-SDK). Report issues here if they reproduce through the Godot plugin; we will route runtime-level problems to the SDK.
+
+Animation binaries are structurally verified when they are loaded. Even so, this plugin is designed for assets you author and ship with your game. Loading `.ssab` / `.ssqb` files obtained from untrusted third parties at runtime is outside the threat model — treat them as you would any other executable content in your project.
+
+For non-security bugs and feature requests, see [SUPPORT.md](./SUPPORT.md).
+
+---
+
+## 日本語 (Security Policy in Japanese)
+
+### サポート対象バージョン
+
+セキュリティ修正は最新リリースに対して行います。過去のメジャーバージョンへのバックポートは行いません。
+
+| バージョン | サポート           |
+| ---------- | ------------------ |
+| 7.0.x      | :white_check_mark: |
+| 1.x        | :x:                |
+
+### 脆弱性の報告
+
+**セキュリティに関する問題を公開の GitHub Issues に投稿しないでください。** 修正が用意される前に問題が利用者に露出してしまいます。
+
+非公開の窓口である公式ヘルプセンターのお問い合わせフォームをご利用ください。再現用データのファイル添付にも対応しています。
+
+👉 [**ヘルプセンター（お問い合わせフォーム）**](https://www.webtech.co.jp/help/ja/spritestudio7/inquiries/ssplayer_tool/)
+
+可能な範囲で以下をお知らせください。
+
+- SSPlayerForGodot のバージョン（リリースタグまたはコミットハッシュ）と、GDExtension 版 / カスタムモジュール版のどちらか。
+- Godot Engine のバージョン、プラットフォーム、エクスポート先。
+- 問題の内容と影響。
+- 再現手順、および必要であれば最小構成のプロジェクトやデータファイル。
+
+ご報告は受領後に確認し、調査の経過をお知らせします。公開の前に修正をリリースする時間をいただけますようお願いします。リリースノートへのクレジット記載をご希望の場合は、その旨をご記入ください。
+
+### 対象範囲
+
+本プロジェクトは、[SpriteStudio-SDK](https://github.com/cri-middleware/SpriteStudio-SDK) で開発されている `libssruntime` を通じてアニメーションバイナリ（`.ssab` / `.ssqb`）を再生します。Godot プラグイン経由で再現する問題は本リポジトリへご報告ください。ランタイム側の問題であればこちらから SDK へ引き継ぎます。
+
+アニメーションバイナリは読み込み時に構造検証を行っていますが、本プラグインは利用者自身が作成しゲームに同梱するアセットを前提としています。信頼できない第三者から入手した `.ssab` / `.ssqb` を実行時に読み込む用途は想定範囲外です。プロジェクト内の他の実行可能なコンテンツと同様に扱ってください。
+
+セキュリティに関わらない不具合や機能要望については [SUPPORT.md](./SUPPORT.md) をご覧ください。

--- a/ss_player/config.py
+++ b/ss_player/config.py
@@ -9,6 +9,9 @@ def configure(env):
 def get_doc_classes():
     return [
         "SpriteStudioPlayer2D",
+        "SpriteStudioPartAttachment2D",
+        "SSABResource",
+        "SSQBResource",
     ]
 
 def get_doc_path():

--- a/ss_player/doc_classes/SSABResource.xml
+++ b/ss_player/doc_classes/SSABResource.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="SSABResource" inherits="Resource" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
+	<brief_description>
+		A SpriteStudio 7 animation binary ([code].ssab[/code]).
+	</brief_description>
+	<description>
+		Holds the animation binary produced from a SpriteStudio project ([code].sspj[/code]), either by dropping the project onto the editor (the [b]SS Import Dock[/b]) or by running [code]ssconverter-cli[/code]. Assign it to [member SpriteStudioPlayer2D.ssab] to play it.
+		Loading does not parse the file: the runtime reads the FlatBuffers buffer in place and borrows it rather than copying, so load cost is close to the cost of reading the bytes. The buffer stays immutable until [method load_from_file] replaces it.
+		Textures and audio referenced by the animation are resolved relative to the directory the resource was loaded from, so keep the converter's output directory intact when moving files around.
+		[b]Note:[/b] when several [SpriteStudioPlayer2D] nodes share one resource, enable [member Resource.resource_local_to_scene] so each node gets its own playback state.
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="load_from_file">
+			<return type="int" enum="Error" />
+			<param index="0" name="path" type="String" />
+			<description>
+				Replaces the contents of this resource with the [code].ssab[/code] file at [param path]. Returns [constant OK] on success.
+				The buffer is verified before it is used, so a truncated or untrusted file fails here rather than during playback.
+			</description>
+		</method>
+		<method name="save_to_file">
+			<return type="int" enum="Error" />
+			<param index="0" name="path" type="String" />
+			<description>
+				Writes the held binary to [param path] unchanged. Returns [constant OK] on success.
+			</description>
+		</method>
+		<method name="is_valid" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] when the held buffer passes verification. The result is computed once and cached until the buffer is replaced, so this is cheap to call repeatedly. The accessors below return empty results while this is [code]false[/code].
+			</description>
+		</method>
+		<method name="get_animation_count">
+			<return type="int" />
+			<description>
+				Returns the number of animations in the resource.
+			</description>
+		</method>
+		<method name="get_animation_names">
+			<return type="PackedStringArray" />
+			<description>
+				Returns the name of every animation, in the order they appear in the binary. These are the values accepted by [member SpriteStudioPlayer2D.animation].
+			</description>
+		</method>
+		<method name="get_cellmap_names">
+			<return type="PackedStringArray" />
+			<description>
+				Returns the name of every cellmap (texture atlas) the animation references. Each one corresponds to a [code]cellmaps/[/code] override slot in the inspector and to the [param cellmap_name] accepted by [method SpriteStudioPlayer2D.set_cellmap_texture].
+			</description>
+		</method>
+		<method name="get_cell_names">
+			<return type="PackedStringArray" />
+			<param index="0" name="cellmap_name" type="String" />
+			<description>
+				Returns the names of the cells inside [param cellmap_name]. Returns an empty array when that cellmap does not exist.
+			</description>
+		</method>
+		<method name="get_sound_stream">
+			<return type="AudioStream" />
+			<param index="0" name="sound_list_name_hash" type="int" />
+			<param index="1" name="sound_name_hash" type="int" />
+			<description>
+				Returns the [AudioStream] for an audio event, or [code]null[/code] when the referenced file is missing. Both hashes are carried by the payload of [signal SpriteStudioPlayer2D.audio], so this is how a script plays animation audio through its own [AudioStreamPlayer].
+			</description>
+		</method>
+		<method name="get_sound_info">
+			<return type="Dictionary" />
+			<param index="0" name="sound_list_name_hash" type="int" />
+			<param index="1" name="sound_name_hash" type="int" />
+			<description>
+				Returns metadata for an audio event without loading the stream: [code]alias[/code] (the name authored in SpriteStudio), [code]file_path[/code] (relative to this resource), [code]path[/code] (the resolved project path), [code]file_path_hash[/code] and [code]time_total[/code]. Returns an empty [Dictionary] when the event is unknown.
+			</description>
+		</method>
+	</methods>
+</class>

--- a/ss_player/doc_classes/SSQBResource.xml
+++ b/ss_player/doc_classes/SSQBResource.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="SSQBResource" inherits="Resource" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
+	<brief_description>
+		A SpriteStudio 7 sequence binary ([code].ssqb[/code]).
+	</brief_description>
+	<description>
+		Holds the sequence binary produced from a SpriteStudio sequence ([code].ssqe[/code]) alongside the animations, either by dropping the project onto the editor (the [b]SS Import Dock[/b]) or by running [code]ssconverter-cli[/code].
+		A sequence is a playlist that chains animations together. The resource loads and saves today, but no node consumes it yet — sequence playback is not implemented in this version, so loading a [code].ssqb[/code] has no effect on [SpriteStudioPlayer2D]. See [SSABResource] for the animation data that is playable.
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="load_from_file">
+			<return type="int" enum="Error" />
+			<param index="0" name="path" type="String" />
+			<description>
+				Replaces the contents of this resource with the [code].ssqb[/code] file at [param path]. Returns [constant OK] on success.
+			</description>
+		</method>
+		<method name="save_to_file">
+			<return type="int" enum="Error" />
+			<param index="0" name="path" type="String" />
+			<description>
+				Writes the held binary to [param path] unchanged. Returns [constant OK] on success.
+			</description>
+		</method>
+	</methods>
+</class>

--- a/ss_player/doc_classes/SpriteStudioPartAttachment2D.xml
+++ b/ss_player/doc_classes/SpriteStudioPartAttachment2D.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="SpriteStudioPartAttachment2D" inherits="Node2D" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
+	<brief_description>
+		Mirrors the pose of one SpriteStudio part onto a [Node2D].
+	</brief_description>
+	<description>
+		Tracks a single part of a [SpriteStudioPlayer2D] animation and copies its pose onto a [Node2D] every frame. Use it to pin Godot content — a weapon sprite, a particle emitter, an [Area2D] — to a part of the animation.
+		It is modeled on [RemoteTransform2D] and shares its vocabulary ([member remote_path], [member use_global_coordinates], [member update_position], [member update_rotation], [member update_scale]), adding [member part_name] and [member follow_path] to say which part of which player to follow.
+		With [member remote_path] left empty the node drives itself, so children simply follow through scene-tree inheritance — this is the usual setup. Set [member remote_path] to drive a [Node2D] elsewhere in the scene instead, decoupled from the player's subtree.
+		The player neither creates nor owns this node: author it in the scene tree yourself and it stays under your control. It reads the pose the player has already computed — it does not make the player do extra work — by connecting to [signal SpriteStudioPlayer2D.frame_updated], so it stays in step with the frame being rendered regardless of the player's [member SpriteStudioPlayer2D.animation_process_mode].
+		[b]Note:[/b] in the editor, [member part_name] is presented as a dropdown of the resolved player's part names. It remains free text, so a name still works when the player cannot be resolved at edit time.
+	</description>
+	<tutorials>
+	</tutorials>
+	<members>
+		<member name="part_name" type="String" setter="set_part_name" getter="get_part_name" default="&quot;&quot;">
+			Name of the part to follow, as authored in SpriteStudio.
+		</member>
+		<member name="follow_path" type="NodePath" setter="set_follow_path" getter="get_follow_path" default="NodePath(&quot;&quot;)">
+			Path to the [SpriteStudioPlayer2D] whose part is followed. When empty, the nearest ancestor [SpriteStudioPlayer2D] is used.
+		</member>
+		<member name="remote_path" type="NodePath" setter="set_remote_path" getter="get_remote_path" default="NodePath(&quot;&quot;)">
+			Path to the [Node2D] that receives the part's pose. When empty, this node drives itself and its children follow through the scene tree.
+		</member>
+		<member name="use_global_coordinates" type="bool" setter="set_use_global_coordinates" getter="get_use_global_coordinates" default="true">
+			If [code]true[/code], the pose is applied in global space; if [code]false[/code], in the target's local space. Matches [member RemoteTransform2D.use_global_coordinates].
+		</member>
+		<member name="update_position" type="bool" setter="set_update_position" getter="get_update_position" default="true">
+			If [code]true[/code], the part's position is copied to the target.
+		</member>
+		<member name="update_rotation" type="bool" setter="set_update_rotation" getter="get_update_rotation" default="true">
+			If [code]true[/code], the part's rotation is copied to the target.
+		</member>
+		<member name="update_scale" type="bool" setter="set_update_scale" getter="get_update_scale" default="false">
+			If [code]true[/code], the part's scale is copied to the target. Off by default: with position and rotation enabled the resulting transform already carries the part's scale in most setups, and copying it as well tends to double-apply it to child nodes.
+		</member>
+		<member name="on_part_hidden" type="int" setter="set_on_part_hidden" getter="get_on_part_hidden" enum="SpriteStudioPartAttachment2D.HiddenBehavior" default="0">
+			What to do on frames where the tracked part is hidden. See [enum HiddenBehavior].
+			This applies only to a part that exists but is hidden on the current frame. A part that is absent from the animation altogether always hides the target.
+		</member>
+	</members>
+	<constants>
+		<constant name="FOLLOW_ALWAYS" value="0" enum="HiddenBehavior">
+			Keep following the part's pose while it is hidden, leaving the target visible.
+		</constant>
+		<constant name="HIDE_TARGET" value="1" enum="HiddenBehavior">
+			Hide the driven target for as long as the part is hidden.
+		</constant>
+	</constants>
+</class>

--- a/ss_player/doc_classes/SpriteStudioPlayer2D.xml
+++ b/ss_player/doc_classes/SpriteStudioPlayer2D.xml
@@ -167,6 +167,12 @@
 				Emitted when an audio part fires an audio event. [param payload] carries [code]part_index[/code], [code]sound_list_name_hash[/code], [code]sound_name_hash[/code], [code]sound_name[/code] and [code]loop_num[/code] (the play count). This is an observation channel and fires in every playback direction (and in the editor), independently of [member play_audio].
 			</description>
 		</signal>
+		<signal name="frame_updated">
+			<param index="0" name="frame_no" type="float" />
+			<description>
+				Emitted after the animation state has been evaluated for [param frame_no], before the parts are drawn. Connect to this to read part poses in the same frame they render, independently of [member animation_process_mode]. [SpriteStudioPartAttachment2D] uses this signal internally.
+			</description>
+		</signal>
 	</signals>
 	<constants>
 		<constant name="ANIMATION_PROCESS_PHYSICS" value="0" enum="AnimationProcessMode">


### PR DESCRIPTION
Pre-release cleanup. Four independent fixes, one commit each.

## 1. `ci(release)`: bundle the editor icons into the release package

`misc/spritestudio.gdextension` declares three editor icons under
`res://addons/spritestudio/icons/`, but nothing ever placed them there. They are
source files (`ss_player/icons/`) rather than build outputs, so they never reach the
per-platform artifacts, and `scripts/build-extension.sh` only copies them into the
example projects. Every published zip therefore shipped a manifest pointing at three
missing files.

Verified by reproducing the `package` job's layout locally: all three `[icons]` entries
resolve against the staged tree.

## 2. `docs`: add a security policy

The repository had CODE_OF_CONDUCT / CONTRIBUTING / SUPPORT but no `SECURITY.md` —
no stated channel for reporting a vulnerability, and nothing steering reporters away
from public issues. Points at the Help Center inquiry form (the private channel already
referenced from `SUPPORT.md` and the issue template config), bilingual EN/JA.

The supported-versions table (7.0.x supported, 1.x not) is a policy statement — please
confirm it matches your intent.

## 3. `docs`: document the remaining public classes

Only `SpriteStudioPlayer2D` had a `doc_classes` entry, so `SSABResource`,
`SSQBResource` and `SpriteStudioPartAttachment2D` were empty in the editor help
despite being public API. Adds an XML for each and lists them in `config.py`'s
`get_doc_classes()` — the SConstruct globs the directory, but the custom module path
needs the names explicitly.

Also documents `SpriteStudioPlayer2D`'s `frame_updated` signal, which was bound
(`ss_player_node_2d.cpp:501`) but missing from its XML, and is what
`SpriteStudioPartAttachment2D` connects to.

Every documented method / member / signal was cross-checked against the actual
`ClassDB` bindings; the three new files match exactly (9/9, 2/2, 8/8).

## 4. `docs`: describe the Godot plugin in its own changelog

The `7.0.0-beta.1` entry described the Rust SDK — `no_std`, SIMD state computation,
custom allocator injection, C-API — which belongs to SpriteStudio-SDK's changelog.
None of the plugin's own surface was listed. Rewritten around what this repository
ships, with Known Limitations extended (unimplemented sequence playback, Web
constraints) and the shared runtime constraints linked rather than restated.

The unsigned macOS/iOS note stays, and is accurate: the workflows read `SS_APPLE_*`
secrets, and `gh secret list` shows only the v1.x-era names (`APPLE_ID`,
`DEV_CERT_*`, `KC_PASS`, `NOTARIZATION_PWD`, `TEAM_ID`). Release binaries will be
unsigned until those are configured.

## Notes

- CI on this branch fails at `Checkout` (`submodules: recursive`) because the SDK
  submodule is private. Unrelated to these changes.
- The SDK submodule pointer is deliberately left at develop's `bef3957`. The local
  checkout is 8 commits ahead (`8938442`), but bumping it is a separate release step
  that goes together with `scripts/SDK_VERSION.txt`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules (n/a)