### PR TITLE
ci: drop the docs PR build, leaving release + dispatch only

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -3,18 +3,13 @@ name: Publish docs via GitHub Pages
 # Build the MkDocs site and deploy it to GitHub Pages via the artifact method
 # (no gh-pages branch) — matching SSPlayerForWeb / SSPlayerForRenPy.
 #
-# The published site is tied to releases, not to merges: a published release and a
-# manual dispatch deploy, while PRs only build with --strict to catch broken links /
-# nav gaps. This keeps the docs site in step with the release the portal links to,
-# rather than running ahead of it on every merge.
+# The published site is tied to releases, not to merges: a published release or a
+# manual dispatch deploys, and nothing else does. This keeps the docs site in step
+# with the release the SpriteStudio Docs portal links to, rather than running ahead
+# of it on every merge. Every sibling player repository uses this same trigger pair.
 on:
   release:
     types: [published]
-  pull_request:
-    paths:
-      - 'docs/**'
-      - 'mkdocs.yml'
-      - '.github/workflows/pages.yml'
   workflow_dispatch:
 
 # Permissions required by the artifact-based Pages deploy. No contents:write —
@@ -24,10 +19,11 @@ permissions:
   pages: write
   id-token: write
 
-# Serialize deploys per ref; cancel only superseded PR builds, never a main deploy.
+# Never run two deploys at once; let an in-progress deploy finish rather than
+# cancelling it.
 concurrency:
-  group: docs-pages-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: pages
+  cancel-in-progress: false
 
 jobs:
   build:
@@ -53,19 +49,17 @@ jobs:
       - name: Install dependencies
         run: pip install -r docs/requirements.txt
 
-      # Fail the build on broken links / missing nav entries so PRs catch it before merge.
+      # --strict fails the build on broken links / missing nav entries.
       - name: Build docs (strict validation)
         run: mkdocs build --strict
 
       # Only the MkDocs output (site/) is served — no examples/demos to bundle.
       - name: Upload Pages artifact
-        if: github.event_name != 'pull_request'
         uses: actions/upload-pages-artifact@v5
         with:
           path: site
 
   deploy:
-    if: github.event_name != 'pull_request'
     needs: build
     runs-on: ubuntu-latest
     environment:


### PR DESCRIPTION
Follow-up to #249. Completes the trigger unification: every repository's docs site now publishes on exactly **`release: published` + `workflow_dispatch`**, and nothing else.

SSPlayerForUnity and SSPlayerForRenPy already had this shape; SSPlayerForFlutter, SSConverterGUI and SSPlayerForWeb get the same change in parallel PRs.

## What changes

- `pull_request` trigger removed from `on:`.
- The conditionals it was guarding go with it — they are dead once the trigger is gone:
  - `if: github.event_name != 'pull_request'` on the *Upload Pages artifact* step
  - `if: github.event_name != 'pull_request'` on the `deploy` job
  - `concurrency: docs-pages-${{ github.ref }}` / `cancel-in-progress: ${{ github.event_name == 'pull_request' }}` → `group: pages` / `cancel-in-progress: false`, matching the siblings

Net: 9 insertions, 15 deletions. No job-level `if:` remains.

## Trade-off

`pages.yml` is the **only** workflow in this repository that builds the docs, so `mkdocs build --strict` no longer runs before merge. A broken internal link or a missing nav entry now surfaces on the **release deploy** rather than on the PR that introduced it. Run `mkdocs build --strict` locally before merging a docs change — the workflow comment now says so.

GitHub Pages is not yet enabled here, so nothing changes for readers today.