### PR TITLE
fix(player): re-borrow the SSAB buffer after an in-place reload

### DIFF
--- a/ss_player/ss_internal_player.cpp
+++ b/ss_player/ss_internal_player.cpp
@@ -751,6 +751,11 @@ void SsInternalPlayer::update(float delta_seconds) {
     // `_update_instance_children`; they must not run their own controller
     // tick (would race the parent's deterministic seek).
     if (_parent_driven) return;
+    // A re-import frees the buffer the runtime borrowed. Checked ahead of the
+    // is_playing early-return, since a stopped player still redraws.
+    if (_subtree_borrow_stale()) {
+        onSSABReloaded();
+    }
     if (!ss_runtime_is_playing(runtime_ctx)) return;
 
     auto d = delta_seconds * 1000.0f;
@@ -1563,6 +1568,23 @@ void SsInternalPlayer::_load_external_ssabs() {
     }
 }
 
+bool SsInternalPlayer::_subtree_borrow_stale() const {
+    if (!_ssabRes.is_null() && runtime_res != nullptr &&
+        _ssabRes->get_generation() != _borrowed_generation) {
+        return true;
+    }
+    // Children borrow external .ssab files, which nothing watches for
+    // "changed". Walking them is what catches a re-import of those. Terminates:
+    // it visits children that exist, not the reference graph behind them.
+    for (uint32_t i = 0; i < _instance_children.size(); i++) {
+        const SsInternalPlayer* child = _instance_children[i].player;
+        if (child && child->_subtree_borrow_stale()) {
+            return true;
+        }
+    }
+    return false;
+}
+
 Ref<SSABResource> SsInternalPlayer::_resolve_ssab_by_hash(uint32_t pack_hash, uint32_t name_hash) const {
     if (pack_hash != 0) {
         if (auto* ext_ptr = _external_ssabs_by_pack_hash.getptr(pack_hash)) {
@@ -1800,6 +1822,12 @@ void SsInternalPlayer::_redraw_child_if_frame_changed(SsInternalPlayer* child, f
 }
 
 void SsInternalPlayer::_seek_and_redraw(float frame_no, float delta_seconds, bool parent_looped) {
+    // Seeking draws without going through `update`, so it needs the same check.
+    // Children are covered by their parent's walk. Falls through afterwards so
+    // the frame the caller asked for is the one drawn.
+    if (!_parent_driven && _subtree_borrow_stale()) {
+        onSSABReloaded();
+    }
     const float draw_frame = _sub_frame_enabled ? frame_no : floorf(frame_no);
     previous_frame_no = draw_frame;
     _update_instance_children(draw_frame, delta_seconds, parent_looped);
@@ -2951,6 +2979,8 @@ void SsInternalPlayer::_fetchAnimation() {
             return;
         }
         _res_rebind_pending = false;
+        // Which incarnation of the buffer this borrow refers to.
+        _borrowed_generation = _ssabRes->get_generation();
     }
 
     // Per-batch canvas_item pool grows on demand inside _drawAnimation via

--- a/ss_player/ss_internal_player.h
+++ b/ss_player/ss_internal_player.h
@@ -355,6 +355,10 @@ private:
     // within the same SSAB must NOT re-bind: binding drops every part override,
     // including the Permanent-priority ones documented to survive it.
     bool _res_rebind_pending = true;
+    // `_ssabRes` generation at the time `runtime_res` borrowed its buffer. A
+    // mismatch means the resource reloaded in place and the borrow (plus
+    // `_currentAnimationData`, which points into it) dangles.
+    uint32_t _borrowed_generation = 0;
     float previous_frame_no = -1.0f;
     float _speed_rate = 1.0f;
     bool _sub_frame_enabled = false;
@@ -791,6 +795,9 @@ private:
 
     void _load_external_ssabs();
     Ref<SSABResource> _resolve_ssab_by_hash(uint32_t pack_hash, uint32_t name_hash) const;
+    // True when this player, or any Instance child below it, borrows a buffer
+    // its resource has since replaced.
+    bool _subtree_borrow_stale() const;
 
     void _apply_blend_material(RenderingServer* rs, RID ci, ss::format::BlendType blend_type);
     // ShaderMaterial variant for Normal and Mesh batches. PartColor is handled

--- a/ss_player/ssab_resource.cpp
+++ b/ss_player/ssab_resource.cpp
@@ -71,7 +71,10 @@ Error SSABResource::load_from_file(const String &path) {
   Error error = OK;
   _parent_dir = path.get_base_dir();
   // New buffer: drop the cached verification verdict before touching `binary`.
+  // The generation is bumped up-front so the failure paths below, which leave
+  // `binary` reassigned or cleared, invalidate outstanding borrows too.
   _valid_cache = -1;
+  _generation++;
 #ifdef SPRITESTUDIO_GODOT_EXTENSION
   binary = FileAccess::get_file_as_bytes(path);
   if (binary.size() == 0) {
@@ -348,6 +351,9 @@ Error SSABResource::copy_from(const Ref<Resource> &p_resource) {
       static_cast<const Ref<SSABResource> &>(p_resource);
   this->binary = ssabFile->binary;
   _valid_cache = -1;
+  // This path emits no "changed", so the generation is the only signal a
+  // borrower gets that its buffer was replaced.
+  _generation++;
   return OK;
 }
 #endif

--- a/ss_player/ssab_resource.h
+++ b/ss_player/ssab_resource.h
@@ -56,6 +56,10 @@ public:
   const ss::format::SsAnimeBinary *get_ss_anime_binary();
   const uint8_t *get_data_ptr();
   int64_t get_data_size();
+  // Bumped every time `binary` is replaced. Holders of a zero-copy borrow of
+  // get_data_ptr() compare it to spot an in-place reload; the pointer alone
+  // won't do, since a same-sized buffer often re-allocates at the same address.
+  uint32_t get_generation() const { return _generation; }
   ss::format::AnimationData *find_animation(const String &name);
   ss::format::AnimationData *find_animation_by_hash(uint32_t name_hash);
   String get_parent_dir() const;
@@ -84,6 +88,8 @@ private:
     // is_valid(): -1 = not verified yet, 0 = invalid, 1 = valid. Reset to -1
     // wherever `binary` is replaced (load_from_file / copy_from).
     mutable int8_t _valid_cache = -1;
+    // Bumped alongside `_valid_cache`; see get_generation().
+    uint32_t _generation = 0;
     // The actual verification; is_valid() is the cached front-end.
     bool _verify_binary() const;
     // (sound_list_name_hash << 32 | sound_name_hash) -> loaded AudioStream.


### PR DESCRIPTION
## Description

Re-importing a project while a `SpriteStudioPlayer2D` is in the scene could crash the editor. Instance parts were required to reproduce it.

The runtime borrows a `.ssab` buffer rather than copying it, and that borrow was outliving the buffer.

### Root cause

`SSImporter::_refresh_cached_output` (`ss_importer.cpp:846`) refreshes every generated `.ssab` by calling `load_from_file` on the resource **already in the cache**, then emitting `changed`. `SSABResource::load_from_file` reassigns `binary`, so the object survives but its buffer is freed and replaced.

`_fetchAnimation` hands that buffer to `ss_resource_create_borrow` and keeps `_currentAnimationData` pointing into the same FlatBuffer, so both dangle the moment it is replaced.

The player's own resource is covered: the Node2D connects `changed` and `onSSABReloaded` re-borrows. The gap is the external `.ssab` files — sibling packs loaded by `_load_external_ssabs` so Instance children can resolve `ref_anime_pack` — which **nothing** connects `changed` on.

Whether it crashed came down to refresh order. `_record_ssabs_in_dir` (`:820`) pushes the generated files in `DirAccess` enumeration order, so when the parent pack sorts before the external one (`Instance` before `Instance_SourceAnime`, for example) the children are rebuilt while the external still holds its old buffer, and are left pointing at freed memory when it is refreshed a moment later. Freed-but-not-yet-reused memory usually still reads, which is why it only crashed sometimes.

This is not module-only. `copy_from` is (`#ifndef SPRITESTUDIO_GODOT_EXTENSION`), but the importer path above compiles in both builds.

### Fix

`SSABResource` now carries a generation, bumped wherever `binary` is replaced — `load_from_file` and `copy_from`. In `load_from_file` it is bumped up-front so the failure paths, which leave `binary` reassigned or cleared, invalidate outstanding borrows as well.

`SsInternalPlayer` records the generation it borrowed and checks it — for itself and, recursively, for its Instance children — before it steps or draws, rebuilding through `onSSABReloaded` on a mismatch. Two call sites: `update`, ahead of the `is_playing` early-return so a stopped player still notices, and `_seek_and_redraw`, which draws without going through `update`. The recursion walks children that already exist, not the reference graph they were built from, so it terminates regardless of how the data references itself.

Comparing `get_data_ptr()` instead would not be enough: freeing and re-allocating a same-sized buffer frequently lands on the same address.

### Alternative considered

Connecting `changed` on the external resources as well. Rejected on two counts: `copy_from` emits no `changed` at all, and the set of resources to watch changes with every animation switch and every level of Instance nesting, so it re-creates the same "one missed spot equals a dangling borrow" failure this bug is an instance of. Checking at the point of use keeps the invariant local to the borrow.

### Verification

- Custom module and GDExtension builds both clean
- Manually confirmed: the iteration loop and pace that used to crash no longer does

No SDK change; the submodule pin is untouched.