### PR TITLE
chore(build): stop compiling the unused flatc translation units

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -89,8 +89,7 @@ env = SConscript("godot-cpp/SConstruct", {"env": env, "customs": customs})
 # Extension sources
 sources_list = Glob("ss_player/*.cpp")
 
-# FlatBuffers sources
-sources_list.extend(sources.get_fb_sources("ss_player"))
+# FlatBuffers is header-only here -- see the note in ss_player/sources.py.
 
 # Version header: stamp VERSION.txt + git hash into ss_player/gen/ss_version.gen.h
 # (gitignored). Shared with the custom module build via ss_player/sources.py.

--- a/ss_player/SCsub
+++ b/ss_player/SCsub
@@ -28,9 +28,7 @@ if not env_ss.msvc:
 # Extension sources
 env_ss.add_source_files(env.modules_sources, "*.cpp")
 
-# FlatBuffers sources
-for f in sources.get_fb_sources():
-    env_ss.add_source_files(env.modules_sources, f)
+# FlatBuffers is header-only here -- see the note in sources.py.
 
 # --- Includes ---
 env_ss.Append(CPPPATH=sources.get_include_paths())

--- a/ss_player/sources.py
+++ b/ss_player/sources.py
@@ -1,19 +1,15 @@
 import os
 import subprocess
 
-def get_fb_sources(base_dir=""):
-    fb_src_dir = os.path.join(base_dir, "flatbuffers/src")
-    fb_sources = [
-        "idl_parser.cpp",
-        "idl_gen_text.cpp",
-        "reflection.cpp",
-        "util.cpp",
-    ]
-    return [os.path.join(fb_src_dir, f) for f in fb_sources]
+# FlatBuffers is used header-only here: the generated format/*.h headers pull in
+# flatbuffers/flatbuffers.h, whose whole reachable set (buffer/table/vector/
+# verifier/builder, 16 headers) is inline. Nothing links against the flatc-side
+# translation units (idl_parser.cpp, idl_gen_text.cpp, reflection.cpp,
+# util.cpp) -- schema compilation is libssconverter's job on the Rust side -- so
+# they are not built, and flatbuffers/src is not on the include path.
 
 def get_include_paths(base_dir=""):
     return [
-        os.path.join(base_dir, "flatbuffers/src"),
         os.path.join(base_dir, "flatbuffers/include"),
         os.path.join(base_dir, "format"),
         os.path.join(base_dir, "runtime/include"),


### PR DESCRIPTION
## Description

Both build paths compiled four FlatBuffers translation units that nothing in this project uses:

```python
# ss_player/sources.py
fb_sources = ["idl_parser.cpp", "idl_gen_text.cpp", "reflection.cpp", "util.cpp"]
```

These are the flatc (schema compiler) side of FlatBuffers. Playback needs none of it — schema compilation is `libssconverter`'s job on the Rust side. They look like a leftover from when `.sspj` → `.ssab` conversion was going to happen in C++.

FlatBuffers is used **header-only** here: the generated `format/*.h` headers include `flatbuffers/flatbuffers.h`, whose reachable set (16 headers: buffer/table/vector/verifier/builder…) is entirely inline.

**Evidence that nothing linked against them:**

- No source includes `idl.h`, `reflection.h` or `util.h` — the only FlatBuffers include anywhere in the project is `flatbuffers/flatbuffers.h`, via `format/*.h`.
- Every FlatBuffers symbol used is header-only: `Offset`, `Vector`, `FlatBufferBuilder`, `Table`, `Verifier`, `GetRoot`, `GetSizePrefixedRoot`, `BufferHasIdentifier`, `EndianScalar`.
- `nm -u` over all 18 built objects (1:1 with the 18 `.cpp` files) reports **zero** undefined `flatbuffers::` symbols. The linker never asked for anything these four files define.

### Changes

- `ss_player/sources.py` — remove `get_fb_sources()`, replaced by a comment recording why FlatBuffers is header-only here. Also drop `flatbuffers/src` from the include path; it was only needed so those translation units could find their own private headers (`format/*.h` resolves fine from `flatbuffers/include` alone).
- `ss_player/SCsub` — remove the `add_source_files` loop (custom module).
- `SConstruct` — remove the `sources_list.extend(...)` call (GDExtension).

### Impact

~757 KB of object code per target is no longer built, on every platform/arch a release build covers:

| object | size (-O2) |
|---|---|
| `idl_parser.o` | 574 KB |
| `idl_gen_text.o` | 84 KB |
| `reflection.o` | 70 KB |
| `util.o` | 30 KB |

Stale objects from earlier builds confirmed this was being paid across 7 targets already (macOS editor, 3 Android ABIs, 3 iOS slices) — 28 objects, 5.0 MB.

No functional change.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

Build cleanup — none of the above categories apply.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation — n/a, no documented behaviour changes
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules — n/a

## Verification

Both build paths were built locally on macOS arm64:

**GDExtension** (`./scripts/build-extension.sh`) — builds and links clean.

```
libSSGodot.macos.editor          4,538,936 bytes
undefined flatbuffers symbols    0  (fully resolved)
flatc-side symbols in binary     0  (Parser / GenerateText / Registry)
```

**Custom module** (`./scripts/build.sh`) — `godot.macos.editor.arm64` links successfully (2m32s). `flatbuffers::` symbols in the binary: **0**, as expected for header-only, fully-inlined use.

The `duplicate symbol` link warnings (Rust runtime symbols shared between `libssruntime.a` and `libssconverter.a`) are pre-existing and identical before and after this change.
