### PR TITLE
docs: link the hosted docs site and the SpriteStudio Docs portal from the README

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -25,8 +25,10 @@
 
 詳細な使い方は `docs/` フォルダ内のドキュメントを参照してください。
 
+- [**ドキュメントサイト (ホスト版)**](https://cri-middleware.github.io/SSPlayerForGodot/) — 🚧 初回リリース後に公開
 - [**ドキュメント (日本語)**](./docs/ja/index.md)
 - [**Documentation (English)**](./docs/en/index.md)
+- [**SpriteStudio Docs（ポータル）**](https://cri-middleware.github.io/SpriteStudio-Docs/) — SDK と全公式 Player の入口 — 🚧 初回リリース後に公開
 
 ### クイックリンク (日本語)
 - [インストール](./docs/ja/setup/install.md)

--- a/README.md
+++ b/README.md
@@ -25,8 +25,10 @@ A high-performance extension plugin (GDExtension / Custom Module) for playing an
 
 Comprehensive documentation is available in the `docs/` folder:
 
+- [**Documentation site (hosted)**](https://cri-middleware.github.io/SSPlayerForGodot/) — 🚧 live after the first release
 - [**Documentation (English)**](./docs/en/index.md)
 - [**ドキュメント (日本語)**](./docs/ja/index.md)
+- [**SpriteStudio Docs (portal)**](https://cri-middleware.github.io/SpriteStudio-Docs/) — the SDK and every official player in one place — 🚧 live after the first release
 
 ### Quick Links (English)
 - [Installation](./docs/en/setup/install.md)


### PR DESCRIPTION
The README linked only the in-repo markdown (`./docs/en/index.md`), so the **published documentation site was unreachable from the repository front page** — even though this repo has a `pages.yml`, a `docs/` folder, and a `site_url` pointing at GitHub Pages.

Added to both `README.md` and `README.ja.md`:

- the **hosted documentation site** line, worded exactly as SSPlayerForWeb / SSPlayerForFlutter / SSPlayerForRenPy already word theirs,
- a line for **SpriteStudio Docs**, the cross-player portal (the SDK, every official player, and the conversion tools).

Both carry the existing 🚧 marker — neither site is live until the first release.
