### PR TITLE
docs: link the portal and unify the related-repositories list

### DIFF
--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -93,6 +93,7 @@ Sample projects based on SDK test projects are available under the `examples/` f
 
 ## Related Repositories
 
+- [SpriteStudio Docs](https://cri-middleware.github.io/SpriteStudio-Docs/) — the documentation portal for the SDK and its official players
 - [SpriteStudio-SDK](https://github.com/cri-middleware/SpriteStudio-SDK) — The SDK itself, providing `libssruntime` / `libssconverter`
 
 ## Migration

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -93,8 +93,9 @@ Sample projects based on SDK test projects are available under the `examples/` f
 
 ## Related Repositories
 
-- [SpriteStudio Docs](https://cri-middleware.github.io/SpriteStudio-Docs/) — the documentation portal for the SDK and its official players
-- [SpriteStudio-SDK](https://github.com/cri-middleware/SpriteStudio-SDK) — The SDK itself, providing `libssruntime` / `libssconverter`
+- [SpriteStudio Docs](https://cri-middleware.github.io/SpriteStudio-Docs/) — the documentation portal for the SDK and its official players.
+- [SpriteStudio-SDK](https://github.com/cri-middleware/SpriteStudio-SDK) — the SDK itself, providing `libssruntime` / `libssconverter`.
+- [SSConverterGUI](https://github.com/cri-middleware/SSConverterGUI) — a standalone desktop GUI for converting `.sspj` without a player.
 
 ## Migration
 

--- a/docs/ja/index.md
+++ b/docs/ja/index.md
@@ -93,6 +93,7 @@ Windows / macOS でのビルドおよび実行を確認しています。
 
 ## 関連リポジトリ
 
+- [SpriteStudio Docs](https://cri-middleware.github.io/SpriteStudio-Docs/) — SDK と公式 Player のドキュメントポータル
 - [SpriteStudio-SDK](https://github.com/cri-middleware/SpriteStudio-SDK) — `libssruntime` / `libssconverter` を提供する SDK 本体
 
 ## マイグレーション

--- a/docs/ja/index.md
+++ b/docs/ja/index.md
@@ -93,8 +93,9 @@ Windows / macOS でのビルドおよび実行を確認しています。
 
 ## 関連リポジトリ
 
-- [SpriteStudio Docs](https://cri-middleware.github.io/SpriteStudio-Docs/) — SDK と公式 Player のドキュメントポータル
-- [SpriteStudio-SDK](https://github.com/cri-middleware/SpriteStudio-SDK) — `libssruntime` / `libssconverter` を提供する SDK 本体
+- [SpriteStudio Docs](https://cri-middleware.github.io/SpriteStudio-Docs/) — SDK と公式 Player のドキュメントポータル。
+- [SpriteStudio-SDK](https://github.com/cri-middleware/SpriteStudio-SDK) — `libssruntime` / `libssconverter` を提供する SDK 本体。
+- [SSConverterGUI](https://github.com/cri-middleware/SSConverterGUI) — Player を介さず `.sspj` を変換するデスクトップ GUI。
 
 ## マイグレーション
 


### PR DESCRIPTION
## What

Two related changes to the index's related-repositories list.

**1. Link the portal.** Nothing on the landing page pointed back at the SpriteStudio Docs
portal, so this site was a dead end for a reader who arrived here first. (Deep links already
existed in one spot — `limitations.md` sends readers to the portal's Shared Limitations page.)

**2. Unify the list across players.** The lists had drifted: each player named a different
subset of the same three repos, in a different order, with its own wording — and two sites
called the section "Related links" while the rest called it "Related Repositories". Every
player now carries the same section, same order, same descriptions, in both locales:

```
## Related Repositories

- [SpriteStudio Docs](…/SpriteStudio-Docs/) — the documentation portal for the SDK and its official players.
- [SpriteStudio-SDK](…/SpriteStudio-SDK) — the SDK itself, providing `libssruntime` / `libssconverter`.
- [SSConverterGUI](…/SSConverterGUI) — a standalone desktop GUI for converting `.sspj` without a player.
```

Order is hub → core → tool. Sibling PRs make the identical change in the other player repos.

## Notes

**SSConverterGUI is deliberately left alone.** It is not a player, it cannot list itself, and
its SDK entry is app-specific ("providing the `ssconverter` crate this application wraps") —
more useful there than the generic line.

The portal's GitHub Pages site is not deployed yet, so that link 404s until it publishes. It is
written as a normal link rather than gated text, matching the entry SSConverterGUI's index
already carried.

## Test plan

- [x] `mkdocs build --strict` — no warnings
- [x] Section renders identically in `en` and `ja`
