### PR TITLE
feat(player): give SpriteStudioPlayer2D real enums and ClassDB properties

### DIFF
--- a/docs/en/api/player.md
+++ b/docs/en/api/player.md
@@ -28,7 +28,7 @@ func _ready() -> void:
 * `set_offset(offset: Vector2)` / `get_offset() -> Vector2`: Shifts the drawing position without moving the Node2D's origin.
 * `set_flip_h(flip: bool)` / `is_flipped_h() -> bool`: Flips the animation horizontally.
 * `set_flip_v(flip: bool)` / `is_flipped_v() -> bool`: Flips the animation vertically.
-* `set_animation_process_mode(mode: int)` / `get_animation_process_mode() -> int`: Sets whether to sync with `_physics_process` (`0` / Physics) or `_process` (`1` / Idle).
+* `set_animation_process_mode(mode: AnimationProcessMode)` / `get_animation_process_mode() -> AnimationProcessMode`: Sets whether to sync with `_physics_process` (`ANIMATION_PROCESS_PHYSICS` / `0`) or `_process` (`ANIMATION_PROCESS_IDLE` / `1`).
 * **In-editor preview**: Select the node and use the **SpriteStudio** bottom panel (play / pause / stop / frame scrubber) to preview without running the game. *(The former `editor_playing` inspector toggle has been replaced by this panel.)*
 * `play(start_frame: float = -1.0)`: Starts playback. If `start_frame` is `-1.0`, it plays from the current frame or the start of the section.
 * `pause()`: Pauses playback while retaining the current frame.
@@ -38,7 +38,8 @@ func _ready() -> void:
 * `set_speed_scale(speed_scale: float)` / `get_speed_scale() -> float`
 * `set_frame_rate(fps: int)` / `get_frame_rate() -> int`
 * `set_animation_section(start: int, end: int)`: Limits the playback to a specific frame range.
-* `set_playback_direction(direction: int, style: int)`: Sets the playback direction and style. See the table below for values.
+* `set_animation_section_start(start: int)` / `get_animation_section_start() -> int` / `set_animation_section_end(end: int)` / `get_animation_section_end() -> int`: Moves one endpoint of the section while keeping the other. These back the `animation_section_start` / `animation_section_end` inspector properties.
+* `set_playback_direction(direction: PlaybackDirection, style: PlaybackStyle)`: Sets the playback direction and style. See the table below for values.
 * `set_loop_count(count: int)` / `get_loop_count() -> int`: `n` plays `n` cycles then stops (`1` plays once). `-1` means infinite loop (`0` is an alias for infinite).
 * `set_frame_skip_enabled(enabled: bool)` / `is_frame_skip_enabled() -> bool` (default: `true`)
 * `set_sub_frame_enabled(enabled: bool)` / `is_sub_frame_enabled() -> bool` (default: `false`)
@@ -47,12 +48,12 @@ func _ready() -> void:
 
 ### Arguments for `set_playback_direction`
 
-| Argument | Value | Meaning |
-| --- | --- | --- |
-| `direction` | `0` | Forward |
-| `direction` | `1` | Backward |
-| `style` | `0` | Normal / One-way |
-| `style` | `1` | PingPong (Round-trip) |
+| Argument | Constant | Value | Meaning |
+| --- | --- | --- | --- |
+| `direction` | `PLAYBACK_DIRECTION_FORWARD` | `0` | Forward |
+| `direction` | `PLAYBACK_DIRECTION_BACKWARD` | `1` | Backward |
+| `style` | `PLAYBACK_STYLE_NORMAL` | `0` | Normal / One-way |
+| `style` | `PLAYBACK_STYLE_PING_PONG` | `1` | PingPong (Round-trip) |
 
 ## Part queries
 
@@ -67,9 +68,9 @@ See [Scripting and Event-Driven Control → Part Tracking](../workflow/usage_scr
 
 Override a single part's color / cell / visibility so that it wins over the keyframes. Every method returns `true` on success, or `false` when the part is unknown or the runtime rejects the call. See [Scripting and Event-Driven Control → Part Overrides](../workflow/usage_scripting.md) for the details and caveats.
 
-* `set_part_color_override(part_name: String, color: Color, blend_op: int = 0, priority: int = 1) -> bool`
-* `set_part_color_override_corners(part_name: String, left_top: Color, right_top: Color, left_bottom: Color, right_bottom: Color, blend_op: int = 0, priority: int = 1) -> bool`: Four-corner (per-vertex) colour, for a gradient across the part. Shares one override slot with `set_part_color_override` — the last call wins, and `clear_part_color_override` clears either kind.
-* `set_part_cell_override(part_name: String, cellmap_name: String, cell_name: String, priority: int = 1) -> bool`
+* `set_part_color_override(part_name: String, color: Color, blend_op: ColorBlendOperation = COLOR_BLEND_MIX, priority: OverridePriority = OVERRIDE_PRIORITY_UNTIL_ANIMATION_CHANGE) -> bool`
+* `set_part_color_override_corners(part_name: String, left_top: Color, right_top: Color, left_bottom: Color, right_bottom: Color, blend_op: ColorBlendOperation = COLOR_BLEND_MIX, priority: OverridePriority = OVERRIDE_PRIORITY_UNTIL_ANIMATION_CHANGE) -> bool`: Four-corner (per-vertex) colour, for a gradient across the part. Shares one override slot with `set_part_color_override` — the last call wins, and `clear_part_color_override` clears either kind.
+* `set_part_cell_override(part_name: String, cellmap_name: String, cell_name: String, priority: OverridePriority = OVERRIDE_PRIORITY_UNTIL_ANIMATION_CHANGE) -> bool`
 * `set_part_visibility_override(part_name: String, force_hidden: bool, cascade: bool = false) -> bool`
 * `clear_part_color_override(part_name: String) -> bool` / `clear_part_cell_override(part_name: String) -> bool` / `clear_part_visibility_override(part_name: String) -> bool`
 * `clear_all_part_overrides() -> bool`
@@ -77,20 +78,20 @@ Override a single part's color / cell / visibility so that it wins over the keyf
 
 ### Values for `blend_op`
 
-| Value | Blend operation |
-| --- | --- |
-| `0` | Mix (default) |
-| `1` | Mul (multiply) |
-| `2` | Add |
-| `3` | Sub (subtract) |
+| Constant | Value | Blend operation |
+| --- | --- | --- |
+| `COLOR_BLEND_MIX` | `0` | Mix (default) |
+| `COLOR_BLEND_MUL` | `1` | Mul (multiply) |
+| `COLOR_BLEND_ADD` | `2` | Add |
+| `COLOR_BLEND_SUB` | `3` | Sub (subtract) |
 
 ### Values for `priority`
 
-| Value | Priority mode | Meaning |
+| Constant | Value | Meaning |
 | --- | --- | --- |
-| `0` | OverwriteOnNextKeyframe | Applies until the animation updates that attribute |
-| `1` | HoldUntilNextAnimation (default) | Applies for the current animation; cleared when a new animation is set up |
-| `2` | Permanent | Applies for as long as the same `.ssab` is playing, surviving animation changes |
+| `OVERRIDE_PRIORITY_NEXT_KEYFRAME` | `0` | Applies until the animation updates that attribute |
+| `OVERRIDE_PRIORITY_UNTIL_ANIMATION_CHANGE` | `1` | Applies for the current animation; cleared when a new animation is set up (default) |
+| `OVERRIDE_PRIORITY_PERMANENT` | `2` | Applies for as long as the same `.ssab` is playing, surviving animation changes |
 
 > [!NOTE]
 > `set_part_visibility_override` has no `priority`. It always wins over the keyframes and is always cleared when a new animation is set up.

--- a/docs/en/workflow/usage_scripting.md
+++ b/docs/en/workflow/usage_scripting.md
@@ -210,9 +210,9 @@ func _ready():
 | Method | Description |
 |---|---|
 | `get_part_index(part_name)` | Part index, or `-1` if the part is not in the asset |
-| `set_part_color_override(part_name, color, blend_op = 0, priority = 1)` | Color override (single color) |
-| `set_part_color_override_corners(part_name, left_top, right_top, left_bottom, right_bottom, blend_op = 0, priority = 1)` | Color override with a distinct color per corner (gradient) |
-| `set_part_cell_override(part_name, cellmap_name, cell_name, priority = 1)` | Draw a different cell |
+| `set_part_color_override(part_name, color, blend_op = COLOR_BLEND_MIX, priority = OVERRIDE_PRIORITY_UNTIL_ANIMATION_CHANGE)` | Color override (single color) |
+| `set_part_color_override_corners(part_name, left_top, right_top, left_bottom, right_bottom, blend_op = COLOR_BLEND_MIX, priority = OVERRIDE_PRIORITY_UNTIL_ANIMATION_CHANGE)` | Color override with a distinct color per corner (gradient) |
+| `set_part_cell_override(part_name, cellmap_name, cell_name, priority = OVERRIDE_PRIORITY_UNTIL_ANIMATION_CHANGE)` | Draw a different cell |
 | `set_part_visibility_override(part_name, force_hidden, cascade = false)` | Force-hide (`force_hidden = false` reverts to the animation) |
 | `clear_part_color_override` / `clear_part_cell_override` / `clear_part_visibility_override` | Clear one override on one part |
 | `clear_all_part_overrides()` | Clear every override on the player |
@@ -237,12 +237,12 @@ Both read the bound `SSABResource` and return an empty array when none is assign
 
 The `blend_op` of `set_part_color_override()` offers the same four operations as the keyframed Part Color.
 
-| Value | Blend operation |
-|---|---|
-| `0` | Mix (default) |
-| `1` | Mul (multiply) |
-| `2` | Add |
-| `3` | Sub (subtract) |
+| Constant | Value | Blend operation |
+|---|---|---|
+| `COLOR_BLEND_MIX` | `0` | Mix (default) |
+| `COLOR_BLEND_MUL` | `1` | Mul (multiply) |
+| `COLOR_BLEND_ADD` | `2` | Add |
+| `COLOR_BLEND_SUB` | `3` | Sub (subtract) |
 
 An out-of-range value fails the call and returns `false`.
 
@@ -250,11 +250,11 @@ An out-of-range value fails the call and returns `false`.
 
 Color and cell overrides conflict with the animation, so they take a `priority` (visibility does not — it is a plain force-hide flag, and any new animation clears it):
 
-| Value | Priority mode | Behavior |
+| Constant | Value | Behavior |
 |---|---|---|
-| `0` | OverwriteOnNextKeyframe | The override applies until the animation data updates that attribute |
-| `1` | HoldUntilNextAnimation (default) | The override wins for the current animation and is cleared when a new animation is set up |
-| `2` | Permanent | The override applies for as long as the same animation data (`.ssab`) is playing, surviving animation changes |
+| `OVERRIDE_PRIORITY_NEXT_KEYFRAME` | `0` | The override applies until the animation data updates that attribute |
+| `OVERRIDE_PRIORITY_UNTIL_ANIMATION_CHANGE` | `1` | The override wins for the current animation and is cleared when a new animation is set up (default) |
+| `OVERRIDE_PRIORITY_PERMANENT` | `2` | The override applies for as long as the same animation data (`.ssab`) is playing, surviving animation changes |
 
 ### Notes
 

--- a/docs/ja/api/player.md
+++ b/docs/ja/api/player.md
@@ -28,7 +28,7 @@ func _ready() -> void:
 * `set_offset(offset: Vector2)` / `get_offset() -> Vector2`: Node2D の原点を動かさずに描画位置だけをずらします。
 * `set_flip_h(flip: bool)` / `is_flipped_h() -> bool`: 水平反転。
 * `set_flip_v(flip: bool)` / `is_flipped_v() -> bool`: 垂直反転。
-* `set_animation_process_mode(mode: int)` / `get_animation_process_mode() -> int`: `0` で Physics (`_physics_process`) 同期、`1` で Idle (`_process`) 同期。
+* `set_animation_process_mode(mode: AnimationProcessMode)` / `get_animation_process_mode() -> AnimationProcessMode`: `ANIMATION_PROCESS_PHYSICS`（`0`）で Physics (`_physics_process`) 同期、`ANIMATION_PROCESS_IDLE`（`1`）で Idle (`_process`) 同期。
 * **エディタ内プレビュー**: ノードを選択すると表示される **SpriteStudio** ボトムパネル（再生 / 一時停止 / 停止 / フレームスクラバ）でゲームを実行せずにプレビューできます。*(旧 `editor_playing` インスペクタトグルはこのパネルに置き換えられました。)*
 * `play(start_frame: float = -1.0)`: 再生を開始します。`-1.0` を指定した場合は、現在のフレームまたは区間の先頭から再生します。
 * `pause()`: 再生を一時停止します。
@@ -38,7 +38,8 @@ func _ready() -> void:
 * `set_speed_scale(speed_scale: float)` / `get_speed_scale() -> float`
 * `set_frame_rate(fps: int)` / `get_frame_rate() -> int`
 * `set_animation_section(start: int, end: int)`: 再生するフレーム区間を限定します。
-* `set_playback_direction(direction: int, style: int)`: 再生方向と再生スタイルを指定します。値の意味は下表を参照してください。
+* `set_animation_section_start(start: int)` / `get_animation_section_start() -> int` / `set_animation_section_end(end: int)` / `get_animation_section_end() -> int`: 片方の端点だけを移動します（もう一方は維持）。インスペクタの `animation_section_start` / `animation_section_end` プロパティの実体です。
+* `set_playback_direction(direction: PlaybackDirection, style: PlaybackStyle)`: 再生方向と再生スタイルを指定します。値の意味は下表を参照してください。
 * `set_loop_count(count: int)` / `get_loop_count() -> int`: `n` で `n` 回再生して停止（`1` なら1回のみ）。`-1` で無限ループ（`0` も無限ループの別名）。
 * `set_frame_skip_enabled(enabled: bool)` / `is_frame_skip_enabled() -> bool` (デフォルト: `true`)
 * `set_sub_frame_enabled(enabled: bool)` / `is_sub_frame_enabled() -> bool` (デフォルト: `false`)
@@ -47,12 +48,12 @@ func _ready() -> void:
 
 ### `set_playback_direction` の引数
 
-| 引数 | 値 | 意味 |
-| --- | --- | --- |
-| `direction` | `0` | 順再生 (Forward) |
-| `direction` | `1` | 逆再生 (Backward) |
-| `style` | `0` | 通常 / 片道 (Normal) |
-| `style` | `1` | 往復再生 (PingPong) |
+| 引数 | 定数 | 値 | 意味 |
+| --- | --- | --- | --- |
+| `direction` | `PLAYBACK_DIRECTION_FORWARD` | `0` | 順再生 (Forward) |
+| `direction` | `PLAYBACK_DIRECTION_BACKWARD` | `1` | 逆再生 (Backward) |
+| `style` | `PLAYBACK_STYLE_NORMAL` | `0` | 通常 / 片道 (Normal) |
+| `style` | `PLAYBACK_STYLE_PING_PONG` | `1` | 往復再生 (PingPong) |
 
 ## パーツの参照
 
@@ -67,9 +68,9 @@ func _ready() -> void:
 
 パーツ単位で、カラー / セル / 表示指定をキーフレームより優先して上書きします。各メソッドは成功時に `true`、パーツが不明な場合やランタイムが受け付けなかった場合に `false` を返します。詳細と注意点は [スクリプト制御とイベント → パーツオーバーライド](../workflow/usage_scripting.md) を参照してください。
 
-* `set_part_color_override(part_name: String, color: Color, blend_op: int = 0, priority: int = 1) -> bool`
-* `set_part_color_override_corners(part_name: String, left_top: Color, right_top: Color, left_bottom: Color, right_bottom: Color, blend_op: int = 0, priority: int = 1) -> bool`: 4 頂点それぞれに色を指定して、パーツ内をグラデーションにします。`set_part_color_override` と同じオーバーライド枠を共有するので、後から呼んだ方が有効になり、`clear_part_color_override` はどちらも解除します。
-* `set_part_cell_override(part_name: String, cellmap_name: String, cell_name: String, priority: int = 1) -> bool`
+* `set_part_color_override(part_name: String, color: Color, blend_op: ColorBlendOperation = COLOR_BLEND_MIX, priority: OverridePriority = OVERRIDE_PRIORITY_UNTIL_ANIMATION_CHANGE) -> bool`
+* `set_part_color_override_corners(part_name: String, left_top: Color, right_top: Color, left_bottom: Color, right_bottom: Color, blend_op: ColorBlendOperation = COLOR_BLEND_MIX, priority: OverridePriority = OVERRIDE_PRIORITY_UNTIL_ANIMATION_CHANGE) -> bool`: 4 頂点それぞれに色を指定して、パーツ内をグラデーションにします。`set_part_color_override` と同じオーバーライド枠を共有するので、後から呼んだ方が有効になり、`clear_part_color_override` はどちらも解除します。
+* `set_part_cell_override(part_name: String, cellmap_name: String, cell_name: String, priority: OverridePriority = OVERRIDE_PRIORITY_UNTIL_ANIMATION_CHANGE) -> bool`
 * `set_part_visibility_override(part_name: String, force_hidden: bool, cascade: bool = false) -> bool`
 * `clear_part_color_override(part_name: String) -> bool` / `clear_part_cell_override(part_name: String) -> bool` / `clear_part_visibility_override(part_name: String) -> bool`
 * `clear_all_part_overrides() -> bool`
@@ -77,20 +78,20 @@ func _ready() -> void:
 
 ### `blend_op` の値
 
-| 値 | 合成モード |
-| --- | --- |
-| `0` | Mix（既定） |
-| `1` | Mul（乗算） |
-| `2` | Add（加算） |
-| `3` | Sub（減算） |
+| 定数 | 値 | 合成モード |
+| --- | --- | --- |
+| `COLOR_BLEND_MIX` | `0` | Mix（既定） |
+| `COLOR_BLEND_MUL` | `1` | Mul（乗算） |
+| `COLOR_BLEND_ADD` | `2` | Add（加算） |
+| `COLOR_BLEND_SUB` | `3` | Sub（減算） |
 
 ### `priority` の値
 
-| 値 | 優先モード | 意味 |
+| 定数 | 値 | 意味 |
 | --- | --- | --- |
-| `0` | OverwriteOnNextKeyframe | アニメーションが当該アトリビュートを更新するまで適用 |
-| `1` | HoldUntilNextAnimation（既定） | 現在のアニメーション中は適用され、アニメーション変更で解除 |
-| `2` | Permanent | 同じ `.ssab` を再生している間は適用（アニメーション変更をまたいで持続） |
+| `OVERRIDE_PRIORITY_NEXT_KEYFRAME` | `0` | アニメーションが当該アトリビュートを更新するまで適用 |
+| `OVERRIDE_PRIORITY_UNTIL_ANIMATION_CHANGE` | `1` | 現在のアニメーション中は適用され、アニメーション変更で解除（既定） |
+| `OVERRIDE_PRIORITY_PERMANENT` | `2` | 同じ `.ssab` を再生している間は適用（アニメーション変更をまたいで持続） |
 
 > [!NOTE]
 > 表示指定（`set_part_visibility_override`）に `priority` はありません。常にキーフレームに勝ち、アニメーションを設定し直すと必ずクリアされます。

--- a/docs/ja/workflow/usage_scripting.md
+++ b/docs/ja/workflow/usage_scripting.md
@@ -210,9 +210,9 @@ func _ready():
 | メソッド | 説明 |
 |---|---|
 | `get_part_index(part_name)` | パーツインデックス。アセットに無ければ `-1` |
-| `set_part_color_override(part_name, color, blend_op = 0, priority = 1)` | パーツカラーオーバーライド（単色） |
-| `set_part_color_override_corners(part_name, left_top, right_top, left_bottom, right_bottom, blend_op = 0, priority = 1)` | パーツカラーオーバーライド（4 頂点それぞれに色を指定＝グラデーション） |
-| `set_part_cell_override(part_name, cellmap_name, cell_name, priority = 1)` | 別のセルで描画する |
+| `set_part_color_override(part_name, color, blend_op = COLOR_BLEND_MIX, priority = OVERRIDE_PRIORITY_UNTIL_ANIMATION_CHANGE)` | パーツカラーオーバーライド（単色） |
+| `set_part_color_override_corners(part_name, left_top, right_top, left_bottom, right_bottom, blend_op = COLOR_BLEND_MIX, priority = OVERRIDE_PRIORITY_UNTIL_ANIMATION_CHANGE)` | パーツカラーオーバーライド（4 頂点それぞれに色を指定＝グラデーション） |
+| `set_part_cell_override(part_name, cellmap_name, cell_name, priority = OVERRIDE_PRIORITY_UNTIL_ANIMATION_CHANGE)` | 別のセルで描画する |
 | `set_part_visibility_override(part_name, force_hidden, cascade = false)` | 強制非表示（`force_hidden = false` でアニメーションに戻す） |
 | `clear_part_color_override` / `clear_part_cell_override` / `clear_part_visibility_override` | 1 パーツの 1 オーバーライドを解除 |
 | `clear_all_part_overrides()` | そのプレーヤの全オーバーライドを解除 |
@@ -237,12 +237,12 @@ print(ss_player.get_cell_names("Ringo"))    # → ["effect3", ...]
 
 `set_part_color_override()` の `blend_op` は、キーフレームのパーツカラーと同じ 4 種です。
 
-| 値 | 合成モード |
-|---|---|
-| `0` | Mix（既定） |
-| `1` | Mul（乗算） |
-| `2` | Add（加算） |
-| `3` | Sub（減算） |
+| 定数 | 値 | 合成モード |
+|---|---|---|
+| `COLOR_BLEND_MIX` | `0` | Mix（既定） |
+| `COLOR_BLEND_MUL` | `1` | Mul（乗算） |
+| `COLOR_BLEND_ADD` | `2` | Add（加算） |
+| `COLOR_BLEND_SUB` | `3` | Sub（減算） |
 
 範囲外の値を渡した場合は設定に失敗し、`false` を返します。
 
@@ -250,11 +250,11 @@ print(ss_player.get_cell_names("Ringo"))    # → ["effect3", ...]
 
 パーツカラーとセルのオーバーライドはアニメーションと競合するため、`priority` を取ります（表示指定にはありません。単なる強制非表示フラグで、アニメーションを設定し直すと必ずクリアされます）。
 
-| 値 | 優先モード | 挙動 |
+| 定数 | 値 | 挙動 |
 |---|---|---|
-| `0` | OverwriteOnNextKeyframe | アニメーションデータが当該アトリビュートを更新するまで、オーバーライドが適用される |
-| `1` | HoldUntilNextAnimation（既定） | 現在のアニメーション中は勝ち続け、新しいアニメーションを設定するとオーバーライドが解除される |
-| `2` | Permanent | 同じアニメーションデータ（`.ssab`）である間、オーバーライドが適用される（アニメーション変更をまたいでも持続） |
+| `OVERRIDE_PRIORITY_NEXT_KEYFRAME` | `0` | アニメーションデータが当該アトリビュートを更新するまで、オーバーライドが適用される |
+| `OVERRIDE_PRIORITY_UNTIL_ANIMATION_CHANGE` | `1` | 現在のアニメーション中は勝ち続け、新しいアニメーションを設定するとオーバーライドが解除される（既定） |
+| `OVERRIDE_PRIORITY_PERMANENT` | `2` | 同じアニメーションデータ（`.ssab`）である間、オーバーライドが適用される（アニメーション変更をまたいでも持続） |
 
 ### 注意点
 

--- a/ss_player/doc_classes/SpriteStudioPlayer2D.xml
+++ b/ss_player/doc_classes/SpriteStudioPlayer2D.xml
@@ -58,10 +58,10 @@
 		</method>
 		<method name="set_playback_direction">
 			<return type="void" />
-			<param index="0" name="direction" type="int" />
-			<param index="1" name="style" type="int" />
+			<param index="0" name="direction" type="int" enum="SpriteStudioPlayer2D.PlaybackDirection" />
+			<param index="1" name="style" type="int" enum="SpriteStudioPlayer2D.PlaybackStyle" />
 			<description>
-				Sets the playback direction ([code]0[/code] = forward, non-zero = backward) and style ([code]0[/code] = normal, [code]1[/code] = ping-pong).
+				Sets the playback direction and style.
 			</description>
 		</method>
 		<method name="set_cellmap_texture">
@@ -92,10 +92,10 @@
 			<param index="2" name="right_top" type="Color" />
 			<param index="3" name="left_bottom" type="Color" />
 			<param index="4" name="right_bottom" type="Color" />
-			<param index="5" name="blend_op" type="int" default="0" />
-			<param index="6" name="priority" type="int" default="1" />
+			<param index="5" name="blend_op" type="int" enum="SpriteStudioPlayer2D.ColorBlendOperation" default="0" />
+			<param index="6" name="priority" type="int" enum="SpriteStudioPlayer2D.OverridePriority" default="1" />
 			<description>
-				Overrides a part's color with a distinct color per corner, producing a gradient across the part. [param blend_op] is [code]0[/code] = Mix, [code]1[/code] = Mul, [code]2[/code] = Add, [code]3[/code] = Sub; [param priority] is [code]0[/code] = until the animation updates the attribute, [code]1[/code] = until the next animation is set up, [code]2[/code] = permanent.
+				Overrides a part's color with a distinct color per corner, producing a gradient across the part. See [enum ColorBlendOperation] and [enum OverridePriority] for [param blend_op] and [param priority].
 				Shares one override slot with [method set_part_color_override], so the last call wins and [method clear_part_color_override] clears either kind. Returns [code]false[/code] when the part is unknown or the runtime rejects the call.
 			</description>
 		</method>
@@ -120,7 +120,13 @@
 			If [code]true[/code], the animation is flipped vertically.
 		</member>
 		<member name="animation_process_mode" type="int" enum="SpriteStudioPlayer2D.AnimationProcessMode" default="1">
-			Determines whether to advance the animation in [code]_physics_process[/code] ([code]0[/code] / Physics) or [code]_process[/code] ([code]1[/code] / Idle). Use Physics if the parent node moves using the physics engine to avoid jitter.
+			Determines whether to advance the animation in [code]_physics_process[/code] ([constant ANIMATION_PROCESS_PHYSICS]) or [code]_process[/code] ([constant ANIMATION_PROCESS_IDLE]). Use Physics if the parent node moves using the physics engine to avoid jitter.
+		</member>
+		<member name="animation_section_start" type="int">
+			First frame of the played section, inclusive. Setting it keeps [member animation_section_end]; use [method set_animation_section] to move both endpoints at once.
+		</member>
+		<member name="animation_section_end" type="int">
+			Last frame of the played section, inclusive. Setting it keeps [member animation_section_start]; use [method set_animation_section] to move both endpoints at once.
 		</member>
 		<member name="frame" type="float">
 			Current playback frame (editor-only display). Can be keyframed from an [AnimationPlayer] to drive playback from a timeline.
@@ -207,6 +213,39 @@
 		</constant>
 		<constant name="ANIMATION_PROCESS_IDLE" value="1" enum="AnimationProcessMode">
 			Syncs animation to [code]_process[/code] frame.
+		</constant>
+		<constant name="PLAYBACK_DIRECTION_FORWARD" value="0" enum="PlaybackDirection">
+			Plays the animation from the section start towards its end.
+		</constant>
+		<constant name="PLAYBACK_DIRECTION_BACKWARD" value="1" enum="PlaybackDirection">
+			Plays the animation from the section end towards its start. Audio parts do not fire while playing backwards.
+		</constant>
+		<constant name="PLAYBACK_STYLE_NORMAL" value="0" enum="PlaybackStyle">
+			Each loop restarts from the same end of the section.
+		</constant>
+		<constant name="PLAYBACK_STYLE_PING_PONG" value="1" enum="PlaybackStyle">
+			Playback reverses at each end of the section instead of restarting.
+		</constant>
+		<constant name="COLOR_BLEND_MIX" value="0" enum="ColorBlendOperation">
+			Blends the override color over the part's color.
+		</constant>
+		<constant name="COLOR_BLEND_MUL" value="1" enum="ColorBlendOperation">
+			Multiplies the part's color by the override color.
+		</constant>
+		<constant name="COLOR_BLEND_ADD" value="2" enum="ColorBlendOperation">
+			Adds the override color to the part's color.
+		</constant>
+		<constant name="COLOR_BLEND_SUB" value="3" enum="ColorBlendOperation">
+			Subtracts the override color from the part's color.
+		</constant>
+		<constant name="OVERRIDE_PRIORITY_NEXT_KEYFRAME" value="0" enum="OverridePriority">
+			The override is dropped as soon as the animation next keys the attribute.
+		</constant>
+		<constant name="OVERRIDE_PRIORITY_UNTIL_ANIMATION_CHANGE" value="1" enum="OverridePriority">
+			The override is held until another animation is set up. This is the default.
+		</constant>
+		<constant name="OVERRIDE_PRIORITY_PERMANENT" value="2" enum="OverridePriority">
+			The override survives animation changes and is only removed by an explicit clear.
 		</constant>
 	</constants>
 </class>

--- a/ss_player/ss_playback_panel.cpp
+++ b/ss_player/ss_playback_panel.cpp
@@ -308,7 +308,7 @@ void SSPlaybackPanel::_on_play_start_pressed() {
     if (!_player) {
         return;
     }
-    _player->setPlaybackDirection(0, _player->getPlaybackStyle());
+    _player->setPlaybackDirection(SpriteStudioPlayer2D::PLAYBACK_DIRECTION_FORWARD, _player->getPlaybackStyle());
     _player->play(0.0f);
 }
 

--- a/ss_player/ss_player_node_2d.cpp
+++ b/ss_player/ss_player_node_2d.cpp
@@ -215,22 +215,22 @@ bool SpriteStudioPlayer2D::clear_part_visibility_override_by_index(int part_inde
     return _internal->clear_part_visibility_override(part_index);
 }
 
-bool SpriteStudioPlayer2D::set_part_color_override_by_index(int part_index, const Color& color, int blend_op, int priority) {
-    return _internal->set_part_color_override(part_index, color, blend_op, priority);
+bool SpriteStudioPlayer2D::set_part_color_override_by_index(int part_index, const Color& color, ColorBlendOperation blend_op, OverridePriority priority) {
+    return _internal->set_part_color_override(part_index, color, (int)blend_op, (int)priority);
 }
 
 bool SpriteStudioPlayer2D::set_part_color_override_corners_by_index(int part_index, const Color& left_top, const Color& right_top,
                                                                     const Color& left_bottom, const Color& right_bottom,
-                                                                    int blend_op, int priority) {
-    return _internal->set_part_color_override_corners(part_index, left_top, right_top, left_bottom, right_bottom, blend_op, priority);
+                                                                    ColorBlendOperation blend_op, OverridePriority priority) {
+    return _internal->set_part_color_override_corners(part_index, left_top, right_top, left_bottom, right_bottom, (int)blend_op, (int)priority);
 }
 
 bool SpriteStudioPlayer2D::clear_part_color_override_by_index(int part_index) {
     return _internal->clear_part_color_override(part_index);
 }
 
-bool SpriteStudioPlayer2D::set_part_cell_override_by_index(int part_index, const String& cellmap_name, const String& cell_name, int priority) {
-    return _internal->set_part_cell_override(part_index, cellmap_name, cell_name, priority);
+bool SpriteStudioPlayer2D::set_part_cell_override_by_index(int part_index, const String& cellmap_name, const String& cell_name, OverridePriority priority) {
+    return _internal->set_part_cell_override(part_index, cellmap_name, cell_name, (int)priority);
 }
 
 bool SpriteStudioPlayer2D::clear_part_cell_override_by_index(int part_index) {
@@ -248,13 +248,13 @@ bool SpriteStudioPlayer2D::clear_part_visibility_override(const String& part_nam
     return clear_part_visibility_override_by_index(_internal->resolve_part_index(part_name));
 }
 
-bool SpriteStudioPlayer2D::set_part_color_override(const String& part_name, const Color& color, int blend_op, int priority) {
+bool SpriteStudioPlayer2D::set_part_color_override(const String& part_name, const Color& color, ColorBlendOperation blend_op, OverridePriority priority) {
     return set_part_color_override_by_index(_internal->resolve_part_index(part_name), color, blend_op, priority);
 }
 
 bool SpriteStudioPlayer2D::set_part_color_override_corners(const String& part_name, const Color& left_top, const Color& right_top,
                                                            const Color& left_bottom, const Color& right_bottom,
-                                                           int blend_op, int priority) {
+                                                           ColorBlendOperation blend_op, OverridePriority priority) {
     return set_part_color_override_corners_by_index(_internal->resolve_part_index(part_name), left_top, right_top, left_bottom, right_bottom, blend_op, priority);
 }
 
@@ -262,7 +262,7 @@ bool SpriteStudioPlayer2D::clear_part_color_override(const String& part_name) {
     return clear_part_color_override_by_index(_internal->resolve_part_index(part_name));
 }
 
-bool SpriteStudioPlayer2D::set_part_cell_override(const String& part_name, const String& cellmap_name, const String& cell_name, int priority) {
+bool SpriteStudioPlayer2D::set_part_cell_override(const String& part_name, const String& cellmap_name, const String& cell_name, OverridePriority priority) {
     return set_part_cell_override_by_index(_internal->resolve_part_index(part_name), cellmap_name, cell_name, priority);
 }
 
@@ -380,10 +380,10 @@ void SpriteStudioPlayer2D::_push_host_viewport() {
     _internal->setHostViewport(vp ? vp->get_viewport_rid() : RID());
 }
 
-void SpriteStudioPlayer2D::set_animation_process_mode(int p_mode) {
-    AnimationProcessMode mode = (AnimationProcessMode)p_mode;
+void SpriteStudioPlayer2D::set_animation_process_mode(AnimationProcessMode p_mode) {
+    AnimationProcessMode mode = p_mode;
     if (_process_mode == mode) return;
-    
+
     bool active = is_inside_tree();
     if (active) {
         if (_process_mode == ANIMATION_PROCESS_IDLE) {
@@ -404,7 +404,7 @@ void SpriteStudioPlayer2D::set_animation_process_mode(int p_mode) {
     }
 }
 
-int SpriteStudioPlayer2D::get_animation_process_mode() const { return (int)_process_mode; }
+SpriteStudioPlayer2D::AnimationProcessMode SpriteStudioPlayer2D::get_animation_process_mode() const { return _process_mode; }
 
 void SpriteStudioPlayer2D::setSpeedScale(float p_speed) { _internal->setSpeed(p_speed); }
 float SpriteStudioPlayer2D::getSpeedScale() const { return _internal->getSpeed(); }
@@ -421,12 +421,14 @@ int SpriteStudioPlayer2D::getStartFrame() const { return _internal->getAnimation
 int SpriteStudioPlayer2D::getEndFrame() const { return _internal->getAnimationSectionEnd(); }
 
 void SpriteStudioPlayer2D::setAnimationSection(int p_start, int p_end) { _internal->setAnimationSection(p_start, p_end); }
+void SpriteStudioPlayer2D::setAnimationSectionStart(int p_start) { setAnimationSection(p_start, getAnimationSectionEnd()); }
+void SpriteStudioPlayer2D::setAnimationSectionEnd(int p_end) { setAnimationSection(getAnimationSectionStart(), p_end); }
 int SpriteStudioPlayer2D::getAnimationSectionStart() const { return _internal->getAnimationSectionStart(); }
 int SpriteStudioPlayer2D::getAnimationSectionEnd() const { return _internal->getAnimationSectionEnd(); }
 
-void SpriteStudioPlayer2D::setPlaybackDirection(int p_direction, int p_style) { _internal->setPlaybackDirection(p_direction, p_style); }
-int SpriteStudioPlayer2D::getPlaybackDirection() const { return _internal->getPlaybackDirection(); }
-int SpriteStudioPlayer2D::getPlaybackStyle() const { return _internal->getPlaybackStyle(); }
+void SpriteStudioPlayer2D::setPlaybackDirection(PlaybackDirection p_direction, PlaybackStyle p_style) { _internal->setPlaybackDirection((int)p_direction, (int)p_style); }
+SpriteStudioPlayer2D::PlaybackDirection SpriteStudioPlayer2D::getPlaybackDirection() const { return (PlaybackDirection)_internal->getPlaybackDirection(); }
+SpriteStudioPlayer2D::PlaybackStyle SpriteStudioPlayer2D::getPlaybackStyle() const { return (PlaybackStyle)_internal->getPlaybackStyle(); }
 
 void SpriteStudioPlayer2D::setLoopCount(int p_count) { _internal->setLoop(p_count); }
 int SpriteStudioPlayer2D::getLoopCount() const { return _internal->getLoop(); }
@@ -466,6 +468,8 @@ void SpriteStudioPlayer2D::_bind_methods() {
     ClassDB::bind_method( D_METHOD( "get_frame_rate" ), &SpriteStudioPlayer2D::getFrameRate );
 
     ClassDB::bind_method( D_METHOD( "set_animation_section", "start", "end" ), &SpriteStudioPlayer2D::setAnimationSection );
+    ClassDB::bind_method( D_METHOD( "set_animation_section_start", "start" ), &SpriteStudioPlayer2D::setAnimationSectionStart );
+    ClassDB::bind_method( D_METHOD( "set_animation_section_end", "end" ), &SpriteStudioPlayer2D::setAnimationSectionEnd );
     ClassDB::bind_method( D_METHOD( "get_animation_section_start" ), &SpriteStudioPlayer2D::getAnimationSectionStart );
     ClassDB::bind_method( D_METHOD( "get_animation_section_end" ), &SpriteStudioPlayer2D::getAnimationSectionEnd );
 
@@ -498,9 +502,6 @@ void SpriteStudioPlayer2D::_bind_methods() {
     ClassDB::bind_method( D_METHOD( "set_offset", "offset" ), &SpriteStudioPlayer2D::set_offset );
     ClassDB::bind_method( D_METHOD( "get_offset" ), &SpriteStudioPlayer2D::get_offset );
 
-    BIND_CONSTANT( ANIMATION_PROCESS_PHYSICS );
-    BIND_CONSTANT( ANIMATION_PROCESS_IDLE );
-    
     ClassDB::bind_method( D_METHOD( "set_animation_process_mode", "mode" ), &SpriteStudioPlayer2D::set_animation_process_mode );
     ClassDB::bind_method( D_METHOD( "get_animation_process_mode" ), &SpriteStudioPlayer2D::get_animation_process_mode );
 
@@ -517,20 +518,20 @@ void SpriteStudioPlayer2D::_bind_methods() {
     // ---- Override Layer (Phase 2): per-part runtime overrides -------------
     ClassDB::bind_method( D_METHOD( "set_part_visibility_override", "part_name", "force_hidden", "cascade" ), &SpriteStudioPlayer2D::set_part_visibility_override, DEFVAL(false) );
     ClassDB::bind_method( D_METHOD( "clear_part_visibility_override", "part_name" ), &SpriteStudioPlayer2D::clear_part_visibility_override );
-    ClassDB::bind_method( D_METHOD( "set_part_color_override", "part_name", "color", "blend_op", "priority" ), &SpriteStudioPlayer2D::set_part_color_override, DEFVAL(0), DEFVAL(1) );
-    ClassDB::bind_method( D_METHOD( "set_part_color_override_corners", "part_name", "left_top", "right_top", "left_bottom", "right_bottom", "blend_op", "priority" ), &SpriteStudioPlayer2D::set_part_color_override_corners, DEFVAL(0), DEFVAL(1) );
+    ClassDB::bind_method( D_METHOD( "set_part_color_override", "part_name", "color", "blend_op", "priority" ), &SpriteStudioPlayer2D::set_part_color_override, DEFVAL(COLOR_BLEND_MIX), DEFVAL(OVERRIDE_PRIORITY_UNTIL_ANIMATION_CHANGE) );
+    ClassDB::bind_method( D_METHOD( "set_part_color_override_corners", "part_name", "left_top", "right_top", "left_bottom", "right_bottom", "blend_op", "priority" ), &SpriteStudioPlayer2D::set_part_color_override_corners, DEFVAL(COLOR_BLEND_MIX), DEFVAL(OVERRIDE_PRIORITY_UNTIL_ANIMATION_CHANGE) );
     ClassDB::bind_method( D_METHOD( "clear_part_color_override", "part_name" ), &SpriteStudioPlayer2D::clear_part_color_override );
-    ClassDB::bind_method( D_METHOD( "set_part_cell_override", "part_name", "cellmap_name", "cell_name", "priority" ), &SpriteStudioPlayer2D::set_part_cell_override, DEFVAL(1) );
+    ClassDB::bind_method( D_METHOD( "set_part_cell_override", "part_name", "cellmap_name", "cell_name", "priority" ), &SpriteStudioPlayer2D::set_part_cell_override, DEFVAL(OVERRIDE_PRIORITY_UNTIL_ANIMATION_CHANGE) );
     ClassDB::bind_method( D_METHOD( "clear_part_cell_override", "part_name" ), &SpriteStudioPlayer2D::clear_part_cell_override );
     ClassDB::bind_method( D_METHOD( "clear_all_part_overrides" ), &SpriteStudioPlayer2D::clear_all_part_overrides );
 
     // By-index variants
     ClassDB::bind_method( D_METHOD( "set_part_visibility_override_by_index", "part_index", "force_hidden", "cascade" ), &SpriteStudioPlayer2D::set_part_visibility_override_by_index, DEFVAL(false) );
     ClassDB::bind_method( D_METHOD( "clear_part_visibility_override_by_index", "part_index" ), &SpriteStudioPlayer2D::clear_part_visibility_override_by_index );
-    ClassDB::bind_method( D_METHOD( "set_part_color_override_by_index", "part_index", "color", "blend_op", "priority" ), &SpriteStudioPlayer2D::set_part_color_override_by_index, DEFVAL(0), DEFVAL(1) );
-    ClassDB::bind_method( D_METHOD( "set_part_color_override_corners_by_index", "part_index", "left_top", "right_top", "left_bottom", "right_bottom", "blend_op", "priority" ), &SpriteStudioPlayer2D::set_part_color_override_corners_by_index, DEFVAL(0), DEFVAL(1) );
+    ClassDB::bind_method( D_METHOD( "set_part_color_override_by_index", "part_index", "color", "blend_op", "priority" ), &SpriteStudioPlayer2D::set_part_color_override_by_index, DEFVAL(COLOR_BLEND_MIX), DEFVAL(OVERRIDE_PRIORITY_UNTIL_ANIMATION_CHANGE) );
+    ClassDB::bind_method( D_METHOD( "set_part_color_override_corners_by_index", "part_index", "left_top", "right_top", "left_bottom", "right_bottom", "blend_op", "priority" ), &SpriteStudioPlayer2D::set_part_color_override_corners_by_index, DEFVAL(COLOR_BLEND_MIX), DEFVAL(OVERRIDE_PRIORITY_UNTIL_ANIMATION_CHANGE) );
     ClassDB::bind_method( D_METHOD( "clear_part_color_override_by_index", "part_index" ), &SpriteStudioPlayer2D::clear_part_color_override_by_index );
-    ClassDB::bind_method( D_METHOD( "set_part_cell_override_by_index", "part_index", "cellmap_name", "cell_name", "priority" ), &SpriteStudioPlayer2D::set_part_cell_override_by_index, DEFVAL(1) );
+    ClassDB::bind_method( D_METHOD( "set_part_cell_override_by_index", "part_index", "cellmap_name", "cell_name", "priority" ), &SpriteStudioPlayer2D::set_part_cell_override_by_index, DEFVAL(OVERRIDE_PRIORITY_UNTIL_ANIMATION_CHANGE) );
     ClassDB::bind_method( D_METHOD( "clear_part_cell_override_by_index", "part_index" ), &SpriteStudioPlayer2D::clear_part_cell_override_by_index );
 
     ADD_SIGNAL(
@@ -563,71 +564,77 @@ void SpriteStudioPlayer2D::_bind_methods() {
     // mirror a part's pose in the same frame it is rendered.
     ADD_SIGNAL(MethodInfo("frame_updated", PropertyInfo(Variant::FLOAT, "frame_no")));
 
+    // Properties are registered statically so they land in ClassDB (visible to
+    // class_get_property_list and to binding generators). The hints that depend
+    // on the bound resource — the `animation` name list and the frame / section
+    // ranges — are injected per-instance by _validate_property. The order here
+    // is the inspector order; `cellmaps/*` still comes from _get_property_list
+    // because its entries depend on the resource's cell maps.
     ADD_PROPERTY(
         PropertyInfo(Variant::OBJECT, "ssab", PROPERTY_HINT_RESOURCE_TYPE, "SSABResource"),
         "set_ssab_resource",
         "get_ssab_resource"
     );
+    ADD_PROPERTY(PropertyInfo(Variant::STRING, "animation", PROPERTY_HINT_ENUM, ""), "set_animation", "get_animation");
+    ADD_PROPERTY(PropertyInfo(Variant::BOOL, "autoplay"), "set_autoplay", "is_autoplay");
+    // Editor-only (never stored): the playhead is runtime state, but it stays in
+    // the property list so an AnimationPlayer can keyframe it.
+    ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "frame", PROPERTY_HINT_RANGE, "0,0,0.01", PROPERTY_USAGE_EDITOR), "set_frame", "get_frame");
+    ADD_PROPERTY(PropertyInfo(Variant::INT, "loop_count", PROPERTY_HINT_RANGE, "-1,9999,1,or_greater"), "set_loop_count", "get_loop_count");
+    ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "speed_scale", PROPERTY_HINT_RANGE, "0,4,0.01,or_greater"), "set_speed_scale", "get_speed_scale");
+
+    ADD_GROUP("Playback Options", "");
+    ADD_PROPERTY(PropertyInfo(Variant::BOOL, "frame_skip_enabled"), "set_frame_skip_enabled", "is_frame_skip_enabled");
+    ADD_PROPERTY(PropertyInfo(Variant::BOOL, "sub_frame_enabled"), "set_sub_frame_enabled", "is_sub_frame_enabled");
+    ADD_PROPERTY(PropertyInfo(Variant::INT, "animation_process_mode", PROPERTY_HINT_ENUM, "Physics,Idle"), "set_animation_process_mode", "get_animation_process_mode");
+
+    ADD_GROUP("Section", "");
+    ADD_PROPERTY(PropertyInfo(Variant::INT, "animation_section_start", PROPERTY_HINT_RANGE, "0,0,1"), "set_animation_section_start", "get_animation_section_start");
+    ADD_PROPERTY(PropertyInfo(Variant::INT, "animation_section_end", PROPERTY_HINT_RANGE, "0,0,1"), "set_animation_section_end", "get_animation_section_end");
+
+    ADD_GROUP("Offset", "");
+    ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "offset"), "set_offset", "get_offset");
+    ADD_PROPERTY(PropertyInfo(Variant::BOOL, "flip_h"), "set_flip_h", "is_flipped_h");
+    ADD_PROPERTY(PropertyInfo(Variant::BOOL, "flip_v"), "set_flip_v", "is_flipped_v");
+
+    ADD_GROUP("Audio", "");
+    ADD_PROPERTY(PropertyInfo(Variant::BOOL, "play_audio"), "set_play_audio", "is_play_audio");
+    ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "audio_volume", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_audio_volume", "get_audio_volume");
+    ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "audio_backend", PROPERTY_HINT_RESOURCE_TYPE, "SpriteStudioAudioBackend"), "set_audio_backend", "get_audio_backend");
+
+    BIND_ENUM_CONSTANT(ANIMATION_PROCESS_PHYSICS);
+    BIND_ENUM_CONSTANT(ANIMATION_PROCESS_IDLE);
+
+    BIND_ENUM_CONSTANT(PLAYBACK_DIRECTION_FORWARD);
+    BIND_ENUM_CONSTANT(PLAYBACK_DIRECTION_BACKWARD);
+
+    BIND_ENUM_CONSTANT(PLAYBACK_STYLE_NORMAL);
+    BIND_ENUM_CONSTANT(PLAYBACK_STYLE_PING_PONG);
+
+    BIND_ENUM_CONSTANT(COLOR_BLEND_MIX);
+    BIND_ENUM_CONSTANT(COLOR_BLEND_MUL);
+    BIND_ENUM_CONSTANT(COLOR_BLEND_ADD);
+    BIND_ENUM_CONSTANT(COLOR_BLEND_SUB);
+
+    BIND_ENUM_CONSTANT(OVERRIDE_PRIORITY_NEXT_KEYFRAME);
+    BIND_ENUM_CONSTANT(OVERRIDE_PRIORITY_UNTIL_ANIMATION_CHANGE);
+    BIND_ENUM_CONSTANT(OVERRIDE_PRIORITY_PERMANENT);
 }
 
+// Runtime-only properties. They stay reachable by name (`player.frame_rate = 30`)
+// but are deliberately absent from the property list, so they are neither shown
+// in the inspector nor stored in the scene. Everything the inspector does show
+// is registered statically in _bind_methods.
 bool SpriteStudioPlayer2D::_set(const StringName& p_name, const Variant& p_property) {
     String name = p_name;
-    if (name == "animation") {
-        setAnimation(p_property);
-        return true;
-    } else if (name == "autoplay") {
-        setAutoplay(p_property);
-        return true;
-    } else if (name == "animation_process_mode") {
-        set_animation_process_mode((int)p_property);
-        return true;
-    } else if (name == "frame") {
-        setFrame(p_property);
-        return true;
-    } else if (name == "loop_count") {
-        setLoopCount(p_property);
-        return true;
-    } else if (name == "speed_scale") {
-        setSpeedScale(p_property);
-        return true;
-    } else if (name == "frame_skip_enabled") {
-        setFrameSkipEnabled(p_property);
-        return true;
-    } else if (name == "sub_frame_enabled") {
-        setSubFrameEnabled(p_property);
-        return true;
-    } else if (name == "playback_direction") {
-        setPlaybackDirection((int)p_property, getPlaybackStyle());
-        return true;
-    } else if (name == "playback_style") {
-        setPlaybackDirection(getPlaybackDirection(), (int)p_property);
-        return true;
-    } else if (name == "offset") {
-        set_offset(p_property);
-        return true;
-    } else if (name == "flip_h") {
-        set_flip_h(p_property);
-        return true;
-    } else if (name == "flip_v") {
-        set_flip_v(p_property);
-        return true;
-    } else if (name == "frame_rate") {
+    if (name == "frame_rate") {
         setFrameRate(p_property);
         return true;
-    } else if (name == "animation_section_start") {
-        setAnimationSection((int)p_property, getAnimationSectionEnd());
+    } else if (name == "playback_direction") {
+        setPlaybackDirection((PlaybackDirection)(int)p_property, getPlaybackStyle());
         return true;
-    } else if (name == "animation_section_end") {
-        setAnimationSection(getAnimationSectionStart(), (int)p_property);
-        return true;
-    } else if (name == "play_audio") {
-        set_play_audio(p_property);
-        return true;
-    } else if (name == "audio_volume") {
-        set_audio_volume(p_property);
-        return true;
-    } else if (name == "audio_backend") {
-        set_audio_backend(p_property);
+    } else if (name == "playback_style") {
+        setPlaybackDirection(getPlaybackDirection(), (PlaybackStyle)(int)p_property);
         return true;
     }
 
@@ -642,62 +649,14 @@ bool SpriteStudioPlayer2D::_set(const StringName& p_name, const Variant& p_prope
 
 bool SpriteStudioPlayer2D::_get(const StringName& p_name, Variant& r_property) const {
     String name = p_name;
-    if (name == "animation") {
-        r_property = getAnimation();
-        return true;
-    } else if (name == "autoplay") {
-        r_property = isAutoplay();
-        return true;
-    } else if (name == "animation_process_mode") {
-        r_property = get_animation_process_mode();
-        return true;
-    } else if (name == "frame") {
-        r_property = getFrame();
-        return true;
-    } else if (name == "loop_count") {
-        r_property = getLoopCount();
-        return true;
-    } else if (name == "speed_scale") {
-        r_property = getSpeedScale();
-        return true;
-    } else if (name == "frame_skip_enabled") {
-        r_property = isFrameSkipEnabled();
-        return true;
-    } else if (name == "sub_frame_enabled") {
-        r_property = isSubFrameEnabled();
+    if (name == "frame_rate") {
+        r_property = getFrameRate();
         return true;
     } else if (name == "playback_direction") {
         r_property = getPlaybackDirection();
         return true;
     } else if (name == "playback_style") {
         r_property = getPlaybackStyle();
-        return true;
-    } else if (name == "offset") {
-        r_property = get_offset();
-        return true;
-    } else if (name == "flip_h") {
-        r_property = is_flipped_h();
-        return true;
-    } else if (name == "flip_v") {
-        r_property = is_flipped_v();
-        return true;
-    } else if (name == "frame_rate") {
-        r_property = getFrameRate();
-        return true;
-    } else if (name == "animation_section_start") {
-        r_property = getAnimationSectionStart();
-        return true;
-    } else if (name == "animation_section_end") {
-        r_property = getAnimationSectionEnd();
-        return true;
-    } else if (name == "play_audio") {
-        r_property = is_play_audio();
-        return true;
-    } else if (name == "audio_volume") {
-        r_property = get_audio_volume();
-        return true;
-    } else if (name == "audio_backend") {
-        r_property = get_audio_backend();
         return true;
     }
 
@@ -711,60 +670,54 @@ bool SpriteStudioPlayer2D::_get(const StringName& p_name, Variant& r_property) c
 }
 
 void SpriteStudioPlayer2D::_get_property_list(List<PropertyInfo>* p_list) const {
+    // One entry per cell map in the bound resource. Unlike the rest of the
+    // inspector these cannot be registered statically, because both their count
+    // and their names come from the resource.
     Ref<SSABResource> res = _internal->getSSABResource();
-    bool has_res = !res.is_null();
-
-    if (has_res) {
-#ifdef SPRITESTUDIO_GODOT_EXTENSION
-        PackedStringArray anim_names = res->get_animation_names();
-#else
-        Vector<String> anim_names = res->get_animation_names();
-#endif
-        p_list->push_back(PropertyInfo(Variant::STRING, "animation", PROPERTY_HINT_ENUM, String(",").join(anim_names)));
-    } else {
-        p_list->push_back(PropertyInfo(Variant::STRING, "animation", PROPERTY_HINT_ENUM, ""));
+    if (res.is_null()) {
+        return;
     }
 
-    int total = getTotalFrames();
-    int max_frame = total > 0 ? total - 1 : 0;
-    p_list->push_back(PropertyInfo(Variant::BOOL, "autoplay"));
-    p_list->push_back(PropertyInfo(Variant::FLOAT, "frame", PROPERTY_HINT_RANGE, "0," + String::num(max_frame) + ",0.01", PROPERTY_USAGE_EDITOR));
-
-    p_list->push_back(PropertyInfo(Variant::INT, "loop_count", PROPERTY_HINT_RANGE, "-1,9999,1,or_greater"));
-    p_list->push_back(PropertyInfo(Variant::FLOAT, "speed_scale", PROPERTY_HINT_RANGE, "0,4,0.01,or_greater"));
-
-    p_list->push_back(PropertyInfo(Variant::NIL, "Playback Options", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_GROUP));
-    p_list->push_back(PropertyInfo(Variant::BOOL, "frame_skip_enabled"));
-    p_list->push_back(PropertyInfo(Variant::BOOL, "sub_frame_enabled"));
-    p_list->push_back(PropertyInfo(Variant::INT, "animation_process_mode", PROPERTY_HINT_ENUM, "Physics,Idle"));
-
-    String section_range = "0," + String::num(max_frame) + ",1";
-    p_list->push_back(PropertyInfo(Variant::NIL, "Section", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_GROUP));
-    p_list->push_back(PropertyInfo(Variant::INT, "animation_section_start", PROPERTY_HINT_RANGE, section_range));
-    p_list->push_back(PropertyInfo(Variant::INT, "animation_section_end", PROPERTY_HINT_RANGE, section_range));
-
-    p_list->push_back(PropertyInfo(Variant::NIL, "Offset", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_GROUP));
-    p_list->push_back(PropertyInfo(Variant::VECTOR2, "offset"));
-    p_list->push_back(PropertyInfo(Variant::BOOL, "flip_h"));
-    p_list->push_back(PropertyInfo(Variant::BOOL, "flip_v"));
-
-    p_list->push_back(PropertyInfo(Variant::NIL, "Audio", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_GROUP));
-    p_list->push_back(PropertyInfo(Variant::BOOL, "play_audio"));
-    p_list->push_back(PropertyInfo(Variant::FLOAT, "audio_volume", PROPERTY_HINT_RANGE, "0,1,0.01"));
-    p_list->push_back(PropertyInfo(Variant::OBJECT, "audio_backend", PROPERTY_HINT_RESOURCE_TYPE, "SpriteStudioAudioBackend"));
-
-    if (has_res) {
 #ifdef SPRITESTUDIO_GODOT_EXTENSION
-        PackedStringArray cellmap_names = res->get_cellmap_names();
+    PackedStringArray cellmap_names = res->get_cellmap_names();
 #else
-        Vector<String> cellmap_names = res->get_cellmap_names();
+    Vector<String> cellmap_names = res->get_cellmap_names();
 #endif
-        if (cellmap_names.size() > 0) {
-            p_list->push_back(PropertyInfo(Variant::NIL, "CellMap Overrides", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_GROUP));
-            for (int i = 0; i < cellmap_names.size(); i++) {
-                p_list->push_back(PropertyInfo(Variant::OBJECT, "cellmaps/" + cellmap_names[i], PROPERTY_HINT_RESOURCE_TYPE, "Texture2D"));
-            }
+    if (cellmap_names.size() == 0) {
+        return;
+    }
+
+    p_list->push_back(PropertyInfo(Variant::NIL, "CellMap Overrides", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_GROUP));
+    for (int i = 0; i < cellmap_names.size(); i++) {
+        p_list->push_back(PropertyInfo(Variant::OBJECT, "cellmaps/" + cellmap_names[i], PROPERTY_HINT_RESOURCE_TYPE, "Texture2D"));
+    }
+}
+
+void SpriteStudioPlayer2D::_validate_property(PropertyInfo& p_property) const {
+    if (p_property.name == StringName("animation")) {
+        // Turn the statically registered enum hint into the animation names of
+        // the bound resource. Left empty when no resource is assigned.
+        Ref<SSABResource> res = _internal->getSSABResource();
+        if (res.is_valid()) {
+#ifdef SPRITESTUDIO_GODOT_EXTENSION
+            PackedStringArray anim_names = res->get_animation_names();
+#else
+            Vector<String> anim_names = res->get_animation_names();
+#endif
+            p_property.hint_string = String(",").join(anim_names);
         }
+        return;
+    }
+
+    // The playhead and the section endpoints are bounded by the current
+    // animation's length, which only the instance knows.
+    bool is_frame = p_property.name == StringName("frame");
+    bool is_section = p_property.name == StringName("animation_section_start") ||
+                      p_property.name == StringName("animation_section_end");
+    if (is_frame || is_section) {
+        int total = getTotalFrames();
+        int max_frame = total > 0 ? total - 1 : 0;
+        p_property.hint_string = "0," + String::num(max_frame) + (is_frame ? ",0.01" : ",1");
     }
 }
 

--- a/ss_player/ss_player_node_2d.h
+++ b/ss_player/ss_player_node_2d.h
@@ -2,9 +2,11 @@
 
 #ifdef SPRITESTUDIO_GODOT_EXTENSION
 #include <godot_cpp/classes/node2d.hpp>
+#include <godot_cpp/core/binder_common.hpp>
 using namespace godot;
 #else
 #include "scene/2d/node_2d.h"
+#include "core/variant/binder_common.h"
 #endif
 
 #include "ss_audio_backend.h"
@@ -21,6 +23,36 @@ public:
         ANIMATION_PROCESS_IDLE,
     };
 
+    // Playback direction / style. The values mirror the runtime's FFI encoding
+    // (which normalizes to 0/1 on both sides of the boundary) — they are NOT
+    // the Rust PlaybackDirection discriminants (Forward=1, Backward=-1).
+    enum PlaybackDirection {
+        PLAYBACK_DIRECTION_FORWARD,
+        PLAYBACK_DIRECTION_BACKWARD,
+    };
+
+    enum PlaybackStyle {
+        PLAYBACK_STYLE_NORMAL,
+        PLAYBACK_STYLE_PING_PONG,
+    };
+
+    // Blend operation applied by the part color overrides. Mirrors the
+    // runtime's `blend_op` encoding.
+    enum ColorBlendOperation {
+        COLOR_BLEND_MIX,
+        COLOR_BLEND_MUL,
+        COLOR_BLEND_ADD,
+        COLOR_BLEND_SUB,
+    };
+
+    // How long a part override outlives the keyframes it overrides. Mirrors
+    // the runtime's `priority_mode` encoding.
+    enum OverridePriority {
+        OVERRIDE_PRIORITY_NEXT_KEYFRAME,          // dropped when the animation next keys the attribute
+        OVERRIDE_PRIORITY_UNTIL_ANIMATION_CHANGE, // held until another animation is set up
+        OVERRIDE_PRIORITY_PERMANENT,              // survives animation changes
+    };
+
 private:
     void _notification( int p_notification );
     SpriteStudioPlayer2D();
@@ -29,6 +61,10 @@ private:
     bool _set( const StringName& p_name, const Variant& p_property );
     bool _get( const StringName& p_name, Variant& r_property ) const;
     void _get_property_list( List<PropertyInfo>* p_list ) const;
+    // Injects the hints that depend on the bound resource / current animation
+    // (the `animation` name list, and the frame + section ranges) into the
+    // statically registered properties. Same signature in module + godot-cpp.
+    void _validate_property( PropertyInfo& p_property ) const;
 
 public:
 #ifdef SPRITESTUDIO_GODOT_EXTENSION
@@ -59,8 +95,8 @@ public:
     void set_offset( const Vector2& p_offset );
     Vector2 get_offset() const;
 
-    void set_animation_process_mode(int p_mode);
-    int get_animation_process_mode() const;
+    void set_animation_process_mode(AnimationProcessMode p_mode);
+    AnimationProcessMode get_animation_process_mode() const;
 
     void setSpeedScale( float p_speed );
     float getSpeedScale() const;
@@ -76,12 +112,16 @@ public:
     int getFrameRate() const;
 
     void setAnimationSection( int p_start, int p_end );
+    // Single-endpoint setters backing the `animation_section_start` /
+    // `animation_section_end` properties; each keeps the other endpoint.
+    void setAnimationSectionStart( int p_start );
+    void setAnimationSectionEnd( int p_end );
     int getAnimationSectionStart() const;
     int getAnimationSectionEnd() const;
 
-    void setPlaybackDirection( int p_direction, int p_style );
-    int getPlaybackDirection() const;
-    int getPlaybackStyle() const;
+    void setPlaybackDirection( PlaybackDirection p_direction, PlaybackStyle p_style );
+    PlaybackDirection getPlaybackDirection() const;
+    PlaybackStyle getPlaybackStyle() const;
 
     void setLoopCount( int p_count );
     int getLoopCount() const;
@@ -127,31 +167,30 @@ public:
     // ---- Override Layer (Phase 2): per-part runtime overrides -------------
     // Overrides win over both keyframes and blend for the named part. Return
     // false when the part name is unknown / no animation is bound.
-    // priority: 0=on next keyframe (NON), 1=until next animation (default),
-    // 2=permanent (survives animation changes). blend_op: 0=Mix 1=Mul 2=Add
-    // 3=Sub. Color parts: Normal only; Cell parts: Normal + Mask.
+    // See OverridePriority and ColorBlendOperation for the enum values.
+    // Color parts: Normal only; Cell parts: Normal + Mask.
     bool set_part_visibility_override(const String& part_name, bool force_hidden, bool cascade);
     bool clear_part_visibility_override(const String& part_name);
-    bool set_part_color_override(const String& part_name, const Color& color, int blend_op, int priority);
+    bool set_part_color_override(const String& part_name, const Color& color, ColorBlendOperation blend_op, OverridePriority priority);
     // Four-corner (per-vertex) color override. Corners follow the runtime's
     // order: left-top, right-top, left-bottom, right-bottom. Shares one slot
     // with set_part_color_override — clear_part_color_override clears either.
     bool set_part_color_override_corners(const String& part_name, const Color& left_top, const Color& right_top,
                                          const Color& left_bottom, const Color& right_bottom,
-                                         int blend_op, int priority);
+                                         ColorBlendOperation blend_op, OverridePriority priority);
     bool clear_part_color_override(const String& part_name);
-    bool set_part_cell_override(const String& part_name, const String& cellmap_name, const String& cell_name, int priority);
+    bool set_part_cell_override(const String& part_name, const String& cellmap_name, const String& cell_name, OverridePriority priority);
     bool clear_part_cell_override(const String& part_name);
     bool clear_all_part_overrides();
     // By-index variants (part_index from get_part_index): skip the name lookup.
     bool set_part_visibility_override_by_index(int part_index, bool force_hidden, bool cascade);
     bool clear_part_visibility_override_by_index(int part_index);
-    bool set_part_color_override_by_index(int part_index, const Color& color, int blend_op, int priority);
+    bool set_part_color_override_by_index(int part_index, const Color& color, ColorBlendOperation blend_op, OverridePriority priority);
     bool set_part_color_override_corners_by_index(int part_index, const Color& left_top, const Color& right_top,
                                                   const Color& left_bottom, const Color& right_bottom,
-                                                  int blend_op, int priority);
+                                                  ColorBlendOperation blend_op, OverridePriority priority);
     bool clear_part_color_override_by_index(int part_index);
-    bool set_part_cell_override_by_index(int part_index, const String& cellmap_name, const String& cell_name, int priority);
+    bool set_part_cell_override_by_index(int part_index, const String& cellmap_name, const String& cell_name, OverridePriority priority);
     bool clear_part_cell_override_by_index(int part_index);
 
 private:
@@ -193,3 +232,9 @@ private:
 
     void _on_ssab_changed();
 };
+
+VARIANT_ENUM_CAST(SpriteStudioPlayer2D::AnimationProcessMode);
+VARIANT_ENUM_CAST(SpriteStudioPlayer2D::PlaybackDirection);
+VARIANT_ENUM_CAST(SpriteStudioPlayer2D::PlaybackStyle);
+VARIANT_ENUM_CAST(SpriteStudioPlayer2D::ColorBlendOperation);
+VARIANT_ENUM_CAST(SpriteStudioPlayer2D::OverridePriority);


### PR DESCRIPTION
## What

Registers the two halves of `SpriteStudioPlayer2D`'s public surface that never reached ClassDB: the enums behind its `int` parameters, and the inspector properties.

### Enums

`set_playback_direction`, `set_part_color_override*` and `set_part_cell_override` took plain `int`s documented only in a comment. Four enums are added and taken as parameter types, and bound alongside the existing `AnimationProcessMode`:

| enum | constants |
|---|---|
| `AnimationProcessMode` | `ANIMATION_PROCESS_PHYSICS` / `_IDLE` |
| `PlaybackDirection` | `PLAYBACK_DIRECTION_FORWARD` / `_BACKWARD` |
| `PlaybackStyle` | `PLAYBACK_STYLE_NORMAL` / `_PING_PONG` |
| `ColorBlendOperation` | `COLOR_BLEND_MIX` / `_MUL` / `_ADD` / `_SUB` |
| `OverridePriority` | `OVERRIDE_PRIORITY_NEXT_KEYFRAME` / `_UNTIL_ANIMATION_CHANGE` / `_PERMANENT` |

Values follow the runtime's FFI encoding (`ss_runtime_set/get_playback_direction` normalizes direction and style to `0`/`1` on both sides, so these are *not* the Rust `PlaybackDirection` discriminants; `blend_op` and `priority_mode` match `ssruntime.h`). `DEFVAL` now names the default instead of spelling `0` / `1`.

**Bug fixed along the way**: `AnimationProcessMode`'s two constants were already registered via `BIND_CONSTANT` (constants with no enum). That collided with `BIND_ENUM_CONSTANT` — `Class 'SpriteStudioPlayer2D' already has constant 'ANIMATION_PROCESS_PHYSICS'` — and kept the enum out of ClassDB, even though `doc_classes/` already described the property as `enum="SpriteStudioPlayer2D.AnimationProcessMode"`. The old binding is dropped.

### Properties

Only `ssab` was registered; the other 17 came from `_set` / `_get` / `_get_property_list`, so they were invisible to `ClassDB.class_get_property_list`, to the doc tooling, and to any binding generator. They move to `ADD_PROPERTY` / `ADD_GROUP`, with the three genuinely instance-dependent hints — the `animation` name list and the `frame` / section ranges — injected through `_validate_property`, the same pattern `SpriteStudioPartAttachment2D` already uses for `part_name`.

- `cellmaps/*` stays in `_get_property_list`: both its count and its names come from the resource.
- `frame_rate` / `playback_direction` / `playback_style` stay in `_set` / `_get` — reachable by name, deliberately absent from the property list, and already covered by bound accessors.
- `set_animation_section_start` / `set_animation_section_end` are added because `ADD_PROPERTY` needs single-argument setters. `set_animation_section(start, end)` is unchanged.

## Compatibility

Names, order, hints and usage flags are unchanged — including `frame`'s editor-only usage — so existing scenes keep loading and the inspector looks the same. GDScript passing raw ints to the now-enum parameters still compiles.

**One visible difference**: `ADD_PROPERTY` lets Godot resolve default values, so a re-saved scene omits properties left at their default instead of writing all 17. Verified by packing and saving a scene:

```
=== all-default player ===
[node name="Player" type="SpriteStudioPlayer2D" parent="." unique_id=2105169513]

=== modified player ===
[node name="Player" type="SpriteStudioPlayer2D" parent="." unique_id=246106748]
speed_scale = 2.0
flip_h = true
```

## Test plan

- [x] `./scripts/build-extension.sh target=editor` (macOS arm64) — builds and links
- [x] `./scripts/build.sh target=editor` (macOS arm64, custom module) — builds and links
- [x] Headless ClassDB inspection against the module build:
  - all 5 enums appear in `class_get_enum_list` with the expected constants
  - `class_get_property_list` reports the 17 properties + 4 groups in the original order, with the original hints and usage flags (`frame` still `PROPERTY_USAGE_EDITOR` only)
  - `_validate_property` injects the live hints: `animation` → `'Arrow_Attack'`, `frame` → `'0,70.0,0.01'`, section → `'0,70.0,1'`
  - round trip on `frame_rate`, direction/style, section endpoints, `animation_process_mode`, and `set_part_color_override` with default arguments
- [x] `doc_classes/SpriteStudioPlayer2D.xml` compiles into `doc_data.gen.cpp`

Runtime behaviour of the GDExtension build was not exercised separately — it shares `_bind_methods` with the module build, and `ADD_GROUP` / `_validate_property` already have working precedent in both builds via `SpriteStudioPartAttachment2D`.

## Docs

`doc_classes/SpriteStudioPlayer2D.xml` gains the new constants and the two section members; the value tables in `docs/{en,ja}/api/player.md` and `docs/{en,ja}/workflow/usage_scripting.md` now name the constants next to the numbers.
