### PR TITLE
ci: align Apple signing secrets with the org-provided names, and stop signing the weekly build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,19 +120,21 @@ jobs:
       - name: Set up signing keychain
         if: matrix.platform == 'macos' || matrix.platform == 'ios'
         env:
-          SS_APPLE_CERTIFICATE: ${{ secrets.SS_APPLE_CERTIFICATE }}
-          SS_APPLE_CERTIFICATE_PASSWORD: ${{ secrets.SS_APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_DEV_ID_APP_CERT: ${{ secrets.APPLE_DEV_ID_APP_CERT }}
+          APPLE_DEV_ID_APP_CERT_PASS: ${{ secrets.APPLE_DEV_ID_APP_CERT_PASS }}
         run: |
-          if [ -z "$SS_APPLE_CERTIFICATE" ]; then
-            echo "SS_APPLE_CERTIFICATE not set — skipping keychain setup (artifacts will be unsigned)."
+          if [ -z "$APPLE_DEV_ID_APP_CERT" ]; then
+            echo "APPLE_DEV_ID_APP_CERT not set — skipping keychain setup (artifacts will be unsigned)."
             exit 0
           fi
 
           CERTIFICATE_PATH="$RUNNER_TEMP/build_certificate.p12"
           # Random per-run password for the throwaway keychain; never persisted.
+          # (The org also holds a TMP_KC_PASS secret, deliberately unused here —
+          # generating the password per run is strictly better than sharing one.)
           KEYCHAIN_PASSWORD="$(openssl rand -base64 24)"
 
-          echo -n "$SS_APPLE_CERTIFICATE" | base64 --decode > "$CERTIFICATE_PATH"
+          echo -n "$APPLE_DEV_ID_APP_CERT" | base64 --decode > "$CERTIFICATE_PATH"
 
           # Create, harden and unlock a temporary keychain.
           security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
@@ -140,7 +142,7 @@ jobs:
           security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
 
           # Import the cert and authorize codesign to use its private key.
-          security import "$CERTIFICATE_PATH" -P "$SS_APPLE_CERTIFICATE_PASSWORD" -f pkcs12 -k "$KEYCHAIN_PATH" -T /usr/bin/codesign
+          security import "$CERTIFICATE_PATH" -P "$APPLE_DEV_ID_APP_CERT_PASS" -f pkcs12 -k "$KEYCHAIN_PATH" -T /usr/bin/codesign
           security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
 
           # Put the keychain on the search list so codesign resolves the identity
@@ -155,13 +157,13 @@ jobs:
       - name: Prepare Apple API key
         if: matrix.platform == 'macos'
         env:
-          SS_APPLE_API_KEY_BASE64: ${{ secrets.SS_APPLE_API_KEY_BASE64 }}
+          ASC_API_KEY_PASS: ${{ secrets.ASC_API_KEY_PASS }}
         run: |
-          if [ -z "$SS_APPLE_API_KEY_BASE64" ]; then
-            echo "SS_APPLE_API_KEY_BASE64 not set — skipping API key setup (frameworks will not be notarized)."
+          if [ -z "$ASC_API_KEY_PASS" ]; then
+            echo "ASC_API_KEY_PASS not set — skipping API key setup (frameworks will not be notarized)."
             exit 0
           fi
-          echo "$SS_APPLE_API_KEY_BASE64" | base64 --decode > "$RUNNER_TEMP/apple_api_key.p8"
+          echo "$ASC_API_KEY_PASS" | base64 --decode > "$RUNNER_TEMP/apple_api_key.p8"
           echo "APPLE_API_KEY_PATH=$RUNNER_TEMP/apple_api_key.p8" >> "$GITHUB_ENV"
 
       - name: build Linux
@@ -176,9 +178,9 @@ jobs:
       - name: build macOS
         if: matrix.platform == 'macos'
         env:
-          APPLE_SIGNING_IDENTITY: ${{ secrets.SS_APPLE_SIGNING_IDENTITY }}
-          APPLE_API_ISSUER: ${{ secrets.SS_APPLE_API_ISSUER }}
-          APPLE_API_KEY: ${{ secrets.SS_APPLE_API_KEY }}
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_DEV_ID_APP_NAME }}
+          APPLE_API_ISSUER: ${{ secrets.ASC_API_ISSUER_ID }}
+          APPLE_API_KEY: ${{ secrets.ASC_API_KEY_ID }}
         run: |
           ./scripts/release-gdextension-macos.sh api_version=${{ env.GODOT_VERSION }}
 
@@ -187,7 +189,7 @@ jobs:
       - name: build iOS
         if: matrix.platform == 'ios'
         env:
-          APPLE_SIGNING_IDENTITY: ${{ secrets.SS_APPLE_SIGNING_IDENTITY }}
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_DEV_ID_APP_NAME }}
         run: |
           ./scripts/release-gdextension-ios.sh api_version=${{ env.GODOT_VERSION }}
 

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -140,25 +140,27 @@ jobs:
         if: matrix.platform == 'macos' || matrix.platform == 'ios'
         continue-on-error: true # Weeklyでは署名できなくても通す
         env:
-          SS_APPLE_CERTIFICATE: ${{ secrets.SS_APPLE_CERTIFICATE }}
-          SS_APPLE_CERTIFICATE_PASSWORD: ${{ secrets.SS_APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_DEV_ID_APP_CERT: ${{ secrets.APPLE_DEV_ID_APP_CERT }}
+          APPLE_DEV_ID_APP_CERT_PASS: ${{ secrets.APPLE_DEV_ID_APP_CERT_PASS }}
         run: |
-          if [ -z "$SS_APPLE_CERTIFICATE" ]; then
-            echo "SS_APPLE_CERTIFICATE not set — skipping keychain setup (artifacts will be unsigned)."
+          if [ -z "$APPLE_DEV_ID_APP_CERT" ]; then
+            echo "APPLE_DEV_ID_APP_CERT not set — skipping keychain setup (artifacts will be unsigned)."
             exit 0
           fi
 
           CERTIFICATE_PATH="$RUNNER_TEMP/build_certificate.p12"
           # Random per-run password for the throwaway keychain; never persisted.
+          # (The org also holds a TMP_KC_PASS secret, deliberately unused here —
+          # generating the password per run is strictly better than sharing one.)
           KEYCHAIN_PASSWORD="$(openssl rand -base64 24)"
 
-          echo -n "$SS_APPLE_CERTIFICATE" | base64 --decode > "$CERTIFICATE_PATH"
+          echo -n "$APPLE_DEV_ID_APP_CERT" | base64 --decode > "$CERTIFICATE_PATH"
 
           security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
           security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
           security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
 
-          security import "$CERTIFICATE_PATH" -P "$SS_APPLE_CERTIFICATE_PASSWORD" -f pkcs12 -k "$KEYCHAIN_PATH" -T /usr/bin/codesign
+          security import "$CERTIFICATE_PATH" -P "$APPLE_DEV_ID_APP_CERT_PASS" -f pkcs12 -k "$KEYCHAIN_PATH" -T /usr/bin/codesign
           security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
 
           security list-keychain -d user -s "$KEYCHAIN_PATH" login.keychain-db
@@ -174,7 +176,7 @@ jobs:
       - name: build macOS
         if: matrix.platform == 'macos'
         env:
-          APPLE_SIGNING_IDENTITY: ${{ secrets.SS_APPLE_SIGNING_IDENTITY }}
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_DEV_ID_APP_NAME }}
         run: |
           ./scripts/release-gdextension-macos.sh
 
@@ -183,7 +185,7 @@ jobs:
       - name: build iOS
         if: matrix.platform == 'ios'
         env:
-          APPLE_SIGNING_IDENTITY: ${{ secrets.SS_APPLE_SIGNING_IDENTITY }}
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_DEV_ID_APP_NAME }}
         run: |
           ./scripts/release-gdextension-ios.sh
 

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -9,7 +9,6 @@ env:
   LANG: en_US.UTF-8
   LC_ALL: en_US.UTF-8
   PYTHONIOENCODING: utf8
-  KEYCHAIN_PATH: app-signing.keychain-db
   SCONS_CACHE: ~/.scons_cache
 
 permissions:
@@ -132,60 +131,22 @@ jobs:
         shell: pwsh
         run: ./scripts/build-runtime.ps1 platform=windows build=release
 
-      # Import the Developer ID Application certificate into an ephemeral keychain
-      # so codesign (run inside the release scripts) can resolve the signing
-      # identity. No-ops when the certificate secret is absent, leaving the
-      # artifacts unsigned.
-      - name: Set up signing keychain
-        if: matrix.platform == 'macos' || matrix.platform == 'ios'
-        continue-on-error: true # Weeklyでは署名できなくても通す
-        env:
-          APPLE_DEV_ID_APP_CERT: ${{ secrets.APPLE_DEV_ID_APP_CERT }}
-          APPLE_DEV_ID_APP_CERT_PASS: ${{ secrets.APPLE_DEV_ID_APP_CERT_PASS }}
-        run: |
-          if [ -z "$APPLE_DEV_ID_APP_CERT" ]; then
-            echo "APPLE_DEV_ID_APP_CERT not set — skipping keychain setup (artifacts will be unsigned)."
-            exit 0
-          fi
-
-          CERTIFICATE_PATH="$RUNNER_TEMP/build_certificate.p12"
-          # Random per-run password for the throwaway keychain; never persisted.
-          # (The org also holds a TMP_KC_PASS secret, deliberately unused here —
-          # generating the password per run is strictly better than sharing one.)
-          KEYCHAIN_PASSWORD="$(openssl rand -base64 24)"
-
-          echo -n "$APPLE_DEV_ID_APP_CERT" | base64 --decode > "$CERTIFICATE_PATH"
-
-          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
-          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
-          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
-
-          security import "$CERTIFICATE_PATH" -P "$APPLE_DEV_ID_APP_CERT_PASS" -f pkcs12 -k "$KEYCHAIN_PATH" -T /usr/bin/codesign
-          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
-
-          security list-keychain -d user -s "$KEYCHAIN_PATH" login.keychain-db
-
-          rm -f "$CERTIFICATE_PATH"
-
       - name: build Linux
         if: matrix.platform == 'linux'
         run: ./scripts/release-gdextension-linux.sh
 
-      # release-gdextension-macos.sh signs the frameworks when APPLE_SIGNING_IDENTITY
-      # is present; no-op (unsigned) otherwise, so weekly stays green without secrets.
+      # Weekly artifacts are deliberately NOT code-signed: this is a continuous
+      # build for our own verification, not something we distribute, so it has no
+      # business handling the Developer ID certificate. Signing belongs to
+      # release.yml alone. The scripts no-op on signing without
+      # APPLE_SIGNING_IDENTITY, so nothing else has to change here.
       - name: build macOS
         if: matrix.platform == 'macos'
-        env:
-          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_DEV_ID_APP_NAME }}
         run: |
           ./scripts/release-gdextension-macos.sh
 
-      # release-gdextension-ios.sh signs the XCFrameworks when APPLE_SIGNING_IDENTITY
-      # is present; no-op (unsigned) otherwise.
       - name: build iOS
         if: matrix.platform == 'ios'
-        env:
-          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_DEV_ID_APP_NAME }}
         run: |
           ./scripts/release-gdextension-ios.sh
 

--- a/scripts/release-gdextension-ios.sh
+++ b/scripts/release-gdextension-ios.sh
@@ -44,7 +44,7 @@ popd > /dev/null # ${BINDIR}
 
 # --- Code signing (opt-in via env) ------------------------------------------
 # Signs the XCFrameworks inside-out when APPLE_SIGNING_IDENTITY is set (maps to the
-# SS_APPLE_SIGNING_IDENTITY secret set by CI).
+# APPLE_DEV_ID_APP_NAME secret set by CI).
 # iOS is NOT notarized and does NOT use the macOS hardened runtime (--options runtime)
 # nor --deep: sign each embedded .framework first, then the .xcframework wrapper. The
 # consuming app re-signs the embedded framework with its own identity at build time;

--- a/scripts/release-gdextension-macos.sh
+++ b/scripts/release-gdextension-macos.sh
@@ -17,14 +17,14 @@ done
 
 # --- Code signing & notarization (opt-in via env) ----------------------------
 # Signs the GDExtension frameworks with a Developer ID Application identity when
-# APPLE_SIGNING_IDENTITY is set (maps to the SS_APPLE_SIGNING_IDENTITY secret; the
+# APPLE_SIGNING_IDENTITY is set (maps to the APPLE_DEV_ID_APP_NAME secret; the
 # CI sets it in .github/workflows/release.yml). Hardened runtime (--options
 # runtime) + a secure timestamp. Notarization of the frameworks additionally
 # needs an App Store Connect API key:
 #   APPLE_API_KEY_PATH — path to the .p8 private key file
 #   APPLE_API_KEY      — the key ID
 #   APPLE_API_ISSUER   — the issuer ID
-# These map to the SS_APPLE_* GitHub secrets — see .github/workflows/release.yml
+# These map to the ASC_API_* GitHub secrets — see .github/workflows/release.yml
 # for the CI wiring. No-op (unsigned) when the identity is absent, so local
 # builds without a certificate still succeed.
 if [ -n "${APPLE_SIGNING_IDENTITY:-}" ]; then


### PR DESCRIPTION
## Summary

Two related changes to how this repo handles the Apple Developer ID certificate.

**1. `release.yml` — rename the secrets.** They were provisioned at the organization level under different names than the workflow assumed. This mattered more than a rename usually does: every signing step treats an empty secret as "not configured", skips its work, and **returns success**. With the names mismatched, a fully green release run would still have produced unsigned macOS/iOS GDExtension frameworks.

| Old | New |
| --- | --- |
| `SS_APPLE_CERTIFICATE` | `APPLE_DEV_ID_APP_CERT` |
| `SS_APPLE_CERTIFICATE_PASSWORD` | `APPLE_DEV_ID_APP_CERT_PASS` |
| `SS_APPLE_SIGNING_IDENTITY` | `APPLE_DEV_ID_APP_NAME` |
| `SS_APPLE_API_ISSUER` | `ASC_API_ISSUER_ID` |
| `SS_APPLE_API_KEY` | `ASC_API_KEY_ID` |
| `SS_APPLE_API_KEY_BASE64` | `ASC_API_KEY_PASS` |

Only the `secrets.*` right-hand sides change. The env var names the release scripts read (`APPLE_SIGNING_IDENTITY`, `APPLE_API_ISSUER`, `APPLE_API_KEY`, `APPLE_API_KEY_PATH`) are untouched, so `release-gdextension-macos.sh` and `release-gdextension-ios.sh` keep working unchanged locally. The script comments that named the old secrets are updated to match.

**2. `weekly.yml` — stop signing entirely.** The weekly build is continuous verification of our own tree, not something we distribute, so it has no business handling the Developer ID certificate. Signing belongs to `release.yml` alone, and keeping the certificate out of a scheduled job that runs unattended every week is the smaller attack surface. This drops the "Set up signing keychain" step, the `APPLE_SIGNING_IDENTITY` hand-off to the macOS/iOS build steps, and the now-unused `KEYCHAIN_PATH` workflow env.

The builds themselves are unchanged — the scripts already no-op on signing when `APPLE_SIGNING_IDENTITY` is absent, so the artifacts are simply unsigned. That was already the tolerated outcome: the keychain step carried `continue-on-error: true` with the comment 「Weeklyでは署名できなくても通す」.

## Notes on the mapping

- **`ASC_API_KEY_PASS` holds the base64 of the `.p8` private key**, despite what its name suggests, so it maps to the key file the notarization step decodes — not to a passphrase. Worth confirming on the first signed run.
- **`TMP_KC_PASS` is deliberately unused.** `release.yml` still generates the temporary keychain password per run with `openssl rand`, which is strictly better than sharing one value across runs. A comment records why.
- The sibling repos got the identical rename: SpriteStudio-SDK and SSConverterGUI (both merged).

## Verification

Both workflows parse as valid YAML. No `SS_APPLE_*` references remain in the tree, and after the second commit `weekly.yml` has no `secrets.`, `KEYCHAIN` or `codesign` references left at all.

The signing itself cannot be verified from this branch — release only runs on `workflow_dispatch`, and org secrets are not exposed to a non-permitted repository. Two things to check after merge:

1. A macOS/iOS **release** run's log does not report skipped signing or notarization. Those lines are the failure mode this PR exists to prevent, and they do not fail the job.
2. `SSPlayerForGodot` is on the repository access list of the org secrets. **This repo lives under the `SpriteStudio` org**, so the `cri-middleware` org secrets must be shared with it explicitly — the most likely thing to still be missing.
