### PR TITLE
Follow the SDK's Windows x64 directory rename

### DIFF
--- a/scripts/download-sdk.ps1
+++ b/scripts/download-sdk.ps1
@@ -68,7 +68,7 @@ if (Test-Path "$targetDir/runtime") {
 Expand-Archive -Path $zipFile -DestinationPath "$targetDir/runtime" -Force
 
 # Godot Custom Module compatibility (Windows x86_64)
-$winLibDir = "$targetDir/runtime/libs/windows/x86_64"
+$winLibDir = "$targetDir/runtime/libs/windows/x64"
 if (Test-Path $winLibDir) {
     Write-Host "Creating library copies for Godot Custom Module..."
     $targets = "editor", "template_release", "template_debug"


### PR DESCRIPTION
Depends on cri-middleware/SpriteStudio-SDK#342 — land that first.

The SDK now names its Windows library directories the way Windows does:
`libs/windows/x64` instead of `libs/windows/x86_64`. `download-sdk.ps1` reads
from the new path.

The custom-module copies it makes keep their
`ssruntime.windows.<target>.x86_64.lib` names: that is Godot's own artifact
convention (`godot.windows.editor.x86_64.exe`), not the SDK's layout, so it
stays on Godot's vocabulary.

The SDK also starts shipping Windows arm64 libraries in the same release. This
PR does not wire them up — that needs matching `.arm64.lib` module copies and
build configuration, which is a Windows-on-ARM port rather than a path change.
