### PR TITLE
ci: publish the docs site on release rather than on push to main

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -3,16 +3,13 @@ name: Publish docs via GitHub Pages
 # Build the MkDocs site and deploy it to GitHub Pages via the artifact method
 # (no gh-pages branch) — matching SSPlayerForWeb / SSPlayerForRenPy.
 #
-# Triggers stay on the docs hot path: push to main and manual dispatch deploy,
-# while PRs only build with --strict to catch broken links / nav gaps.
+# The published site is tied to releases, not to merges: a published release and a
+# manual dispatch deploy, while PRs only build with --strict to catch broken links /
+# nav gaps. This keeps the docs site in step with the release the portal links to,
+# rather than running ahead of it on every merge.
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - 'docs/**'
-      - 'mkdocs.yml'
-      - '.github/workflows/pages.yml'
+  release:
+    types: [published]
   pull_request:
     paths:
       - 'docs/**'


### PR DESCRIPTION
Aligns this repository's docs deploy trigger with SSPlayerForUnity / SSPlayerForRenPy / SSConverterGUI, which already publish on `release: published`.

## Why

Deploying on every merge to `main` puts the published site **ahead of the release** that the [SpriteStudio Docs](https://github.com/cri-middleware/SpriteStudio-Docs) portal links to, so a reader can land on documentation for behavior that has not shipped. Tying the deploy to a published release keeps the site and the portal's "coming soon" gate in step.

## What changes

```diff
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - 'docs/**'
-      - 'mkdocs.yml'
-      - '.github/workflows/pages.yml'
+  release:
+    types: [published]
   pull_request:
     paths: ...
   workflow_dispatch:
```

- `workflow_dispatch` is unchanged — a manual deploy still works at any time.
- `pull_request` is unchanged, so every PR still builds with `--strict` and catches broken links / nav gaps. The deploy job is gated on `github.event_name != 'pull_request'`, so PRs build without publishing.
- The `paths` filter stays on `pull_request` only; release events do not take one.

No behavior change for readers today: GitHub Pages is not yet enabled on this repository.