### PR TITLE
chore: fill in the docs site configuration gaps before launch

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,16 @@ A Godot Engine integration for SpriteStudio 7, providing a C++ `SpriteStudioPlay
 *   **SDK Versioning:** `scripts/SDK_VERSION.txt` pins the required SDK release. Binaries in `ss_player/runtime/` must match this version.
 *   **Build System:** `SConstruct` and `SCsub` files must be updated if new C++ source files are added.
 
+## Documentation site
+
+Folder-based i18n (`mkdocs-static-i18n`, `docs_structure: folder`): every page exists as both `docs/en/<path>` and `docs/ja/<path>`, and `nav` is defined once in `mkdocs.yml` with Japanese labels from `nav_translations`. Three things do **not** follow that "everything twice" rule — check before duplicating:
+
+*   **`overrides/main.html`** (`theme.custom_dir`) emits the Open Graph / Twitter Card tags Material omits. **One template serves both locales**: the i18n plugin substitutes `languages.ja.site_description` before rendering, so Japanese cards need no second copy. Localize by adding a per-locale config override, never by branching in the template. Keep it in sync with the copies in SpriteStudio-Docs and the sibling player repos.
+*   **Footer social icons are defined twice** — `extra.social` and the `ja` block's `extra` override, which *replaces* the whole `social` list rather than merging into it. Add or reorder an icon in both, or Japanese readers lose it. Keep `twitter:site` in `overrides/main.html` in sync with the X link.
+*   **There is deliberately no `edit_uri`**, so no "edit this page" button renders. It is a branch name nothing validates, and it had drifted wrong in three of the five player repos. Do not reintroduce it.
+
+`mkdocs.yml` sets `strict: true`, so a plain `build` (and `serve`) fails on a broken link or nav mismatch. Nothing builds the docs on a pull request — `pages.yml` runs on `release: published` and dispatch — so the local build is the only gate: `.venv/bin/mkdocs build --strict`.
+
 ## Verification
 
 | Task | Command |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,13 +4,28 @@ site_author: "CRI Middleware Co., Ltd."
 site_url: "https://cri-middleware.github.io/SSPlayerForGodot/"
 repo_name: "cri-middleware/SSPlayerForGodot"
 repo_url: "https://github.com/cri-middleware/SSPlayerForGodot"
-edit_uri: "edit/main/docs/"
+# No `edit_uri`, so Material renders no "edit this page" button. The value is a branch name
+# that nothing validates -- `--strict` does not look at it -- and it was already wrong in
+# three of the five player repos (this one's default branch is `develop`). The footer
+# repo link and CONTRIBUTING.md already route corrections. Deleted rather than left inert.
 # Rendered in the site footer. Deliberately year-less so it never goes stale.
 copyright: "Copyright &copy; CRI Middleware Co., Ltd."
+
+# Nothing builds the docs on a pull request - pages.yml runs on `release: published` and
+# dispatch - so the local build is the only gate, and a plain `build`/`serve` should fail on
+# a broken link too rather than depend on remembering `--strict`.
+strict: true
 
 theme:
   name: material
   language: en
+  # Only overrides/main.html lives here: it appends the Open Graph / Twitter Card metadata
+  # that Material does not emit on its own.
+  custom_dir: overrides
+  # Matches this player's card on the SpriteStudio-Docs landing page. A bundled Material
+  # icon, so it needs no image file; there is no SpriteStudio artwork for a favicon yet.
+  icon:
+    logo: simple/godotengine
   palette:
     - media: "(prefers-color-scheme: light)"
       scheme: default
@@ -30,6 +45,13 @@ theme:
     - navigation.tabs
     - navigation.sections
     - navigation.expand
+    - navigation.top
+    - navigation.tracking
+    # Previous / next links in the footer, so the guides can be read in order.
+    - navigation.footer
+    - toc.follow
+    - search.suggest
+    - search.highlight
     - content.code.copy
 
 plugins:
@@ -45,6 +67,9 @@ plugins:
         - locale: ja
           name: 日本語
           build: true
+          # Feeds <meta name="description"> and the Open Graph tags on every ja page;
+          # without it they inherit the top-level English site_description.
+          site_description: "SpriteStudio 7 のアニメーションを Godot Engine で再生するプラグイン"
           extra:
             # Footer icon labels (title / aria-label). Mirrors the `extra.social` list below.
             social:
@@ -54,6 +79,9 @@ plugins:
               - icon: material/web
                 link: https://www.webtech.co.jp/spritestudio/
                 name: OPTPiX SpriteStudio
+              - icon: fontawesome/brands/x-twitter
+                link: https://x.com/spritestudio
+                name: X の SpriteStudio
           # Japanese nav labels. Keys must match the `nav:` titles below *exactly*,
           # emoji included - a mismatched key silently leaves the English label.
           nav_translations:
@@ -120,6 +148,10 @@ extra:
     - icon: material/web
       link: https://www.webtech.co.jp/spritestudio/
       name: OPTPiX SpriteStudio
+    # Keep the handle here in sync with `twitter:site` in overrides/main.html.
+    - icon: fontawesome/brands/x-twitter
+      link: https://x.com/spritestudio
+      name: SpriteStudio on X
   alternate:
     - name: English
       link: ./

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -1,0 +1,45 @@
+{% extends "base.html" %}
+
+{#-
+  Open Graph / Twitter Card metadata.
+
+  Material emits none of this on its own, so a link shared into Slack, X, or Discord
+  previews as a bare URL. The title/description logic mirrors Material's own <title> logic
+  in base.html so the card and the tab always agree.
+
+  `config.site_name` / `config.site_description` are already per-locale here: the i18n
+  plugin swaps in the `languages.ja.site_description` override before rendering, so the ja
+  build gets Japanese cards without a second template.
+
+  No og:image yet - there is no SpriteStudio artwork in this repository to point at. Adding
+  one means dropping the file into docs/assets/ (not under en/ and ja/: the `url` filter
+  resolves against the site root from every page in both locales) and un-commenting the tag
+  below. Until then `summary` is the correct card type; `summary_large_image` without an
+  image renders as nothing.
+
+  Keep this template in sync with the copies in SpriteStudio-Docs and the sibling player
+  repos - it is deliberately generic, reading everything from config. Anything
+  player-specific belongs in mkdocs.yml, not here.
+-#}
+{% block extrahead %}
+  {%- if page.meta and page.meta.title -%}
+    {%- set og_title = page.meta.title ~ (" - " ~ config.site_name if not page.is_homepage else "") -%}
+  {%- elif page.title and not page.is_homepage -%}
+    {%- set og_title = page.title | striptags ~ " - " ~ config.site_name -%}
+  {%- else -%}
+    {%- set og_title = config.site_name -%}
+  {%- endif -%}
+  {%- set og_description = page.meta.description if page.meta and page.meta.description else config.site_description -%}
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="{{ config.site_name }}">
+  <meta property="og:title" content="{{ og_title }}">
+  <meta property="og:description" content="{{ og_description }}">
+  <meta property="og:url" content="{{ page.canonical_url }}">
+  <meta property="og:locale" content="{{ 'ja_JP' if config.theme.language == 'ja' else 'en_US' }}">
+  {#- <meta property="og:image" content="{{ 'assets/og-image.png' | url }}"> -#}
+  <meta name="twitter:card" content="summary">
+  {#- Attributes the card to the account linked from the footer; keep in sync with extra.social. -#}
+  <meta name="twitter:site" content="@spritestudio">
+  <meta name="twitter:title" content="{{ og_title }}">
+  <meta name="twitter:description" content="{{ og_description }}">
+{% endblock %}


### PR DESCRIPTION
Ports the pre-launch pass from [SpriteStudio-Docs#20](https://github.com/cri-middleware/SpriteStudio-Docs/pull/20) and [SSPlayerForUnity#94](https://github.com/cri-middleware/SSPlayerForUnity/pull/94) to this repo. Several theme options were inert, and the metadata a shared link is judged by was missing outright. **No page content changes.**

## What was wrong

| | Before | After |
|---|---|---|
| Open Graph / Twitter Card | **None.** A link shared into Slack, X, or Discord previewed as a bare URL | Emitted on every page, localized |
| JA `<meta name="description">` | The **English** `site_description` | `SpriteStudio 7 のアニメーションを Godot Engine で再生するプラグイン` |
| Strict validation | Only when you remembered `--strict` | `strict: true`, so plain `build` / `serve` fail too |
| `edit_uri` | Pointed at `main`; the button was never enabled | Removed — see below |
| Header logo | Material for MkDocs' own artwork | `simple/godotengine`, matching this player's card on the portal |
| Footer nav | No previous/next links | `navigation.footer`, plus `navigation.top`, `navigation.tracking`, `toc.follow`, `search.suggest`, `search.highlight` |
| X account | Not linked | In the footer, both locales |

`strict: true` matters here: `pages.yml` runs on `release: published` with no PR build, so a broken link would first surface **while publishing a release**, aborting that deploy.

## Why `edit_uri` is deleted

Pointed at `main` while the default branch is `develop` — so the pencil would have opened a **stale copy of the page the reader is on**, and their PR would have targeted the wrong branch. Nothing validates the value: `--strict` does not look at `edit_uri`, so the mismatch was invisible.

`edit/HEAD/...` would remove the branch name entirely, mirroring the `blob/HEAD/...` rule already used for cross-repo links, but **could not be confirmed to work**: the web editor redirects an anonymous request to a login page whether the ref is valid or not — a deliberately bogus ref behaves identically. Not shipping an unverified trick across six repositories.

The footer repo link and `CONTRIBUTING.md` already route corrections, so this is deleted rather than left as inert config.

## No `og:image`, no favicon

There is no SpriteStudio artwork in this repository or the siblings to point at, and inventing branding seemed worse than shipping without. Title, description and site name still preview; `summary_large_image` renders as nothing without an image, so the card type is `summary`. The header logo uses a bundled Material icon, which needs no image file.

## Verification

`mkdocs build --strict` passes with no warnings. Checked in the built HTML rather than assumed:

- `og:locale` is `en_US` on en pages and `ja_JP` on ja pages
- ja pages carry the Japanese meta description; en pages the English one
- No edit button rendered anywhere (0 occurrences)
- Footer shows all three social icons with correct per-locale labels, and the X link in both
- Previous/next links present; the header logo renders the intended inline SVG

Part of a five-repo rollout: SSPlayerForUnity landed first, and Godot, Flutter, Ren'Py and SSConverterGUI go up together now. `SSPlayerForWeb` is VitePress and needs a separate approach — it has no `head:` block at all, so it is missing the same OG tags.