### PR TITLE
build: include the SDK's C headers instead of the C++ ones

### DIFF
--- a/scripts/build-runtime.ps1
+++ b/scripts/build-runtime.ps1
@@ -82,11 +82,12 @@ if ($IS_HOST_BUILD) {
 }
 popd
 
-# 1. Collect Headers
+# 1. Collect Headers. The plain-C headers carry `extern "C"` guards (cbindgen
+# cpp_compat), so they are what this C++ code includes; the .hpp variants are unused.
 $INCLUDE_OUTPUT = "$rootDirectory/ss_player/runtime/include"
 New-Item -ItemType Directory -Path $INCLUDE_OUTPUT -Force | Out-Null
-Copy-Item "$SDK_DIR/libs/ssconverter/target/ssconverter.hpp" "$INCLUDE_OUTPUT/" -Force
-Copy-Item "$SDK_DIR/libs/ssruntime/target/ssruntime.hpp" "$INCLUDE_OUTPUT/" -Force
+Copy-Item "$SDK_DIR/libs/ssconverter/target/ssconverter.h" "$INCLUDE_OUTPUT/" -Force
+Copy-Item "$SDK_DIR/libs/ssruntime/target/ssruntime.h" "$INCLUDE_OUTPUT/" -Force
 
 # 1.5. Collect Licenses
 $RUNTIME_OUTPUT = "$rootDirectory/ss_player/runtime"

--- a/scripts/build-runtime.sh
+++ b/scripts/build-runtime.sh
@@ -127,11 +127,12 @@ popd > /dev/null
 echo "Collecting artifacts from $SRC_DIR..."
 RUNTIME_DIR=${ROOTDIR}/ss_player/runtime
 
-# Headers
+# Headers. The plain-C headers carry `extern "C"` guards (cbindgen cpp_compat),
+# so they are what this C++ code includes; the SDK's .hpp variants are not used.
 mkdir -p ${RUNTIME_DIR}/include
-cp ${SDK_DIR}/libs/ssruntime/target/ssruntime.hpp ${RUNTIME_DIR}/include/
+cp ${SDK_DIR}/libs/ssruntime/target/ssruntime.h ${RUNTIME_DIR}/include/
 if [[ "$PLATFORM" == "macos" || "$PLATFORM" == "windows" || "$PLATFORM" == "linux" ]]; then
-    cp ${SDK_DIR}/libs/ssconverter/target/ssconverter.hpp ${RUNTIME_DIR}/include/
+    cp ${SDK_DIR}/libs/ssconverter/target/ssconverter.h ${RUNTIME_DIR}/include/
 fi
 
 # Licenses

--- a/ss_player/ss_import_dock.cpp
+++ b/ss_player/ss_import_dock.cpp
@@ -41,7 +41,7 @@ using namespace godot;
 #include "ss_clickable_label.h"
 #include "ss_import_dock.h"
 #include "ss_importer.h"
-#include "ssconverter.hpp"
+#include "ssconverter.h"
 
 // Plugin version, stamped at build time from VERSION.txt + git hash.
 // Generated into ss_player/gen/ by generate_version_header() (ss_player/sources.py).

--- a/ss_player/ss_importer.cpp
+++ b/ss_player/ss_importer.cpp
@@ -40,7 +40,7 @@ using namespace godot;
 #endif
 #endif
 
-#include "ssconverter.hpp"
+#include "ssconverter.h"
 
 void SSImporter::_bind_methods() {
     ADD_SIGNAL(MethodInfo("import_started"));

--- a/ss_player/ss_internal_player.cpp
+++ b/ss_player/ss_internal_player.cpp
@@ -1,7 +1,7 @@
 #include "ss_internal_player.h"
 #include "format/ssab.h"
 #include "format/effect_draw_plan.h"
-#include "ssruntime.hpp"
+#include "ssruntime.h"
 #include "format/framedata.h"
 #include <mutex>
 #include <cstring>

--- a/ss_player/ss_internal_player.h
+++ b/ss_player/ss_internal_player.h
@@ -37,7 +37,7 @@ using namespace godot;
 
 #include "ssab_resource.h"
 
-// Forward declaration; full definition comes from runtime/include/ssruntime.hpp.
+// Forward declaration; full definition comes from runtime/include/ssruntime.h.
 struct ss_event_instance_info;
 
 namespace ss {


### PR DESCRIPTION
> **Do not merge before the SDK side lands.** See [Merge order](#merge-order).

## Why

cbindgen emits both a plain-C header and a C++ one for `ssruntime` / `ssconverter`, and this player has been taking the `.hpp`. That was less a preference than a constraint: the `.h` had **no `extern "C"` guard**, so a C++ translation unit compiled its declarations with C++ linkage and never found the library's C symbols:

```
"ss_runtime_create()", referenced from: _main in ...
 NOTE: found '_ss_runtime_create' in libssruntime.dylib,
       declaration possibly missing 'extern "C"'
```

Meanwhile the SDK's own documentation points C++ callers at the `.h` — `libs/ssruntime/README.md`'s section titled *"Example C++ Usage"*, the Player guide (`docs/30_core/10_initialization.md`), and `OVERRIDE_LAYER_SPEC.md` §10, which describes **this player** as *"GDExtension C++, `#include "ssruntime.h"`"*.

cri-middleware/SpriteStudio-SDK#333 turns `cpp_compat` on, so the `.h` now carries the guard and serves C and C++ alike. This PR puts the player on the header the SDK documents.

## What changed

| File | Change |
|---|---|
| `ss_player/ss_internal_player.cpp` | `ssruntime.hpp` → `ssruntime.h` |
| `ss_player/ss_importer.cpp`, `ss_player/ss_import_dock.cpp` | `ssconverter.hpp` → `ssconverter.h` |
| `ss_player/ss_internal_player.h` | comment follows the rename |
| `scripts/build-runtime.sh`, `scripts/build-runtime.ps1` | collect the `.h` into `ss_player/runtime/include/` |
| `ss_player/SpriteStudio-SDK` | moved to the SDK's `feature/cbindgen-cpp-compat` so this builds today |

Nothing is lost in the move: the generated C header has **no enums**, so the C++ variant differed mainly in `constexpr` constants instead of `#define` (plus ostream operators this code never used).

## Verification

macOS / arm64, GDExtension:

```sh
rm ss_player/runtime/include/*.hpp     # so a stale C++ header cannot satisfy an include
./scripts/build-runtime.sh
./scripts/build-extension.sh           # → Linking Shared Library libSSGodot.macos.editor ✅
```

- Deleting the `.hpp` first means any translation unit still reaching for one would fail outright, so the build genuinely uses the `.h`.
- **Linking is itself the proof the guard works** — without it those symbols come out undefined, as quoted above.
- Confirmed `ss_internal_player.os`, `ss_importer.os` and `ss_import_dock.os` were all recompiled in this run (not served from cache).
- The `duplicate symbol '_rust_eh_personality'` link warnings are pre-existing (`libssruntime.a` vs `libssconverter.a`) and unrelated to headers.

## Merge order

`scripts/download-sdk.sh` consumes a released SDK archive pinned by `scripts/SDK_VERSION.txt` (`v7.0.0-alpha.1`). That release's `ssruntime.h` predates the fix and has no guards, so **the prebuilt-SDK path stays broken until a release ships the fix**:

1. Merge cri-middleware/SpriteStudio-SDK#333
2. Cut an SDK release containing the guarded headers
3. Here: bump `scripts/SDK_VERSION.txt`, move the submodule off the feature branch onto the released commit, then merge this

Until then, only the source-SDK path (`./scripts/build-runtime.sh`) works — which is what the verification above exercises.
