### PR TITLE
ci(release): fail the build when notarization is not Accepted

### DIFF
--- a/scripts/release-gdextension-macos.sh
+++ b/scripts/release-gdextension-macos.sh
@@ -42,14 +42,49 @@ if [ -n "${APPLE_SIGNING_IDENTITY:-}" ]; then
     if [ -n "${APPLE_API_KEY_PATH:-}" ] && [ -n "${APPLE_API_KEY:-}" ] && [ -n "${APPLE_API_ISSUER:-}" ]; then
         echo "==> Notarizing macOS frameworks"
         NOTARIZE_ZIP="${BINDIR}/frameworks.notarize.zip"
-        /bin/rm -f "${NOTARIZE_ZIP}"
+        NOTARIZE_OUT="${BINDIR}/frameworks.notarize.json"
+        # rm before the redirect below too: a zsh configured with `noclobber`
+        # would otherwise refuse to overwrite a leftover response file.
+        /bin/rm -f "${NOTARIZE_ZIP}" "${NOTARIZE_OUT}"
         ( cd "${BINDIR}" && /usr/bin/zip -qry frameworks.notarize.zip *.framework )
+
+        # `notarytool submit --wait` is not reliably non-zero on a rejected
+        # submission, so the exit code alone can let an unnotarized addon ship on
+        # a green run. Assert on the reported status instead, and keep going past
+        # a non-zero exit (|| NOTARIZE_RC=$?, which set -e tolerates) so the
+        # status check below is what decides. plutil parses the JSON — it ships
+        # with macOS, unlike jq, so this holds for a local release build too.
+        #
+        # All three frameworks (editor, template_release, template_debug) go up
+        # as one archive, so a rejection is all-or-nothing and the status alone
+        # does not say which one failed — fetch the notary log, which reports
+        # per-binary issues, before failing the build.
+        NOTARIZE_RC=0
         xcrun notarytool submit "${NOTARIZE_ZIP}" \
             --key "${APPLE_API_KEY_PATH}" \
             --key-id "${APPLE_API_KEY}" \
             --issuer "${APPLE_API_ISSUER}" \
-            --wait
-        /bin/rm -f "${NOTARIZE_ZIP}"
+            --wait --output-format json > "${NOTARIZE_OUT}" || NOTARIZE_RC=$?
+        cat "${NOTARIZE_OUT}"
+
+        # An unparseable response leaves the status empty, which fails below —
+        # the safe direction, since the raw response is echoed above.
+        NOTARIZE_STATUS=$(/usr/bin/plutil -extract status raw -o - -- "${NOTARIZE_OUT}" 2>/dev/null || true)
+        NOTARIZE_ID=$(/usr/bin/plutil -extract id raw -o - -- "${NOTARIZE_OUT}" 2>/dev/null || true)
+        if [ "${NOTARIZE_STATUS}" != "Accepted" ]; then
+            echo "ERROR: notarization failed (status=${NOTARIZE_STATUS:-unknown}, notarytool exit=${NOTARIZE_RC})" >&2
+            if [ -n "${NOTARIZE_ID}" ]; then
+                echo "==> Notary log for submission ${NOTARIZE_ID}:" >&2
+                xcrun notarytool log "${NOTARIZE_ID}" \
+                    --key "${APPLE_API_KEY_PATH}" \
+                    --key-id "${APPLE_API_KEY}" \
+                    --issuer "${APPLE_API_ISSUER}" >&2 || true
+            fi
+            exit 1
+        fi
+        echo "==> Notarization accepted (submission ${NOTARIZE_ID})"
+
+        /bin/rm -f "${NOTARIZE_ZIP}" "${NOTARIZE_OUT}"
     else
         echo "==> Skipping notarization (APPLE_API_KEY_PATH / APPLE_API_KEY / APPLE_API_ISSUER not all set)"
     fi


### PR DESCRIPTION
Ports the fix from [SpriteStudio-SDK#355](https://github.com/cri-middleware/SpriteStudio-SDK/pull/355), which hit the same latent problem in its own `release-macos.sh`.

## Problem

`scripts/release-gdextension-macos.sh` calls `notarytool submit --wait` and relies on its exit code. That exit code is not reliably non-zero on a rejected submission, so a failed notarization can pass as a green run and ship an addon whose macOS frameworks have no ticket.

All three frameworks (`editor`, `template_release`, `template_debug`) go up as a single archive, so a rejection is all-or-nothing: one silent failure loses the tickets for every macOS binary in the addon at once.

This matters here specifically because the addon zip is downloaded from Releases in a browser, which stamps `com.apple.quarantine` on everything extracted from it — and Gatekeeper refuses to `dlopen` quarantined code with no ticket when the Godot editor first loads the GDExtension.

## Fix

Capture the JSON response and assert `status == Accepted`, while tolerating a non-zero exit so the status check is what decides. `plutil` does the parsing — it ships with macOS, unlike `jq`, so this holds for a local release build as well as CI.

On rejection the status alone does not say *which* framework failed, since they go up together, so the notary log (which reports per-binary issues) is fetched before exiting non-zero. An unparseable response also fails, with the raw response echoed for diagnosis — the safe direction.

## Verification

Exercised against a fake `notarytool` under zsh (this script is `#!/usr/bin/env zsh`, not bash). Only the Accepted cases proceed:

| notarytool output | exit code | result |
| --- | --- | --- |
| `status: Accepted` | 0 | build continues |
| `status: Invalid` | 0 | **build fails** (the silent-failure case) |
| `status: Invalid` | 1 | build fails |
| unparseable | 1 | build fails, raw response echoed |
| `status: Accepted`, stale response file present under `setopt noclobber` | 0 | build continues |

That last row is why the response file is added to the existing `rm -f` before the redirect: a zsh configured with `noclobber` would otherwise refuse to overwrite a leftover file from a previous run.

The submission itself is not exercised — it needs credentials and is an outward-facing call. On the next release run the script should print `Notarization accepted (submission ...)`.

## Scope

No change to what gets signed or submitted, and no new secrets — only how the result is checked. The macOS GDExtension frameworks are flat (no `Versions/` symlinks), so the existing `zip -qry` for the submission archive is left as is.